### PR TITLE
docs: セッション失効時の再ログイン手順を明文化

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,10 @@ curl "http://localhost:8000/api/v1/auth/mock/login?user=alice&provider=google"
 curl "http://localhost:8000/api/v1/auth/mock/users"
 ```
 
+### セッション失効時の再ログイン
+
+`401 Unauthorized` が返る場合は、`POST /api/v1/auth/refresh` でトークン再発行を試し、失敗時は OAuth ログインを再実行してください。運用時の手順は [`docs/getting-started.md`](docs/getting-started.md) の「セッション失効時の再ログイン手順」にまとめています。
+
 ### Running Tests
 
 ```bash

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -61,6 +61,36 @@ curl http://localhost:8000/health
 curl "http://localhost:8000/api/v1/auth/mock/login?user=alice&provider=google"
 ```
 
+## 5. セッション失効時の再ログイン手順
+
+アクセストークン失効で `401 Unauthorized` が返る場合は、次の順序で復旧します。
+
+1. まずリフレッシュトークンで再発行を試す
+
+```bash
+curl -X POST "http://localhost:8000/api/v1/auth/refresh" \
+  -H "Content-Type: application/json" \
+  -d '{"refresh_token":"<refresh_token>"}'
+```
+
+2. 再発行できない場合は OAuth ログインを再実行する
+
+```bash
+# 例: Google OAuth を再開始
+open "http://localhost:8000/api/v1/auth/google"
+```
+
+3. 複数端末で状態がずれた場合は古いセッションを失効させる
+
+```bash
+curl -X DELETE "http://localhost:8000/api/v1/sessions/me" \
+  -H "Authorization: Bearer <access_token>"
+```
+
+補足:
+- 認証API詳細は `docs/api/auth.md` を参照してください。
+- セッションAPI一覧は `README.md` の `Sessions` セクションと同一です。
+
 ## 次のステップ
 
 - [OAuth設定](guides/oauth/index.md) - 各プロバイダーの設定方法


### PR DESCRIPTION
## Summary
- docs/getting-started にセッション失効時の再ログイン手順を追加
- README に再ログイン手順への導線を追加
- OAuth導入運用で `401 Unauthorized` からの復旧順を明文化

## Test
- docker compose config --profiles

## Impact
- OAuth導入時の運用手順が明確になり、セルフホスト環境での障害一次対応が容易化