### PR TITLE
docs: add oauth common checklist template

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -64,6 +64,7 @@ curl "http://localhost:8000/api/v1/auth/mock/login?user=alice&provider=google"
 ## 次のステップ
 
 - [OAuth設定](guides/oauth/index.md) - 各プロバイダーの設定方法
+- [OAuthガイド共通チェックテンプレート](guides/oauth/index.md#oauthガイド共通チェックテンプレート) - callback/scope/secrets/test の確認観点
 - [トラブルシューティング](help/troubleshooting.md#state-mismatch-flow) - `Invalid or expired state` の診断手順
 - [Webhook設定](guides/webhooks.md) - 外部サービス連携
 - [デプロイ](guides/deployment.md) - 本番環境へのデプロイ

--- a/docs/guides/oauth/github.md
+++ b/docs/guides/oauth/github.md
@@ -27,6 +27,20 @@ echo "your-client-secret" > secrets/github_client_secret.txt
     YESOD Authは`read:user`と`user:email`スコープを使用します。
     これにより、ユーザーの基本情報とメールアドレスを取得できます。
 
+## 共通チェック観点の適用例
+
+- [x] Callback URL
+  - [x] ローカル: `http://localhost:8000/api/v1/auth/github/callback`
+  - [x] 本番: `https://<your-domain>/api/v1/auth/github/callback`
+- [x] Scope
+  - [x] 使用スコープ: `read:user user:email`
+  - [x] 不足時の症状: メールアドレス取得不可で初回ログイン連携に失敗する
+- [x] Secrets
+  - [x] `secrets/github_client_id.txt`
+  - [x] `secrets/github_client_secret.txt`
+- [x] Test
+  - [x] `curl -I "http://localhost:8000/api/v1/auth/github/login"` が `302` を返し、GitHub認可画面へ遷移する
+
 ## 技術仕様
 
 | 項目 | 値 |

--- a/docs/guides/oauth/google.md
+++ b/docs/guides/oauth/google.md
@@ -32,6 +32,20 @@ echo "your-client-id" > secrets/google_client_id.txt
 echo "your-client-secret" > secrets/google_client_secret.txt
 ```
 
+## 共通チェック観点の適用例
+
+- [x] Callback URL
+  - [x] ローカル: `http://localhost:8000/api/v1/auth/google/callback`
+  - [x] 本番: `https://<your-domain>/api/v1/auth/google/callback`
+- [x] Scope
+  - [x] 使用スコープ: `openid email profile`
+  - [x] 不足時の症状: メールアドレス未取得でユーザー同定に失敗する
+- [x] Secrets
+  - [x] `secrets/google_client_id.txt`
+  - [x] `secrets/google_client_secret.txt`
+- [x] Test
+  - [x] `curl -I "http://localhost:8000/api/v1/auth/google/login"` が `302` を返し、Google認可画面へ遷移する
+
 ## 技術仕様
 
 | 項目 | 値 |

--- a/docs/guides/oauth/index.md
+++ b/docs/guides/oauth/index.md
@@ -62,3 +62,28 @@ secrets/
 
 !!! tip "PKCE"
     PKCEに対応しているプロバイダーでは、YESOD Authが自動的にPKCEを使用してセキュリティを強化します。
+
+### OAuthガイド共通チェックテンプレート
+
+新しいOAuthプロバイダーガイドを追加するときは、以下の4観点を必ず埋めてください。
+
+- Callback URL: ローカル/本番の両方で `.../api/v1/auth/{provider}/callback` を明記する
+- Scope: 必須スコープと、スコープ不足時に起きる症状を明記する
+- Secrets: `secrets/{provider}_client_id.txt` と `secrets/{provider}_client_secret.txt` の作成手順を明記する
+- Test: ログイン開始エンドポイントにアクセスして遷移確認する手順を明記する
+
+```md
+## 共通チェック観点
+
+- [ ] Callback URL
+  - [ ] ローカル: `http://localhost:8000/api/v1/auth/{provider}/callback`
+  - [ ] 本番: `https://<your-domain>/api/v1/auth/{provider}/callback`
+- [ ] Scope
+  - [ ] 使用スコープ: `<space-separated-scopes>`
+  - [ ] 不足時の症状: `<example>`
+- [ ] Secrets
+  - [ ] `secrets/{provider}_client_id.txt`
+  - [ ] `secrets/{provider}_client_secret.txt`
+- [ ] Test
+  - [ ] `curl -I "http://localhost:8000/api/v1/auth/{provider}/login"` が 302 を返す
+```


### PR DESCRIPTION
## Summary
- add reusable OAuth checklist template (callback/scope/secrets/test) to index
- add applied examples to Google and GitHub guides
- add one entry-point from getting-started

## Testing
- `git diff --check`
- `mkdocs build -q` (not available in this environment: command not found)

Closes #37