### PR TITLE
docs: X OAuth scopeにoffline.accessを追記

### DIFF
--- a/docs/guides/oauth/x.md
+++ b/docs/guides/oauth/x.md
@@ -43,6 +43,7 @@ echo "your-client-secret" > secrets/x_client_secret.txt
 | 認可エンドポイント | `https://twitter.com/i/oauth2/authorize` |
 | トークンエンドポイント | `https://api.twitter.com/2/oauth2/token` |
 | ユーザー情報エンドポイント | `https://api.twitter.com/2/users/me` |
-| スコープ | `users.read tweet.read` |
+| スコープ | `users.read tweet.read offline.access` |
+| 補足 | `offline.access` は refresh token を受け取り長期セッションを維持するために必要 |
 | PKCE | ✅ 必須 |
 | OpenID Connect | ❌ 非対応 |


### PR DESCRIPTION
## 概要
- `docs/guides/oauth/x.md` のX OAuthスコープを `users.read tweet.read offline.access` に更新
- `offline.access` が refresh token 取得（長期セッション維持）に必要である旨を1行補足

## 背景
OAuth導入時の設定ミスを減らし、セルフホスト運用時の初期セットアップを簡潔化するため、実運用で必要なスコープを明示しました。

## テスト
- `rg -n "offline.access" docs/guides/oauth/x.md` ✅
- `mkdocs build` ❌ (`mkdocs: command not found` のためこの環境では未実施)

## 公開時の影響
- ドキュメント変更のみ（アプリ実装の挙動変更なし）
- X OAuth導入手順の正確性が上がり、OSS利用者のセットアップ失敗を減らせます。
