### PR TITLE
test: add unauthenticated accounts API test

### DIFF
--- a/api/tests/test_accounts.py
+++ b/api/tests/test_accounts.py
@@ -1,0 +1,14 @@
+"""Accounts API tests."""
+
+import pytest
+from httpx import AsyncClient
+
+
+@pytest.mark.asyncio
+async def test_list_accounts_requires_authentication(client: AsyncClient):
+    """Unauthenticated access to accounts endpoint should be rejected."""
+    response = await client.get("/api/v1/accounts")
+
+    assert response.status_code == 401
+    data = response.json()
+    assert "detail" in data


### PR DESCRIPTION
## 概要
- `/api/v1/accounts` への未認証アクセスが拒否されることを保証するAPIテストを追加
- ステータスコード `401` とレスポンス本文の `detail` 存在を検証

## テスト
- `cd api && UV_CACHE_DIR=/tmp/uv-cache uv run --with-requirements requirements.txt pytest tests -k accounts -q`
- `cd api && UV_CACHE_DIR=/tmp/uv-cache uv run --with-requirements requirements.txt pytest -q`

Closes #20