### PR TITLE
docs: installationに環境変数/Secrets優先順位表を追加

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -81,6 +81,18 @@ rg -n "docker compose --profile (default|full|ci) up -d" docs/installation.md
 | `ACCESS_TOKEN_LIFETIME_SECONDS` | アクセストークン有効期限 | `900` |
 | `REFRESH_TOKEN_LIFETIME_DAYS` | リフレッシュトークン有効期限 | `7` |
 
+### 環境変数・Secrets の優先順位
+
+設定元が複数ある場合は、以下の優先順位で値が決まります。
+
+| 対象 | 優先順位（高 → 低） | 根拠 |
+|------|----------------------|------|
+| OAuthクライアントID/Secret、`JWT_SECRET` | `/run/secrets/<name>` → 同名の環境変数（大文字）→ 既定値 | `api/app/config.py` の `read_secret()` |
+| `DATABASE_URL` / `VALKEY_URL` / `CORS_ORIGINS` / `FRONTEND_URL` など | 環境変数 → 既定値 | `api/app/config.py` の `os.getenv()` |
+| `MOCK_OAUTH_ENABLED`（`default`/`ci`プロファイル） | Compose の service `environment` での指定（`1`）→ アプリ既定値（`0`） | `docker-compose.yml` と `api/app/config.py` |
+
+`read_secret()` の優先順は `api/tests/test_config.py` でテストされています（secret file 優先、次に環境変数、最後に既定値）。
+
 ### 管理画面用環境変数
 
 | 変数名 | 説明 | デフォルト |


### PR DESCRIPTION
## 概要\n- docs/installation.md に環境変数/Secrets の優先順位表を追加\n- \ の実装とテストに基づく根拠を明記\n- MOCK_OAUTH_ENABLED の Compose 上書き優先も追記\n\n## テスト\n- docker compose config --profiles\n\n## 公開時の影響\n- ドキュメントのみの変更でアプリ挙動への影響なし\n- OAuth導入時の設定確認手順が明確化され、セルフホスト運用の誤設定リスクを低減