### PR TITLE
[Bench-80][36] API認証トラブル時の参照ドキュメント順を定義する

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -67,3 +67,11 @@ curl "http://localhost:8000/api/v1/auth/mock/login?user=alice&provider=google"
 - [トラブルシューティング](help/troubleshooting.md#state-mismatch-flow) - `Invalid or expired state` の診断手順
 - [Webhook設定](guides/webhooks.md) - 外部サービス連携
 - [デプロイ](guides/deployment.md) - 本番環境へのデプロイ
+
+## API認証トラブル時の参照順
+
+API認証で問題が発生した場合は、次の順で確認してください。
+
+1. [インストール](installation.md#oauth認証情報)で OAuth シークレットの配置と profile を確認する
+2. [クイックスタート](getting-started.md#4-動作確認)で `/health` と `/docs` の到達性を確認する
+3. [トラブルシューティング](help/troubleshooting.md#state-mismatch-flow)で症状別の診断手順を実施する

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,6 +30,12 @@ docker compose --profile default up -d
 
 APIドキュメントは http://localhost:8000/docs で確認できます。
 
+## API認証トラブル時の参照順
+
+1. [インストール](installation.md#oauth認証情報)で OAuth シークレットと profile 設定を確認
+2. [クイックスタート](getting-started.md#4-動作確認)で `/health` と `/docs` を確認
+3. [トラブルシューティング](help/troubleshooting.md#state-mismatch-flow)で原因を切り分け
+
 ## アーキテクチャ
 
 ```

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -113,6 +113,12 @@ Docker Secretsまたは環境変数で設定：
 | `twitch_client_secret` | Twitch OAuth Client Secret |
 | `jwt_secret` | JWT署名用シークレット |
 
+### API認証トラブル時の確認順
+
+1. このセクションのシークレットが有効化した provider 分そろっていることを確認する
+2. [クイックスタート](getting-started.md#4-動作確認)で API 到達性を確認する
+3. [トラブルシューティング](help/troubleshooting.md#state-mismatch-flow)で症状別の対処を行う
+
 ## ポート
 
 | サービス | ポート |


### PR DESCRIPTION
## 概要\n- docs/index.md に API認証トラブル時の参照順を追加\n- docs/getting-started.md に同一順序の参照手順を追加\n- docs/installation.md に確認順を追加し、導線を統一\n\n## テスト\n- docs/getting-started.md:67:- [トラブルシューティング](help/troubleshooting.md#state-mismatch-flow) - `Invalid or expired state` の診断手順
docs/getting-started.md:71:## API認証トラブル時の参照順
docs/getting-started.md:77:3. [トラブルシューティング](help/troubleshooting.md#state-mismatch-flow)で症状別の診断手順を実施する
docs/installation.md:116:### API認証トラブル時の確認順
docs/installation.md:120:3. [トラブルシューティング](help/troubleshooting.md#state-mismatch-flow)で症状別の対処を行う
docs/index.md:33:## API認証トラブル時の参照順
docs/index.md:37:3. [トラブルシューティング](help/troubleshooting.md#state-mismatch-flow)で原因を切り分け\n- ============================= test session starts ==============================
platform darwin -- Python 3.14.3, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/shiroguchi/.codex/worktrees/90d4/yesod-auth/api
configfile: pytest.ini (WARNING: ignoring pytest config in pyproject.toml!)
testpaths: tests
plugins: anyio-4.12.1, respx-0.22.0, hypothesis-6.151.9, asyncio-1.3.0
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=function, asyncio_default_test_loop_scope=function
collected 149 items

tests/test_accounts.py .                                                 [  0%]
tests/test_auth_logout.py .                                              [  1%]
tests/test_auth_refresh.py ..                                            [  2%]
tests/test_config.py ...                                                 [  4%]
tests/test_discord_oauth.py .............                                [ 13%]
tests/test_facebook_oauth.py ............                                [ 21%]
tests/test_github_oauth.py ..............                                [ 30%]
tests/test_health.py ....                                                [ 33%]
tests/test_linkedin_oauth.py ............                                [ 41%]
tests/test_mock_oauth.py ......                                          [ 45%]
tests/test_sessions.py ...                                               [ 47%]
tests/test_sessions_api.py .                                             [ 48%]
tests/test_slack_oauth.py ................                               [ 59%]
tests/test_twitch_oauth.py ...............                               [ 69%]
tests/test_webhook_config.py .......                                     [ 73%]
tests/test_webhook_delivery.py ...                                       [ 75%]
tests/test_webhook_emitter.py .....                                      [ 79%]
tests/test_webhook_event.py ...                                          [ 81%]
tests/test_webhook_integration.py .....                                  [ 84%]
tests/test_webhook_signer.py ......                                      [ 88%]
tests/test_webhook_worker.py ......                                      [ 92%]
tests/test_x_oauth.py ...........                                        [100%]

============================= 149 passed in 6.50s ==============================\n\nCloses #154