### PR TITLE
ci: add Slack OAuth secret files in GitHub CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - master
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Prepare OAuth secrets for CI
+        run: |
+          mkdir -p secrets
+          echo "ci-google-client-id" > secrets/google_client_id.txt
+          echo "ci-google-client-secret" > secrets/google_client_secret.txt
+          echo "ci-discord-client-id" > secrets/discord_client_id.txt
+          echo "ci-discord-client-secret" > secrets/discord_client_secret.txt
+          echo "ci-slack-client-id" > secrets/slack_client_id.txt
+          echo "ci-slack-client-secret" > secrets/slack_client_secret.txt
+          echo "ci-jwt-secret" > secrets/jwt_secret.txt
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r api/requirements.txt
+
+      - name: Run API tests
+        run: |
+          cd api
+          pytest -q


### PR DESCRIPTION
## Summary
- add `.github/workflows/ci.yml` for GitHub Actions CI
- generate OAuth secret files under `secrets/` using existing echo style
- include `slack_client_id.txt` and `slack_client_secret.txt` generation lines

## Test
- `rg -n "slack_client_(id|secret)" .github/workflows/ci.yml`
- `gh workflow view ci.yml --repo mashirou1234/yesod-auth --ref codex/issue-11-slack-secrets-ci --yaml`

Closes #11