### PR TITLE
docs: add webhook quick path from getting-started

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -61,6 +61,30 @@ curl http://localhost:8000/health
 curl "http://localhost:8000/api/v1/auth/mock/login?user=alice&provider=google"
 ```
 
+## 5. Webhook導入の最短導線
+
+Webhookは、getting-started から以下の2クリック以内で設定手順へ到達できます。
+
+1. このページの「次のステップ」から [Webhook設定](guides/webhooks.md) を開く
+2. ガイド内の [ローカルテスト](guides/webhooks.md#ローカルテスト) に沿って設定する
+
+### Webhook導入の前提条件
+
+- API が起動していること（`docker compose --profile default up -d`）
+- `config/webhooks.yaml` を作成済みであること
+- Webhook受信先URLを用意できること（例: [webhook.site](https://webhook.site)）
+
+### 送信確認の最小手順
+
+1. [Webhook設定](guides/webhooks.md) の例を使って `config/webhooks.yaml` を作成する
+2. Mock OAuth ログインを実行する
+3. 配信履歴 API で Webhook 送信結果を確認する
+
+```bash
+curl "http://localhost:8000/api/v1/auth/mock/login?user=alice&provider=google"
+curl http://localhost:8000/api/v1/admin/webhooks/deliveries
+```
+
 ## 次のステップ
 
 - [OAuth設定](guides/oauth/index.md) - 各プロバイダーの設定方法


### PR DESCRIPTION
## Summary\n- add a dedicated webhook quickstart section in `docs/getting-started.md`\n- clarify prerequisites and add direct link to `docs/guides/webhooks.md` local test section\n- add minimal send/receive confirmation steps using Mock OAuth and deliveries API\n\n## Test\n- `rg -n "Webhook導入の最短導線|guides/webhooks.md#ローカルテスト|/api/v1/admin/webhooks/deliveries" docs/getting-started.md`\n- `test -f docs/guides/webhooks.md`\n- `mkdocs build -q` (not available in this environment: command not found)\n\nCloses #43