### PR TITLE
docs: getting-started に OAuth ガイド導線を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ git clone https://github.com/mashirou1234/yesod-auth.git
 cd yesod-auth
 ```
 
-### 2. Set up OAuth credentials
+### 2. Set up OAuth credentials (Client ID / Client Secret)
 
 #### Google OAuth
 1. Go to [Google Cloud Console](https://console.cloud.google.com/)
@@ -45,7 +45,7 @@ cd yesod-auth
 # Create secrets directory (already exists in repo)
 mkdir -p secrets
 
-# Add your credentials
+# Add your OAuth credentials (Client ID / Client Secret)
 echo "your-google-client-id" > secrets/google_client_id.txt
 echo "your-google-client-secret" > secrets/google_client_secret.txt
 echo "your-discord-client-id" > secrets/discord_client_id.txt

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -32,6 +32,15 @@ cp secrets/jwt_secret.txt.example secrets/jwt_secret.txt
     openssl rand -base64 32 > secrets/jwt_secret.txt
     ```
 
+### OAuthガイドへの導線
+
+クイックスタートで起動確認した後、利用するプロバイダーの設定を進めてください。
+
+- [OAuth設定ハブ](guides/oauth/index.md)
+- [Google OAuth ガイド](guides/oauth/google.md)
+- [Discord OAuth ガイド](guides/oauth/discord.md)
+- [GitHub OAuth ガイド](guides/oauth/github.md)
+
 ## 3. 起動
 
 ```bash


### PR DESCRIPTION
## 概要
- `docs/getting-started.md` に OAuth 設定ハブと主要プロバイダー (Google/Discord/GitHub) への導線を追加
- 5分セットアップ導線は維持
- `README.md` の OAuth 用語を `Client ID / Client Secret` に揃えて最小整合

## テスト
- `rg -n "OAuth設定ハブ|Google OAuth ガイド|Discord OAuth ガイド|GitHub OAuth ガイド" docs/getting-started.md`
- `for f in docs/guides/oauth/{index,google,discord,github}.md; do test -f "$f"; done`
- `rg -n "\[OAuth設定\]\(guides/oauth/index.md\)" docs/getting-started.md`
- `rg -n "Set up OAuth credentials \(Client ID / Client Secret\)|Add your OAuth credentials \(Client ID / Client Secret\)" README.md`

Closes #25