### PR TITLE
ci: add Slack OAuth secrets file generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,8 @@ jobs:
           echo "ci-linkedin-secret" > secrets/linkedin_client_secret.txt
           echo "ci-facebook-id" > secrets/facebook_client_id.txt
           echo "ci-facebook-secret" > secrets/facebook_client_secret.txt
+          echo "ci-slack-id" > secrets/slack_client_id.txt
+          echo "ci-slack-secret" > secrets/slack_client_secret.txt
           echo "ci-jwt-secret-key" > secrets/jwt_secret.txt
           echo "ci-admin-password" > secrets/admin_password.txt
 


### PR DESCRIPTION
## Summary
- add `secrets/slack_client_id.txt` generation in CI workflow
- add `secrets/slack_client_secret.txt` generation in CI workflow
- keep the same echo-based pattern as other providers

## Test
- `rg -n "slack_client_(id|secret)" .github/workflows/ci.yml`
- `gh workflow view ci.yml --ref codex/issue-11-ci-slack-oauth-secrets --yaml`

Closes #11