### PR TITLE
[Bench-80][06] Add Twitch OAuth secrets to docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,6 +60,8 @@ services:
       - google_client_secret
       - discord_client_id
       - discord_client_secret
+      - twitch_client_id
+      - twitch_client_secret
       - jwt_secret
     depends_on:
       db:
@@ -102,6 +104,8 @@ services:
       - google_client_secret
       - discord_client_id
       - discord_client_secret
+      - twitch_client_id
+      - twitch_client_secret
       - jwt_secret
     depends_on:
       db-ci:
@@ -158,6 +162,10 @@ secrets:
     file: ./secrets/discord_client_id.txt
   discord_client_secret:
     file: ./secrets/discord_client_secret.txt
+  twitch_client_id:
+    file: ./secrets/twitch_client_id.txt
+  twitch_client_secret:
+    file: ./secrets/twitch_client_secret.txt
   jwt_secret:
     file: ./secrets/jwt_secret.txt
   admin_password:


### PR DESCRIPTION
## Summary
- add `twitch_client_id` and `twitch_client_secret` to `api.secrets`
- add the same Twitch secrets to `api-ci.secrets`
- define both Twitch secrets in top-level `secrets` section

## Test
- docker compose --profile default config | rg twitch_client_
- docker compose --profile ci config | rg twitch_client_

Closes #6
