### PR TITLE
docs(api): update OpenAPI provider copy to 8-provider support

### DIFF
--- a/api/app/main.py
+++ b/api/app/main.py
@@ -55,7 +55,7 @@ YESOD Auth provides a complete OAuth 2.0 authentication solution with support fo
 
 ### Features
 
-- 🔑 **OAuth 2.0** - Google and Discord authentication with PKCE support
+- 🔑 **OAuth 2.0** - Eight-provider authentication (Google, GitHub, Discord, X, LinkedIn, Facebook, Slack, Twitch) with PKCE support
 - 🔄 **Token Rotation** - Secure refresh token rotation
 - 👤 **User Management** - Profile updates, account linking
 - 📊 **Audit Logging** - Complete authentication event tracking


### PR DESCRIPTION
## Summary\n- update FastAPI OpenAPI description to match current 8 OAuth providers\n- keep existing feature bullets (token rotation etc.) unchanged\n\n## Test\n- rg -n "Google and Discord|Eight-provider|multi-provider|8" api/app/main.py -S\n- . .venv/bin/activate && pytest api/tests/test_health.py -q\n\nCloses #14