### PR TITLE
ci: add Twitch OAuth secret files in CI setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,62 @@
+name: CI
+
+on:
+  workflow_dispatch:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Ruff
+        run: pip install ruff
+
+      - name: Run Ruff (lint)
+        run: ruff check api/
+
+      - name: Run Ruff (format check)
+        run: ruff format --check api/
+
+  test:
+    runs-on: ubuntu-latest
+    needs: lint
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create secrets for CI
+        run: |
+          echo "ci-google-id" > secrets/google_client_id.txt
+          echo "ci-google-secret" > secrets/google_client_secret.txt
+          echo "ci-discord-id" > secrets/discord_client_id.txt
+          echo "ci-discord-secret" > secrets/discord_client_secret.txt
+          echo "ci-twitch-id" > secrets/twitch_client_id.txt
+          echo "ci-twitch-secret" > secrets/twitch_client_secret.txt
+          echo "ci-jwt-secret-key" > secrets/jwt_secret.txt
+          echo "ci-admin-password" > secrets/admin_password.txt
+
+      - name: Start CI services
+        run: docker compose --profile ci up -d db-ci valkey
+
+      - name: Wait for services
+        run: |
+          for i in {1..30}; do
+            if docker compose --profile ci exec -T db-ci pg_isready -U yesod_user -d yesod 2>/dev/null; then
+              echo "DB is ready"
+              break
+            fi
+            echo "Waiting for DB... ($i/30)"
+            sleep 2
+          done
+
+      - name: Run tests
+        run: docker compose --profile ci run --rm api-ci pytest --tb=short -v
+
+      - name: Cleanup
+        if: always()
+        run: docker compose --profile ci down -v


### PR DESCRIPTION
## 概要
- `.github/workflows/ci.yml` を追加し、CI で OAuth 系 secrets を作成する手順を復元
- `Create secrets for CI` ステップに `twitch_client_id.txt` / `twitch_client_secret.txt` を追加

## 背景との整合
- Twitch プロバイダー追加時の CI 環境差異を解消
- セルフホスト運用で使う `secrets/` 配置ルールと整合
- OSS 利用者向けに provider 追加時の破損リスクを低減

## 確認
- `rg -n "twitch_client_(id|secret)" .github/workflows/ci.yml`
- `gh workflow view ci.yml --ref codex/issue-12-bench-80-12-ci-twitch-oauth-secrets --yaml`
