### PR TITLE
docs: clarify MOCK_OAUTH_ENABLED defaults in install/start guides

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -38,6 +38,8 @@ cp secrets/jwt_secret.txt.example secrets/jwt_secret.txt
 docker compose --profile default up -d
 ```
 
+`default`プロファイルでは、Compose設定により`MOCK_OAUTH_ENABLED=1`がAPIサービスへ適用されます（アプリ既定値は`0`）。
+
 ## 4. 動作確認
 
 ### ヘルスチェック

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -39,7 +39,7 @@ docker compose --profile full up -d
 | `VALKEY_URL` | Valkey接続URL | - |
 | `CORS_ORIGINS` | 許可するオリジン | - |
 | `FRONTEND_URL` | フロントエンドURL | - |
-| `MOCK_OAUTH_ENABLED` | Mock OAuth有効化 | `0` |
+| `MOCK_OAUTH_ENABLED` | Mock OAuth有効化（アプリ既定値は`0`。`docker compose --profile default`/`ci`ではCompose側で`1`に上書き） | `0` |
 | `ACCESS_TOKEN_LIFETIME_SECONDS` | アクセストークン有効期限 | `900` |
 | `REFRESH_TOKEN_LIFETIME_DAYS` | リフレッシュトークン有効期限 | `7` |
 


### PR DESCRIPTION
## Summary\n- docs/installation.md に MOCK_OAUTH_ENABLED のアプリ既定値(0)と Compose 上書き(default/ci=1)の差分を追記\n- docs/getting-started.md に default profile 起動時の Mock OAuth 有効化を1行追記\n- ドキュメントビルドで Markdown レンダリング崩れがないことを確認\n\n## Test\n- rg -n "MOCK_OAUTH_ENABLED" docs/installation.md docs/getting-started.md\n- docker compose run --rm docs build