### PR TITLE
docs: sync README and docs index provider feature wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,14 @@
 
 ## Features
 
-- 🔑 OAuth 2.0 authentication (Google, Discord)
+- 🔑 OAuth 2.0 authentication (Google, GitHub, Discord, X, LinkedIn, Facebook, Slack, Twitch)
 - 🐳 Docker Compose ready - just add secrets and run
 - 🗄️ PostgreSQL with automatic migrations
 - 🔒 JWT-based session management
 - 📡 REST API - integrate with any frontend
 - 👤 User profile with avatar support
+
+> Source of truth for provider support notation: `docs/guides/oauth/index.md`.
 
 ## Quick Start
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,6 +13,8 @@
 | :material-webhook: **Webhook連携** | :material-docker: **Docker対応** |
 | ユーザーイベントを外部サービスにリアルタイム通知 | Docker Composeで簡単にデプロイ |
 
+> 対応プロバイダー表記の参照元（正）は `docs/guides/oauth/index.md` です。
+
 ## クイックスタート
 
 ```bash


### PR DESCRIPTION
## 概要
- README の Features にある OAuth 対応プロバイダー表記を docs/index と同期
- `docs/index.md` に対応プロバイダー表記の参照元（正）を追記
- `README.md` にも同じ参照元ポリシーを追記

## 変更詳細
- 対応プロバイダー表記を `Google, GitHub, Discord, X, LinkedIn, Facebook, Slack, Twitch` に統一
- 更新時の参照元を `docs/guides/oauth/index.md` と明示

## テスト
- `rg` で README と docs/index のプロバイダー表記一致を確認
- 参照元ポリシー行の存在を確認

## 公開時の影響
- ドキュメントのみ変更（API/DB/実装挙動への影響なし）
- OSS 利用者の初見導線での認識ズレを低減