### PR TITLE
docs: clarify self-host OAuth onboarding for compose

### DIFF
--- a/docs/guides/oauth/index.md
+++ b/docs/guides/oauth/index.md
@@ -28,6 +28,36 @@ PKCE（Proof Key for Code Exchange）は、認可コード横取り攻撃を防�
 
 ## 共通設定
 
+### セルフホスト向け最短手順
+
+1. 利用するOAuthプロバイダーを決める（例: GitHubのみ）
+2. `secrets/` に対象プロバイダーの `*_client_id.txt` と `*_client_secret.txt` を配置する
+3. `MOCK_OAUTH_ENABLED=0` で実OAuthを有効化する
+4. API公開URLに合わせてリダイレクトURIを更新する
+5. `/api/v1/auth/{provider}` へアクセスして、プロバイダー画面へ遷移することを確認する
+
+!!! note "docker-compose の既定設定"
+    `docker-compose.yml` の既定では `api` / `api-ci` に `google_*` と `discord_*` がマウントされています。
+    GitHubなど他プロバイダーを使う場合は、`docker-compose.override.yml` で `secrets` を追加してください。
+
+    ```yaml
+    services:
+      api:
+        secrets:
+          - github_client_id
+          - github_client_secret
+      api-ci:
+        secrets:
+          - github_client_id
+          - github_client_secret
+
+    secrets:
+      github_client_id:
+        file: ./secrets/github_client_id.txt
+      github_client_secret:
+        file: ./secrets/github_client_secret.txt
+    ```
+
 ### シークレットファイルの配置
 
 各プロバイダーのクライアントIDとシークレットは`secrets/`ディレクトリに配置します：

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -113,6 +113,11 @@ Docker Secretsまたは環境変数で設定：
 | `twitch_client_secret` | Twitch OAuth Client Secret |
 | `jwt_secret` | JWT署名用シークレット |
 
+!!! note "Compose運用時の注意"
+    `docker-compose.yml` の既定では `google_*` / `discord_*` / `jwt_secret` が中心です。
+    GitHubを含む他プロバイダーを利用する場合は、`docs/guides/oauth/index.md` の override 例を使って
+    `api` / `api-ci` の `secrets` に対象プロバイダーを追加してください。
+
 ## ポート
 
 | サービス | ポート |


### PR DESCRIPTION
## Summary\n- add self-host quickstart steps in OAuth guide\n- document compose default secrets behavior and override snippet for non-default providers\n- add installation note linking to OAuth override guidance\n\n## Testing\n- docker compose config --profiles\n- docker compose --profile default config --services\n- docker compose --profile ci config --services\n\nCloses #75