### PR TITLE
docs: add troubleshooting for auth 429 rate limits

### DIFF
--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -38,6 +38,11 @@ YESOD AuthはGoogle OAuthでPKCEを自動的に使用します。
 必須なのは`jwt_secret`と、実際に有効化して使うOAuthプロバイダーの`*_client_id`/`*_client_secret`だけです。
 たとえばGoogleのみ使う最小構成ならGoogle分だけ、複数プロバイダー運用なら有効化した各プロバイダー分を追加してください。
 
+### 429（Too Many Requests）が出たときの確認手順は？
+
+認証レート制限の切り分け手順を [トラブルシューティング: 429 Too Many Requests](./troubleshooting.md#auth-rate-limit-429) にまとめています。  
+`api/app/auth/rate_limit.py` の設定値（`RATE_LIMIT_PER_MINUTE` / `VALKEY_URL`）確認から着手してください。
+
 ---
 
 ## 開発

--- a/docs/help/troubleshooting.md
+++ b/docs/help/troubleshooting.md
@@ -121,6 +121,46 @@ environment:
 
 ---
 
+<a id="auth-rate-limit-429"></a>
+
+### `429 Too Many Requests`（認証レート制限）
+
+```json
+{"detail":"Rate limit exceeded"}
+```
+
+**原因:** 短時間に認証エンドポイントへアクセスが集中し、`api/app/auth/rate_limit.py` の制限値を超過した
+
+**確認手順（一次切り分け）:**
+
+1. 429 発生時刻と対象エンドポイントを特定する
+   ```bash
+   docker compose logs api --since=30m | rg -n "429|Too Many Requests|/api/v1/auth/"
+   ```
+
+2. 現在の制限値と参照元を確認する
+   - 参照元: `api/app/auth/rate_limit.py`
+   - 制限値: `settings.RATE_LIMIT_PER_MINUTE`（`default_limits=[f"{settings.RATE_LIMIT_PER_MINUTE}/minute"]`）
+   - ストレージ: `settings.VALKEY_URL`（レート制限カウンタ保存先）
+
+3. 実行環境の設定値が意図どおりか確認する
+   ```bash
+   docker compose exec api env | rg -n "RATE_LIMIT_PER_MINUTE|VALKEY_URL"
+   ```
+
+4. Valkey 側の疎通とエラー有無を確認する
+   ```bash
+   docker compose logs valkey --since=30m
+   ```
+
+**対処の目安:**
+
+- バースト的なアクセスが原因: クライアント側の再試行間隔を延ばす
+- 設定値が過小: `RATE_LIMIT_PER_MINUTE` を運用実態に合わせて調整
+- Valkey 障害が疑われる: Valkey 復旧後に再試行し、429/接続エラーの再発有無を確認
+
+---
+
 ## Webhook
 
 ### Webhookが発火しない


### PR DESCRIPTION
## Summary
- add a dedicated troubleshooting section for auth 429 (Too Many Requests)
- document where the effective limit comes from in `api/app/auth/rate_limit.py`
- add FAQ link to the 429 troubleshooting section

## Verification
- confirmed troubleshooting contains a 4-step flow
- confirmed references to `RATE_LIMIT_PER_MINUTE` and `VALKEY_URL`
- confirmed FAQ link target `#auth-rate-limit-429`

## Public impact
- improves OSS operator self-host troubleshooting speed for auth 429 incidents
- no runtime behavior changes
