### PR TITLE
docs: docker compose 利用時の最小確認手順を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ docker compose --profile default --profile full up -d
 docker compose --profile ci up -d
 ```
 
+最小動作確認は [`docs/installation.md` の「docker compose利用時の最小確認手順」](docs/installation.md#docker-compose利用時の最小確認手順) を参照してください。
+
 ### 5. Access the API
 
 - API: http://localhost:8000

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,6 +30,8 @@ docker compose --profile default up -d
 
 APIドキュメントは http://localhost:8000/docs で確認できます。
 
+起動直後の最小確認は [インストール手順の「docker compose利用時の最小確認手順」](installation.md#docker-compose利用時の最小確認手順) を参照してください。
+
 ## アーキテクチャ
 
 ```

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -37,6 +37,43 @@ docker compose --profile full up -d
 docker compose --profile ci up -d
 ```
 
+## docker compose利用時の最小確認手順
+
+`docker compose --profile default up -d` 実行後、次の3項目だけ確認すれば最小動作確認が完了します。
+
+1. コンテナ状態の確認
+
+```bash
+docker compose --profile default ps
+```
+
+期待値:
+- `api`, `db`, `docs`, `valkey` が `Up`（または `running`）
+
+2. API ヘルスチェック確認
+
+```bash
+curl -fsS http://localhost:8000/health
+```
+
+期待値:
+- HTTP 200 が返る
+
+3. API ドキュメント到達確認
+
+```bash
+curl -fsS -o /dev/null -w '%{http_code}\n' http://localhost:8000/docs
+```
+
+期待値:
+- `200`
+
+終了時は次のコマンドで後片付けできます。
+
+```bash
+docker compose --profile default down
+```
+
 ## profile整合確認手順
 
 `docker-compose.yml` と本ドキュメントの profile 記載が一致していることを、変更時に必ず確認してください。


### PR DESCRIPTION
## 概要
- `docs/installation.md` に docker compose 利用時の最小確認手順を追加
- `README.md` と `docs/index.md` に確認手順への導線を追加

## テスト
- 最小再現: `docker compose --profile default config --services`
- 回帰: `cd api && python3 -m venv .venv && . .venv/bin/activate && python -m pytest -q`
  - 結果: 149 passed

Closes #155