### PR TITLE
docs: add API connectivity check to quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,16 @@ docker compose --profile ci up -d
 - API Docs: http://localhost:8000/docs
 - Health Check: http://localhost:8000/health
 
+Quick API connectivity check:
+
+```bash
+curl -sS http://localhost:8000/health
+# {"status":"healthy"}
+
+curl -sS -o /dev/null -w "%{http_code}\n" http://localhost:8000/api/v1/metrics
+# 200
+```
+
 ## API Endpoints
 
 Base URL: `http://localhost:8000/api/v1`


### PR DESCRIPTION
## Summary\n- add a quick API connectivity check section to Quick Start in README\n- include exact curl commands and expected responses\n\n## Test\n- docker compose --profile default config\n\n## Issue\n- closes #147