### PR TITLE
docs: OAuth導入/セルフホスト運用ガイドを整備

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # YESOD Auth
 
-🔐 Docker-ready OAuth authentication API template with Google & Discord support.
+🔐 Docker-ready OAuth authentication API template with multi-provider support.
 
 > **YESOD** (יסוד) - "Foundation" in Hebrew. The ninth sephira in the Kabbalistic Tree of Life, representing the foundation that connects the spiritual and physical realms.
 
 ## Features
 
-- 🔑 OAuth 2.0 authentication (Google, Discord)
+- 🔑 OAuth 2.0 authentication (Google, GitHub, Discord, X, LinkedIn, Facebook, Slack, Twitch)
 - 🐳 Docker Compose ready - just add secrets and run
 - 🗄️ PostgreSQL with automatic migrations
 - 🔒 JWT-based session management
@@ -24,20 +24,13 @@ cd yesod-auth
 
 ### 2. Set up OAuth credentials
 
-#### Google OAuth
-1. Go to [Google Cloud Console](https://console.cloud.google.com/)
-2. Create a new project or select existing one
-3. Enable "Google+ API" or "Google Identity"
-4. Go to "Credentials" → "Create Credentials" → "OAuth 2.0 Client ID"
-5. Set authorized redirect URI: `http://localhost:8000/auth/google/callback`
-6. Copy Client ID and Client Secret
-
-#### Discord OAuth
-1. Go to [Discord Developer Portal](https://discord.com/developers/applications)
-2. Create a new application
-3. Go to "OAuth2" section
-4. Add redirect URI: `http://localhost:8000/auth/discord/callback`
-5. Copy Client ID and Client Secret
+1. Choose one or more providers:
+   - `google`, `github`, `discord`, `x`, `linkedin`, `facebook`, `slack`, `twitch`
+2. Configure callback URL on each provider:
+   - Local: `http://localhost:8000/api/v1/auth/{provider}/callback`
+   - Self-hosted production: `https://<your-domain>/api/v1/auth/{provider}/callback`
+3. Follow provider-specific guides:
+   - [OAuth setup docs](docs/guides/oauth/index.md)
 
 ### 3. Configure secrets
 
@@ -45,11 +38,12 @@ cd yesod-auth
 # Create secrets directory (already exists in repo)
 mkdir -p secrets
 
-# Add your credentials
+# Add your credentials for enabled providers
+# Example: Google + GitHub
 echo "your-google-client-id" > secrets/google_client_id.txt
 echo "your-google-client-secret" > secrets/google_client_secret.txt
-echo "your-discord-client-id" > secrets/discord_client_id.txt
-echo "your-discord-client-secret" > secrets/discord_client_secret.txt
+echo "your-github-client-id" > secrets/github_client_id.txt
+echo "your-github-client-secret" > secrets/github_client_secret.txt
 
 # Generate JWT secret (or use your own)
 openssl rand -hex 32 > secrets/jwt_secret.txt
@@ -82,10 +76,8 @@ Base URL: `http://localhost:8000/api/v1`
 
 | Method | Endpoint | Description |
 |--------|----------|-------------|
-| GET | `/auth/google` | Start Google OAuth flow |
-| GET | `/auth/google/callback` | Google OAuth callback |
-| GET | `/auth/discord` | Start Discord OAuth flow |
-| GET | `/auth/discord/callback` | Discord OAuth callback |
+| GET | `/auth/{provider}` | Start OAuth flow (`google`,`github`,`discord`,`x`,`linkedin`,`facebook`,`slack`,`twitch`) |
+| GET | `/auth/{provider}/callback` | OAuth callback |
 | POST | `/auth/refresh` | Refresh access token |
 | POST | `/auth/logout` | Logout (invalidate token) |
 
@@ -170,7 +162,7 @@ export function useAuth() {
   const token = ref(localStorage.getItem('auth_token'));
   const user = ref(null);
 
-  const login = (provider: 'google' | 'discord') => {
+  const login = (provider: 'google' | 'github' | 'discord' | 'x' | 'linkedin' | 'facebook' | 'slack' | 'twitch') => {
     window.location.href = `http://localhost:8000/api/v1/auth/${provider}`;
   };
 
@@ -209,8 +201,20 @@ export function useAuth() {
 |------|-------------|
 | `secrets/google_client_id.txt` | Google OAuth Client ID |
 | `secrets/google_client_secret.txt` | Google OAuth Client Secret |
+| `secrets/github_client_id.txt` | GitHub OAuth Client ID |
+| `secrets/github_client_secret.txt` | GitHub OAuth Client Secret |
 | `secrets/discord_client_id.txt` | Discord OAuth Client ID |
 | `secrets/discord_client_secret.txt` | Discord OAuth Client Secret |
+| `secrets/x_client_id.txt` | X (Twitter) OAuth Client ID |
+| `secrets/x_client_secret.txt` | X (Twitter) OAuth Client Secret |
+| `secrets/linkedin_client_id.txt` | LinkedIn OAuth Client ID |
+| `secrets/linkedin_client_secret.txt` | LinkedIn OAuth Client Secret |
+| `secrets/facebook_client_id.txt` | Facebook OAuth Client ID |
+| `secrets/facebook_client_secret.txt` | Facebook OAuth Client Secret |
+| `secrets/slack_client_id.txt` | Slack OAuth Client ID |
+| `secrets/slack_client_secret.txt` | Slack OAuth Client Secret |
+| `secrets/twitch_client_id.txt` | Twitch OAuth Client ID |
+| `secrets/twitch_client_secret.txt` | Twitch OAuth Client Secret |
 | `secrets/jwt_secret.txt` | JWT signing secret |
 
 ## Admin Panel

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -26,12 +26,18 @@ echo "your-google-client-id" | docker secret create google_client_id -
 
 ### 3. OAuthリダイレクトURIの更新
 
-Google Cloud Console / Discord Developer Portalで、リダイレクトURIを本番ドメインに更新：
+使用する各OAuthプロバイダーの管理画面で、リダイレクトURIを本番ドメインへ更新：
 
 ```
-https://api.your-domain.com/api/v1/auth/google/callback
-https://api.your-domain.com/api/v1/auth/discord/callback
+https://api.your-domain.com/api/v1/auth/{provider}/callback
 ```
+
+代表例:
+
+- `https://api.your-domain.com/api/v1/auth/google/callback`
+- `https://api.your-domain.com/api/v1/auth/github/callback`
+- `https://api.your-domain.com/api/v1/auth/discord/callback`
+- `https://api.your-domain.com/api/v1/auth/x/callback`
 
 ---
 

--- a/docs/guides/oauth/index.md
+++ b/docs/guides/oauth/index.md
@@ -12,8 +12,8 @@ YESOD Authは複数のOAuthプロバイダーに対応しています。各プ�
 | [LinkedIn](linkedin.md) | ✅ | - | ✅ | |
 | [Facebook](facebook.md) | ✅ | - | ❌ | [Graph API v18.0](https://developers.facebook.com/docs/graph-api/){:target="_blank"} |
 | [Discord](discord.md) | - | ✅ | ❌ | プロバイダーは対応しているが公式ドキュメントなし |
-| [Slack](slack.md) | - | ✅ | ✅ | プロバイダー未サポート |
-| [Twitch](twitch.md) | - | ✅ | ❌ | プロバイダー未サポート、[Helix API](https://dev.twitch.tv/docs/api/){:target="_blank"} |
+| [Slack](slack.md) | - | ✅ | ✅ | |
+| [Twitch](twitch.md) | - | ✅ | ❌ | [Helix API](https://dev.twitch.tv/docs/api/){:target="_blank"} |
 
 ### PKCEについて
 
@@ -59,6 +59,15 @@ secrets/
     ```
     https://your-domain.com/api/v1/auth/{provider}/callback
     ```
+
+## セルフホスト運用チェックリスト
+
+1. 公開APIドメインを固定する（例: `https://auth.example.com`）
+2. `FRONTEND_URL` と `CORS_ORIGINS` を同一環境のURLに合わせる
+3. 利用するプロバイダーだけ `secrets/*_client_id.txt` / `*_client_secret.txt` を配置する
+4. 各プロバイダーの callback URL を `https://<api-domain>/api/v1/auth/{provider}/callback` に統一する
+5. 本番では `MOCK_OAUTH_ENABLED=0` を確認する
+6. デプロイ後に `GET /health` と実際の OAuth ログイン（最低1プロバイダー）を疎通確認する
 
 !!! tip "PKCE"
     PKCEに対応しているプロバイダーでは、YESOD Authが自動的にPKCEを使用してセキュリティを強化します。

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: YESOD Auth
 site_url: https://mashirou1234.github.io/yesod-auth/
-site_description: OAuth 2.0認証基盤 - Google/Discord対応、Webhook連携
+site_description: OAuth 2.0認証基盤 - マルチプロバイダー対応、Webhook連携
 site_author: mashirou1234
 repo_url: https://github.com/mashirou1234/yesod-auth
 repo_name: mashirou1234/yesod-auth


### PR DESCRIPTION
## Summary
- READMEをマルチプロバイダー対応に更新し、OAuth導線を整理
- OAuthガイドでSlack/Twitchのサポート状況表記を修正
- デプロイ/OAuth概要にセルフホスト向けcallback運用チェックを追加
- mkdocsのサイト説明を現行仕様に合わせて更新

## Test
- `mkdocs build --strict` (command not found)
- `python -m mkdocs build --strict` (command not found)
- `python3 -m mkdocs build --strict` (No module named mkdocs)
