### PR TITLE
docs: OAuthコールバックURL検証観点を整理

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,14 +29,14 @@ cd yesod-auth
 2. Create a new project or select existing one
 3. Enable "Google+ API" or "Google Identity"
 4. Go to "Credentials" → "Create Credentials" → "OAuth 2.0 Client ID"
-5. Set authorized redirect URI: `http://localhost:8000/auth/google/callback`
+5. Set authorized redirect URI: `http://localhost:8000/api/v1/auth/google/callback`
 6. Copy Client ID and Client Secret
 
 #### Discord OAuth
 1. Go to [Discord Developer Portal](https://discord.com/developers/applications)
 2. Create a new application
 3. Go to "OAuth2" section
-4. Add redirect URI: `http://localhost:8000/auth/discord/callback`
+4. Add redirect URI: `http://localhost:8000/api/v1/auth/discord/callback`
 5. Copy Client ID and Client Secret
 
 ### 3. Configure secrets
@@ -73,6 +73,7 @@ docker compose --profile ci up -d
 - API: http://localhost:8000
 - API Docs: http://localhost:8000/docs
 - Health Check: http://localhost:8000/health
+- Callback URL validation checklist: [docs/getting-started.md](docs/getting-started.md#25-コールバックurlの検証)
 
 ## API Endpoints
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -32,6 +32,25 @@ cp secrets/jwt_secret.txt.example secrets/jwt_secret.txt
     openssl rand -base64 32 > secrets/jwt_secret.txt
     ```
 
+## 2.5 コールバックURLの検証
+
+OAuth導入時は、実装前に「登録したコールバックURL」と「実際にYESOD Authが受けるURL」が一致することを確認します。
+
+### 基本ルール
+
+- 形式は `https://<api-domain>/api/v1/auth/<provider>/callback`
+- `http` はローカル開発以外で使わない
+- 末尾スラッシュを付けない（`.../callback/` は不可）
+- `provider` は実際に有効化したものだけ登録する
+
+### 検証チェックリスト
+
+1. API公開URLを決める（例: `https://api.example.com`）
+2. プロバイダーごとに callback URL を作る（例: `https://api.example.com/api/v1/auth/google/callback`）
+3. OAuthプロバイダー管理画面の設定値と、`docs/api/auth.md` のパス仕様が一致することを確認する
+4. リバースプロキシ利用時は `X-Forwarded-Proto=https` が正しく渡る構成にする
+5. ログイン実行後、`Invalid state` や `redirect_uri_mismatch` が出ないことを確認する
+
 ## 3. 起動
 
 ```bash


### PR DESCRIPTION
## 概要
OAuth導入時のコールバックURL検証観点をドキュメントに整理しました。

## 変更内容
- `docs/getting-started.md` に「2.5 コールバックURLの検証」を追加
- 検証ルール（スキーム/パス/末尾スラッシュ/provider整合）を明文化
- 運用時チェックリスト（API公開URL、管理画面設定整合、Forwardedヘッダ、エラー確認）を追加
- `README.md` の redirect URI を API 実パス（`/api/v1/auth/.../callback`）へ修正
- `README.md` から検証チェックリストへの導線を追加

## テスト
- `docker compose config` 実行（成功）
- 備考: `mkdocs` / `pytest` は実行環境に未インストール

Closes #151