### PR TITLE
ci: add Facebook OAuth secrets file generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,70 @@
+name: CI
+
+on:
+  workflow_dispatch:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install Ruff
+        run: pip install ruff
+
+      - name: Run Ruff (lint)
+        run: ruff check api/
+
+      - name: Run Ruff (format check)
+        run: ruff format --check api/
+
+  test:
+    runs-on: ubuntu-latest
+    needs: lint
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create secrets for CI
+        run: |
+          echo "ci-google-id" > secrets/google_client_id.txt
+          echo "ci-google-secret" > secrets/google_client_secret.txt
+          echo "ci-discord-id" > secrets/discord_client_id.txt
+          echo "ci-discord-secret" > secrets/discord_client_secret.txt
+          echo "ci-github-id" > secrets/github_client_id.txt
+          echo "ci-github-secret" > secrets/github_client_secret.txt
+          echo "ci-x-id" > secrets/x_client_id.txt
+          echo "ci-x-secret" > secrets/x_client_secret.txt
+          echo "ci-linkedin-id" > secrets/linkedin_client_id.txt
+          echo "ci-linkedin-secret" > secrets/linkedin_client_secret.txt
+          echo "ci-facebook-id" > secrets/facebook_client_id.txt
+          echo "ci-facebook-secret" > secrets/facebook_client_secret.txt
+          echo "ci-jwt-secret-key" > secrets/jwt_secret.txt
+          echo "ci-admin-password" > secrets/admin_password.txt
+
+      - name: Start CI services
+        run: docker compose --profile ci up -d db-ci valkey
+
+      - name: Wait for services
+        run: |
+          for i in {1..30}; do
+            if docker compose --profile ci exec -T db-ci pg_isready -U yesod_user -d yesod 2>/dev/null; then
+              echo "DB is ready"
+              break
+            fi
+            echo "Waiting for DB... ($i/30)"
+            sleep 2
+          done
+
+      - name: Run tests
+        run: |
+          docker compose --profile ci run --rm api-ci pytest --tb=short -v
+
+      - name: Cleanup
+        if: always()
+        run: docker compose --profile ci down -v


### PR DESCRIPTION
## Summary
- add `.github/workflows/ci.yml` for lint/test jobs
- generate `secrets/facebook_client_id.txt` and `secrets/facebook_client_secret.txt` in CI
- keep naming aligned with existing provider secret generation pattern

## Test
- `rg -n "facebook_client_(id|secret)" .github/workflows/ci.yml`
- `gh workflow view ci.yml --ref codex/issue-10-ci-facebook-oauth-secrets --yaml`

Closes #10
