### PR TITLE
test: OAuth callback state不一致のAPIテストを追加

### DIFF
--- a/api/tests/test_github_oauth.py
+++ b/api/tests/test_github_oauth.py
@@ -1,6 +1,6 @@
 """Tests for GitHub OAuth implementation."""
 
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 from urllib.parse import parse_qs, urlparse
 
 import httpx
@@ -264,3 +264,24 @@ class TestGitHubMockLogin:
         assert response.status_code == 200
         data = response.json()
         assert data["email"] == "bob@example.com"
+
+
+class TestGitHubOAuthCallback:
+    """Tests for GitHub OAuth callback endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_callback_rejects_mismatched_state(self, client):
+        """State mismatch must fail callback to protect against CSRF replay."""
+        with (
+            patch("app.auth.rate_limit.limiter._check_request_limit", return_value=None),
+            patch(
+                "app.auth.router.OAuthStateStore.get_and_delete",
+                new=AsyncMock(return_value=None),
+            ),
+        ):
+            response = await client.get(
+                "/api/v1/auth/github/callback?code=test-code&state=unexpected-state"
+            )
+
+        assert response.status_code == 400
+        assert response.json() == {"detail": "Invalid or expired state"}


### PR DESCRIPTION
## 概要
- GitHub OAuth callback の state 不一致を検証する API テストを追加
- 期待値として HTTP 400 と `Invalid or expired state` を明示
- テストでは rate limit と OAuth state store をモックし、state 検証の失敗挙動にフォーカス

## テスト
- UV_CACHE_DIR=/tmp/uv-cache-yesod-auth uv run --with-requirements api/requirements.txt pytest -q api/tests/test_github_oauth.py
- UV_CACHE_DIR=/tmp/uv-cache-yesod-auth uv run --with-requirements api/requirements.txt pytest -q api/tests/test_mock_oauth.py

Closes #24
