### PR TITLE
test: webhook設定読み込み失敗時の期待挙動を固定

### DIFF
--- a/api/tests/test_webhook_config.py
+++ b/api/tests/test_webhook_config.py
@@ -2,6 +2,7 @@
 
 import os
 import tempfile
+import logging
 from pathlib import Path
 from unittest.mock import patch
 
@@ -249,6 +250,57 @@ class TestWebhookConfigValidation:
             result = WebhookConfigLoader.load()
 
         assert len(result.endpoints) == 0
+
+    def test_invalid_yaml_is_logged_and_disables_webhooks(self, caplog):
+        """Invalid YAML should be logged and result in disabled webhooks."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write("endpoints:\n  - id: broken\n    url: [unterminated\n")
+            config_path = Path(f.name)
+
+        try:
+            with (
+                patch.object(config_module, "CONFIG_PATH", config_path),
+                caplog.at_level(logging.ERROR, logger=config_module.__name__),
+            ):
+                WebhookConfigLoader._config = None
+                result = WebhookConfigLoader.load()
+
+            assert len(result.endpoints) == 0
+            assert "Failed to parse webhook configuration" in caplog.text
+        finally:
+            config_path.unlink()
+
+    def test_unresolved_secret_is_logged_and_endpoint_skipped(self, caplog):
+        """Unresolved secret reference should be logged and endpoint skipped."""
+        config = {
+            "endpoints": [
+                {
+                    "id": "test-endpoint",
+                    "url": "https://example.com/webhook",
+                    "secret": "${MISSING_WEBHOOK_SECRET}",
+                    "events": ["user.created"],
+                }
+            ]
+        }
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            yaml.dump(config, f)
+            config_path = Path(f.name)
+
+        try:
+            with (
+                patch.object(config_module, "CONFIG_PATH", config_path),
+                patch.dict(os.environ, {}, clear=True),
+                caplog.at_level(logging.WARNING, logger=config_module.__name__),
+            ):
+                WebhookConfigLoader._config = None
+                result = WebhookConfigLoader.load()
+
+            assert len(result.endpoints) == 0
+            assert "Skipping invalid endpoint" in caplog.text
+            assert "secret could not be resolved" in caplog.text
+        finally:
+            config_path.unlink()
 
     def test_get_endpoints_for_event(self):
         """Test filtering endpoints by event type."""


### PR DESCRIPTION
## 概要\n- webhook 設定ファイルが不正 YAML の場合に、設定読み込み失敗ログと無効化挙動を検証するテストを追加\n- secret 参照が解決不能な場合に、無効エンドポイントとしてスキップされることと警告ログ出力を検証\n\n## テスト\n- UV_CACHE_DIR=/tmp/uv-cache uv run --directory api --with-requirements requirements.txt pytest -q tests/test_webhook_config.py tests/test_webhook_delivery.py tests/test_webhook_emitter.py tests/test_webhook_event.py tests/test_webhook_integration.py tests/test_webhook_signer.py tests/test_webhook_worker.py\n\n## 影響\n- OAuth 導入容易化: 設定不備時の診断ポイントが明確になり導入時の原因切り分けが容易\n- セルフホスト運用性: 運用時の設定ミス検知契約がテストで固定され回帰を防止\n- OSS ドキュメント整備: 実装変更なし（テストのみ）で外部公開時の互換性に影響なし