### PR TITLE
docs: 障害時の参照順をhelpへ整備 (#38)

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -64,6 +64,7 @@ curl "http://localhost:8000/api/v1/auth/mock/login?user=alice&provider=google"
 ## 次のステップ
 
 - [OAuth設定](guides/oauth/index.md) - 各プロバイダーの設定方法
+- [障害時の参照順](help/troubleshooting.md#障害時の参照順最短導線) - 調査を health → auth → provider → webhook の順で進める
 - [トラブルシューティング](help/troubleshooting.md#state-mismatch-flow) - `Invalid or expired state` の診断手順
 - [Webhook設定](guides/webhooks.md) - 外部サービス連携
 - [デプロイ](guides/deployment.md) - 本番環境へのデプロイ

--- a/docs/help/troubleshooting.md
+++ b/docs/help/troubleshooting.md
@@ -1,5 +1,21 @@
 # トラブルシューティング
 
+## 障害時の参照順（最短導線）
+
+障害調査は次の順で確認してください。前段が正常なら次段へ進みます。
+
+1. `health`: API と依存サービスの生存確認
+2. `auth`: 認証フローの失敗箇所を特定（state / callback / session）
+3. `provider`: OAuth プロバイダー側設定・資格情報の不一致を確認
+4. `webhook`: 認証後処理や外部通知の遅延・失敗を確認
+
+最小コマンド例（最初の切り分け用）:
+
+```bash
+curl -fsS http://localhost:8000/health
+docker compose logs api --since=30m | rg -n "Invalid state|callback|invalid_client|401"
+```
+
 ## 起動時のエラー
 
 ### `pg_cron`関連のエラー

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -7,6 +7,8 @@
 | Docker | 20.10+ |
 | Docker Compose | 2.0+ |
 
+障害時の確認手順は[トラブルシューティング: 障害時の参照順](help/troubleshooting.md#障害時の参照順最短導線)を参照してください。
+
 ## Docker Composeプロファイル
 
 YESOD Authは3つのプロファイルを提供しています：


### PR DESCRIPTION
## 概要\n- docs/help/troubleshooting に障害時の参照順（health -> auth -> provider -> webhook）を追加\n- 初動切り分け用の最小コマンド例を2件追加\n- docs/installation.md と docs/getting-started.md から当該セクションへの導線リンクを追加\n\n## テスト\n-  を実行（環境に mkdocs がなく失敗）\n- 代替としてリンク先アンカー存在確認を実施\n  - 3:## 障害時の参照順（最短導線）
65:<a id="state-mismatch-flow"></a>\n  - docs/getting-started.md:67:- [障害時の参照順](help/troubleshooting.md#障害時の参照順最短導線) - 調査を health → auth → provider → webhook の順で進める
docs/installation.md:10:障害時の確認手順は[トラブルシューティング: 障害時の参照順](help/troubleshooting.md#障害時の参照順最短導線)を参照してください。\n\nCloses #38