### PR TITLE
docs: add self-hosted secret layout example

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,17 +42,46 @@ cd yesod-auth
 ### 3. Configure secrets
 
 ```bash
-# Create secrets directory (already exists in repo)
-mkdir -p secrets
+# Generate local secret files from templates
+cp secrets/*.example secrets/
 
-# Add your credentials
-echo "your-google-client-id" > secrets/google_client_id.txt
-echo "your-google-client-secret" > secrets/google_client_secret.txt
-echo "your-discord-client-id" > secrets/discord_client_id.txt
-echo "your-discord-client-secret" > secrets/discord_client_secret.txt
+# Fill OAuth client id/secret values (Google/Discord)
+$EDITOR secrets/google_client_id.txt
+$EDITOR secrets/google_client_secret.txt
+$EDITOR secrets/discord_client_id.txt
+$EDITOR secrets/discord_client_secret.txt
 
-# Generate JWT secret (or use your own)
+# Generate JWT secret (or use your own value)
 openssl rand -hex 32 > secrets/jwt_secret.txt
+
+# Required when running --profile full (admin panel)
+openssl rand -base64 24 > secrets/admin_password.txt
+
+# Restrict file permissions
+chmod 600 secrets/*.txt
+```
+
+#### Self-hosted secret layout example
+
+`docker-compose.yml` reads from `./secrets/*.txt`. For self-hosted deployments,
+prepare a dedicated secret directory and mount it as `./secrets` with a symlink:
+
+```text
+/opt/yesod-auth/
+  app/        # git checkout
+  secrets/
+    current/
+      google_client_id.txt
+      google_client_secret.txt
+      discord_client_id.txt
+      discord_client_secret.txt
+      jwt_secret.txt
+      admin_password.txt   # only for --profile full
+```
+
+```bash
+cd /opt/yesod-auth/app
+ln -sfn ../secrets/current secrets
 ```
 
 ### 4. Start the service
@@ -212,6 +241,7 @@ export function useAuth() {
 | `secrets/discord_client_id.txt` | Discord OAuth Client ID |
 | `secrets/discord_client_secret.txt` | Discord OAuth Client Secret |
 | `secrets/jwt_secret.txt` | JWT signing secret |
+| `secrets/admin_password.txt` | Admin panel password (`--profile full` only) |
 
 ## Admin Panel
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,6 +29,8 @@ docker compose --profile default up -d
 ```
 
 APIドキュメントは http://localhost:8000/docs で確認できます。
+セルフホスト運用時の秘密情報配置は
+[インストールガイドの配置例](installation.md#セルフホスト向け秘密情報配置例)を参照してください。
 
 ## アーキテクチャ
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -113,6 +113,45 @@ Docker Secretsまたは環境変数で設定：
 | `twitch_client_secret` | Twitch OAuth Client Secret |
 | `jwt_secret` | JWT署名用シークレット |
 
+## セルフホスト向け秘密情報配置例
+
+`docker-compose.yml` は `./secrets/*.txt` を参照します。セルフホスト環境では
+「アプリ配置」と「秘密情報配置」を分離し、`./secrets` をシンボリックリンクで
+接続するとローテーションしやすくなります。
+
+```text
+/opt/yesod-auth/
+  app/        # このリポジトリを配置
+  secrets/
+    current/
+      google_client_id.txt
+      google_client_secret.txt
+      discord_client_id.txt
+      discord_client_secret.txt
+      jwt_secret.txt
+      admin_password.txt   # --profile full を使う場合のみ
+```
+
+作成例:
+
+```bash
+mkdir -p /opt/yesod-auth/secrets/current
+cp secrets/*.example /opt/yesod-auth/secrets/current/
+openssl rand -hex 32 > /opt/yesod-auth/secrets/current/jwt_secret.txt
+openssl rand -base64 24 > /opt/yesod-auth/secrets/current/admin_password.txt
+chmod 600 /opt/yesod-auth/secrets/current/*.txt
+
+cd /opt/yesod-auth/app
+ln -sfn ../secrets/current secrets
+```
+
+検証:
+
+```bash
+docker compose --profile default config >/dev/null
+docker compose --profile full config >/dev/null
+```
+
 ## ポート
 
 | サービス | ポート |


### PR DESCRIPTION
## Summary
- add a self-hosted secret layout example that keeps app files and secrets separated
- document a reproducible symlink pattern so `docker-compose.yml` can still read `./secrets/*.txt`
- add `admin_password.txt` to README secret table and link docs index to installation details

## Changes
- `README.md`: update secret setup to template copy + permission hardening + self-hosted layout example
- `docs/installation.md`: add `セルフホスト向け秘密情報配置例` section with directory tree, setup commands, and validation commands
- `docs/index.md`: add link to installation section for self-host operations

## Test
- `docker compose config --profiles`
- `docker compose --profile default config >/dev/null`
- `docker compose --profile full config >/dev/null`
