### PR TITLE
docs: add state mismatch troubleshooting flow

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -62,5 +62,6 @@ curl "http://localhost:8000/api/v1/auth/mock/login?user=alice&provider=google"
 ## 次のステップ
 
 - [OAuth設定](guides/oauth/index.md) - 各プロバイダーの設定方法
+- [トラブルシューティング](help/troubleshooting.md#state-mismatch-flow) - `Invalid or expired state` の診断手順
 - [Webhook設定](guides/webhooks.md) - 外部サービス連携
 - [デプロイ](guides/deployment.md) - 本番環境へのデプロイ

--- a/docs/help/troubleshooting.md
+++ b/docs/help/troubleshooting.md
@@ -46,6 +46,32 @@ sqlalchemy.exc.OperationalError: could not connect to server
 1. 認証フローを最初からやり直す
 2. Valkeyが正常に動作しているか確認
 
+<a id="state-mismatch-flow"></a>
+
+#### `state mismatch` 診断フロー
+
+1. 発生時刻とリクエストを特定する（APIログ）
+   ```bash
+   docker compose logs api --since=30m | rg "Invalid state|/auth/.*/callback"
+   ```
+2. `state` が一度だけ消費される前提を確認する（再送/二重callbackの有無）
+   - 同一ブラウザ操作で callback が複数回呼ばれていないか
+   - リバースプロキシや監視が callback URL を再実行していないか
+3. Valkey の接続状態を確認する（保存済みstateが即時消失していないか）
+   ```bash
+   docker compose logs valkey --since=30m
+   ```
+4. OAuth開始URLとcallback URLの組み合わせを確認する（環境不一致の検出）
+   - 開始: `GET /api/v1/auth/{provider}`
+   - callback: `GET /api/v1/auth/{provider}/callback?code=...&state=...`
+   - `API_URL` / `FRONTEND_URL` の環境差分を確認
+
+| 想定原因 | 観測シグナル | 対処 |
+| --- | --- | --- |
+| callback の二重実行 | 同一 `state` で callback ログが連続する | ブラウザ再送・プロキシ再試行を止め、ログイン導線を1回実行に統一 |
+| Valkey 接続不安定 | `OAuthStateStore` 参照前後で Valkey エラーが発生 | Valkey を復旧し、`docker compose ps/logs valkey` で安定化確認後に再試行 |
+| OAuth開始とcallbackの環境不一致 | `API_URL` と実アクセス先のホスト/スキームが異なる | 環境変数を一致させて再デプロイし、再度 `/api/v1/auth/{provider}` から開始 |
+
 ---
 
 ### `Mock OAuth is disabled`


### PR DESCRIPTION
## Summary
- add a 4-step diagnostics flow for OAuth state mismatch in troubleshooting
- map root causes to one-to-one mitigations with observable signals
- add getting-started link to the troubleshooting flow

## Test
- docs/help/troubleshooting.md:1:# トラブルシューティング
docs/help/troubleshooting.md:69:| 想定原因 | 観測シグナル | 対処 |
docs/getting-started.md:65:- [トラブルシューティング](help/troubleshooting.md#state-mismatch-flow) - `Invalid or expired state` の診断手順
- 
- ============================= test session starts ==============================
platform darwin -- Python 3.13.5, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/shiroguchi/.codex/worktrees/ff33/yesod-auth/api
configfile: pytest.ini (WARNING: ignoring pytest config in pyproject.toml!)
testpaths: tests
plugins: anyio-4.12.1, respx-0.22.0, hypothesis-6.151.9, asyncio-1.3.0
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=function, asyncio_default_test_loop_scope=function
collected 138 items

tests/test_discord_oauth.py .............                                [  9%]
tests/test_facebook_oauth.py ............                                [ 18%]
tests/test_github_oauth.py ..............                                [ 28%]
tests/test_health.py ....                                                [ 31%]
tests/test_linkedin_oauth.py ............                                [ 39%]
tests/test_mock_oauth.py ......                                          [ 44%]
tests/test_slack_oauth.py ................                               [ 55%]
tests/test_twitch_oauth.py ...............                               [ 66%]
tests/test_webhook_config.py .......                                     [ 71%]
tests/test_webhook_delivery.py ...                                       [ 73%]
tests/test_webhook_emitter.py .....                                      [ 77%]
tests/test_webhook_event.py ...                                          [ 79%]
tests/test_webhook_integration.py .....                                  [ 83%]
tests/test_webhook_signer.py ......                                      [ 87%]
tests/test_webhook_worker.py ......                                      [ 92%]
tests/test_x_oauth.py ...........                                        [100%]

============================= 138 passed in 2.19s ==============================

Closes #52