### PR TITLE
[Bench-80][05] docker-composeにSlack OAuth secretsを追加する

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,6 +60,8 @@ services:
       - google_client_secret
       - discord_client_id
       - discord_client_secret
+      - slack_client_id
+      - slack_client_secret
       - jwt_secret
     depends_on:
       db:
@@ -102,6 +104,8 @@ services:
       - google_client_secret
       - discord_client_id
       - discord_client_secret
+      - slack_client_id
+      - slack_client_secret
       - jwt_secret
     depends_on:
       db-ci:
@@ -158,6 +162,10 @@ secrets:
     file: ./secrets/discord_client_id.txt
   discord_client_secret:
     file: ./secrets/discord_client_secret.txt
+  slack_client_id:
+    file: ./secrets/slack_client_id.txt
+  slack_client_secret:
+    file: ./secrets/slack_client_secret.txt
   jwt_secret:
     file: ./secrets/jwt_secret.txt
   admin_password:


### PR DESCRIPTION
## 概要
- `api` / `api-ci` サービスの `secrets` に `slack_client_id` と `slack_client_secret` を追加
- top-level `secrets` に Slack 用 secrets ファイル定義を追加

## テスト
- `docker compose config`

Closes #5
