### PR TITLE
test: add unauthenticated /auth/logout API check

### DIFF
--- a/api/tests/test_auth_logout.py
+++ b/api/tests/test_auth_logout.py
@@ -1,0 +1,18 @@
+"""Auth logout endpoint tests."""
+
+import pytest
+from httpx import AsyncClient
+
+
+@pytest.mark.asyncio
+async def test_logout_without_auth_returns_401(client: AsyncClient):
+    """Unauthenticated logout request should be rejected by auth guard."""
+    response = await client.post(
+        "/api/v1/auth/logout",
+        json={"refresh_token": "dummy-refresh-token"},
+    )
+
+    assert response.status_code == 401
+    data = response.json()
+    assert "detail" in data
+    assert isinstance(data["detail"], str)

--- a/docs/api/auth.md
+++ b/docs/api/auth.md
@@ -92,6 +92,16 @@ Content-Type: application/json
 }
 ```
 
+**未認証時のレスポンス:**
+
+```json
+{
+  "detail": "Not authenticated"
+}
+```
+
+ステータスコード: `401 Unauthorized`
+
 ---
 
 ## Mock OAuth（開発用）


### PR DESCRIPTION
## Summary
- add API test for unauthenticated `POST /api/v1/auth/logout`
- assert expected error response schema (`detail` string) and status `401`
- document unauthenticated response in `docs/api/auth.md`

## Test
- `cd api && . .venv/bin/activate && pytest -q tests/test_auth_logout.py`
- `cd api && . .venv/bin/activate && pytest -q`

Closes #49
