### PR TITLE
[Bench-80][38] ユーザー情報取得APIの前提条件をdocsへ追記する

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -61,6 +61,25 @@ curl http://localhost:8000/health
 curl "http://localhost:8000/api/v1/auth/mock/login?user=alice&provider=google"
 ```
 
+### ユーザー情報取得API（`/api/v1/users/me`）の前提条件
+
+`/api/v1/users/me` は認証必須APIです。呼び出し前に次の3点を満たしてください。
+
+1. APIが起動済みである（`docker compose --profile default up -d` 実行済み）
+2. アクセストークンを取得済みである（例: `GET /api/v1/auth/mock/login`）
+3. `Authorization: Bearer <access_token>` ヘッダーを付与する
+
+確認例:
+
+```bash
+# 1) トークン取得
+TOKEN=$(curl -s "http://localhost:8000/api/v1/auth/mock/login?user=alice&provider=google" | jq -r '.access_token')
+
+# 2) ユーザー情報取得
+curl -H "Authorization: Bearer ${TOKEN}" \
+  "http://localhost:8000/api/v1/users/me"
+```
+
 ## 次のステップ
 
 - [OAuth設定](guides/oauth/index.md) - 各プロバイダーの設定方法


### PR DESCRIPTION
## 概要
- `docs/getting-started.md` に `/api/v1/users/me` 実行前の前提条件を追記
- アクセストークン取得と `Authorization: Bearer` 付与の確認手順を追加

## テスト
- `cd api && source .venv/bin/activate && pytest -q tests/test_mock_oauth.py::test_authenticated_request`
- `cd api && source .venv/bin/activate && pytest -q`

Closes #156
