### PR TITLE
docs: Admin i18n未翻訳キーのフォールバック方針を明文化

### DIFF
--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -57,6 +57,19 @@ docker compose --profile default up -d
 curl "http://localhost:8000/api/v1/auth/mock/login?user=alice&provider=google"
 ```
 
+<a id="admin-i18n-untranslated-fallback"></a>
+
+### Adminで未翻訳キーが出たときの表示は？
+
+`admin/i18n.py` の現在実装では、次の順でフォールバックします。
+
+1. 言語コードが未対応なら `en` を使用
+2. キーが未定義なら翻訳文ではなくキー文字列（例: `nav.unknown`）をそのまま表示
+3. フォーマット引数が不足しても例外は出さず、テンプレート文字列をそのまま返す
+
+運用上は「画面にドット区切りキーが見えたら未翻訳」と判定し、翻訳データ追加対象として扱ってください。  
+確認手順は [トラブルシューティング: Admin i18n 未翻訳キーの確認手順](./troubleshooting.md#admin-i18n-fallback) を参照してください。
+
 ---
 
 ## Webhook

--- a/docs/help/troubleshooting.md
+++ b/docs/help/troubleshooting.md
@@ -121,6 +121,39 @@ environment:
 
 ---
 
+<a id="admin-i18n-fallback"></a>
+
+### Admin i18n 未翻訳キーの確認手順
+
+**症状:** Admin 画面で翻訳文の代わりに `nav.xxx` のようなドット区切りキーが表示される
+
+**実装上の期待挙動 (`admin/i18n.py`):**
+
+1. 未対応言語コードは `en` にフォールバック
+2. 未翻訳キーはキー文字列をそのまま返却
+3. フォーマット引数不足時はテンプレート文字列をそのまま返却
+
+**確認コマンド（最小再現）:**
+
+```bash
+python3 - <<'PY'
+from admin.i18n import get_text
+print("unsupported lang ->", get_text("nav.overview", "zz"))
+print("missing key ->", get_text("nav.not_exists", "ja"))
+print("missing format arg ->", get_text("common.environment_warning", "en"))
+PY
+```
+
+**判断基準:**
+
+- `unsupported lang` が英語文言なら言語フォールバックは正常
+- `missing key` が `nav.not_exists` のようにキー文字列なら未翻訳フォールバックは正常
+- `missing format arg` がテンプレート文字列（例: `{name}` を含む）なら例外回避フォールバックは正常
+
+FAQ での方針説明は [FAQ: Adminで未翻訳キーが出たときの表示は？](./faq.md#admin-i18n-untranslated-fallback) を参照。
+
+---
+
 ## Webhook
 
 ### Webhookが発火しない


### PR DESCRIPTION
## 概要
- `admin/i18n.py` の実装挙動（言語・キー・format引数不足時）を確認し、運用方針をFAQへ追記
- troubleshootingに最小再現コマンドと判断基準を追加
- FAQ/troubleshooting間の相互リンクを追加

## テスト
- `python3` で `get_text` のフォールバック確認
  - unsupported lang: `nav.overview` が英語文言へフォールバック
  - missing key: キー文字列をそのまま返却
  - missing format arg: テンプレート文字列を返却

Closes #48