### PR TITLE
[Bench-80][01] Add GitHub OAuth secrets to docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,6 +58,8 @@ services:
     secrets:
       - google_client_id
       - google_client_secret
+      - github_client_id
+      - github_client_secret
       - discord_client_id
       - discord_client_secret
       - jwt_secret
@@ -100,6 +102,8 @@ services:
     secrets:
       - google_client_id
       - google_client_secret
+      - github_client_id
+      - github_client_secret
       - discord_client_id
       - discord_client_secret
       - jwt_secret
@@ -154,6 +158,10 @@ secrets:
     file: ./secrets/google_client_id.txt
   google_client_secret:
     file: ./secrets/google_client_secret.txt
+  github_client_id:
+    file: ./secrets/github_client_id.txt
+  github_client_secret:
+    file: ./secrets/github_client_secret.txt
   discord_client_id:
     file: ./secrets/discord_client_id.txt
   discord_client_secret:


### PR DESCRIPTION
## 概要
- `api.secrets` に `github_client_id` / `github_client_secret` を追加
- `api-ci.secrets` に同2件を追加
- ルート `secrets:` セクションへ file マッピングを追加

## テスト
- `docker compose --profile default config | rg github_client_`
- `docker compose --profile ci config | rg github_client_`

## 公開時の影響
- GitHub OAuth 用シークレットを Compose で注入可能になり、セルフホスト環境で有効化しやすくなります。
- OAuth 実装ロジックへの変更はありません。
