### PR TITLE
test: add refresh invalid/expired token API tests

### DIFF
--- a/api/tests/test_auth_refresh.py
+++ b/api/tests/test_auth_refresh.py
@@ -1,0 +1,62 @@
+"""Refresh token endpoint tests."""
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth.tokens import create_refresh_token, hash_refresh_token
+from app.main import app
+from app.models.refresh_token import RefreshToken
+from app.models.user import User
+
+
+@pytest.fixture(autouse=True)
+def disable_rate_limiter():
+    """Avoid external Redis dependency for refresh endpoint tests."""
+    original_enabled = app.state.limiter.enabled
+    app.state.limiter.enabled = False
+    try:
+        yield
+    finally:
+        app.state.limiter.enabled = original_enabled
+
+
+@pytest.mark.asyncio
+async def test_refresh_rejects_invalid_token(client: AsyncClient):
+    """Invalid refresh token should return 401 with stable detail message."""
+    response = await client.post(
+        "/api/v1/auth/refresh",
+        json={"refresh_token": "invalid-refresh-token"},
+    )
+
+    assert response.status_code == 401
+    assert response.json() == {"detail": "Invalid or expired refresh token"}
+
+
+@pytest.mark.asyncio
+async def test_refresh_rejects_expired_token(client: AsyncClient, db_session: AsyncSession):
+    """Expired refresh token should return the same 401 contract."""
+    user = User()
+    db_session.add(user)
+    await db_session.commit()
+    await db_session.refresh(user)
+
+    refresh_token = await create_refresh_token(db_session, user.id)
+    token_hash = hash_refresh_token(refresh_token)
+    token_record = await db_session.scalar(
+        select(RefreshToken).where(RefreshToken.token_hash == token_hash)
+    )
+    assert token_record is not None
+    token_record.expires_at = datetime.now(UTC) - timedelta(minutes=1)
+    await db_session.commit()
+
+    response = await client.post(
+        "/api/v1/auth/refresh",
+        json={"refresh_token": refresh_token},
+    )
+
+    assert response.status_code == 401
+    assert response.json() == {"detail": "Invalid or expired refresh token"}


### PR DESCRIPTION
## Summary\n- add \n- verify  returns  and expected  for invalid token\n- verify expired token path also returns the same  contract\n\n## Test\n- ============================= test session starts ==============================
platform darwin -- Python 3.14.3, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/shiroguchi/.codex/worktrees/e566/yesod-auth/api
configfile: pytest.ini (WARNING: ignoring pytest config in pyproject.toml!)
plugins: anyio-4.12.1, respx-0.22.0, hypothesis-6.151.9, asyncio-1.3.0
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=function, asyncio_default_test_loop_scope=function
collected 140 items / 138 deselected / 2 selected

tests/test_auth_refresh.py ..                                            [100%]

====================== 2 passed, 138 deselected in 0.20s =======================\n- ============================= test session starts ==============================
platform darwin -- Python 3.14.3, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/shiroguchi/.codex/worktrees/e566/yesod-auth/api
configfile: pytest.ini (WARNING: ignoring pytest config in pyproject.toml!)
testpaths: tests
plugins: anyio-4.12.1, respx-0.22.0, hypothesis-6.151.9, asyncio-1.3.0
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=function, asyncio_default_test_loop_scope=function
collected 140 items

tests/test_auth_refresh.py ..                                            [  1%]
tests/test_discord_oauth.py .............                                [ 10%]
tests/test_facebook_oauth.py ............                                [ 19%]
tests/test_github_oauth.py ..............                                [ 29%]
tests/test_health.py ....                                                [ 32%]
tests/test_linkedin_oauth.py ............                                [ 40%]
tests/test_mock_oauth.py ......                                          [ 45%]
tests/test_slack_oauth.py ................                               [ 56%]
tests/test_twitch_oauth.py ...............                               [ 67%]
tests/test_webhook_config.py .......                                     [ 72%]
tests/test_webhook_delivery.py ...                                       [ 74%]
tests/test_webhook_emitter.py .....                                      [ 77%]
tests/test_webhook_event.py ...                                          [ 80%]
tests/test_webhook_integration.py .....                                  [ 83%]
tests/test_webhook_signer.py ......                                      [ 87%]
tests/test_webhook_worker.py ......                                      [ 92%]
tests/test_x_oauth.py ...........                                        [100%]

============================= 140 passed in 8.59s ==============================\n\n## Issue\n- refs #19