### PR TITLE
docs: add first-install failure patterns to installation guide

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -69,6 +69,91 @@ docker compose --profile ci config --services
 rg -n "docker compose --profile (default|full|ci) up -d" docs/installation.md
 ```
 
+## 初回導入で起きやすい失敗パターン
+
+初回セットアップ時に発生しやすい失敗を、症状ごとの確認順でまとめます。
+
+### 1. `docker compose up` で secret 未設定エラーになる
+
+症状例:
+
+- `Error: secret ... not found`
+- API コンテナが `CreateContainerConfigError` で起動しない
+
+確認:
+
+```bash
+ls -1 secrets | head
+ls -1 secrets/*.txt 2>/dev/null | wc -l
+```
+
+対処:
+
+1. `secrets/*.example` から必要な `.txt` を作成する
+2. 最低限 `jwt_secret.txt` は必ず作成する
+3. 有効化するOAuthプロバイダー分の client id/secret を作成する
+
+### 2. `default` 以外で起動して Mock OAuth が使えない
+
+症状例:
+
+- `/api/v1/auth/mock/login` が想定どおり動作しない
+- 初回確認で外部OAuth設定まで要求される
+
+確認:
+
+```bash
+docker compose --profile default config --services
+docker compose --profile full config --services
+```
+
+対処:
+
+1. 初回動作確認は `docker compose --profile default up -d` を使う
+2. `full` は管理画面込みの確認時に切り替える
+3. `ci` はローカル初回導入用途では使わない
+
+### 3. 8000/5432/6379 が使用中で起動失敗する
+
+症状例:
+
+- `Bind for 0.0.0.0:8000 failed: port is already allocated`
+- 一部サービスだけ `Exited` になる
+
+確認:
+
+```bash
+docker compose ps
+lsof -nP -iTCP:8000 -iTCP:5432 -iTCP:6379 -sTCP:LISTEN
+```
+
+対処:
+
+1. 競合プロセスや既存コンテナを停止する
+2. 必要なら `docker compose down` 後に再起動する
+3. 競合が解消しない場合は `.env` 側のポート割当を見直す
+
+### 4. 古いコンテナ状態が残って挙動が不安定になる
+
+症状例:
+
+- 設定変更後も以前の挙動のまま
+- `healthy` にならない
+
+確認:
+
+```bash
+docker compose ps
+docker compose logs --tail=100 api
+```
+
+対処:
+
+```bash
+docker compose down
+docker compose up -d --build
+```
+
 ## 環境変数
 
 | 変数名 | 説明 | デフォルト |


### PR DESCRIPTION
## 概要\n- docs/installation.md に初回導入で起きやすい失敗パターンを追加\n- 症状・確認コマンド・対処を4パターンで整理\n\n## 変更ファイル\n- docs/installation.md\n\n## テスト\n- 最小再現: 72:## 初回導入で起きやすい失敗パターン
76:### 1. `docker compose up` で secret 未設定エラーになる
134:3. 競合が解消しない場合は `.env` 側のポート割当を見直す
136:### 4. 古いコンテナ状態が残って挙動が不安定になる
201:## ポート
203:| サービス | ポート |\n- 回帰: Requirement already satisfied: fastapi>=0.109.0 in ./.venv/lib/python3.14/site-packages (from -r api/requirements.txt (line 1)) (0.135.1)
Requirement already satisfied: uvicorn>=0.27.0 in ./.venv/lib/python3.14/site-packages (from uvicorn[standard]>=0.27.0->-r api/requirements.txt (line 2)) (0.41.0)
Requirement already satisfied: sqlalchemy>=2.0.0 in ./.venv/lib/python3.14/site-packages (from sqlalchemy[asyncio]>=2.0.0->-r api/requirements.txt (line 3)) (2.0.48)
Requirement already satisfied: asyncpg>=0.29.0 in ./.venv/lib/python3.14/site-packages (from -r api/requirements.txt (line 4)) (0.31.0)
Requirement already satisfied: alembic>=1.13.0 in ./.venv/lib/python3.14/site-packages (from -r api/requirements.txt (line 5)) (1.18.4)
Requirement already satisfied: python-jose>=3.3.0 in ./.venv/lib/python3.14/site-packages (from python-jose[cryptography]>=3.3.0->-r api/requirements.txt (line 6)) (3.5.0)
Requirement already satisfied: passlib>=1.7.4 in ./.venv/lib/python3.14/site-packages (from passlib[bcrypt]>=1.7.4->-r api/requirements.txt (line 7)) (1.7.4)
Requirement already satisfied: httpx>=0.27.0 in ./.venv/lib/python3.14/site-packages (from -r api/requirements.txt (line 8)) (0.28.1)
Requirement already satisfied: pydantic>=2.0.0 in ./.venv/lib/python3.14/site-packages (from -r api/requirements.txt (line 9)) (2.12.5)
Requirement already satisfied: pydantic-settings>=2.0.0 in ./.venv/lib/python3.14/site-packages (from -r api/requirements.txt (line 10)) (2.13.1)
Requirement already satisfied: python-multipart>=0.0.6 in ./.venv/lib/python3.14/site-packages (from -r api/requirements.txt (line 11)) (0.0.22)
Requirement already satisfied: redis>=5.0.0 in ./.venv/lib/python3.14/site-packages (from -r api/requirements.txt (line 12)) (7.2.1)
Requirement already satisfied: slowapi>=0.1.9 in ./.venv/lib/python3.14/site-packages (from -r api/requirements.txt (line 13)) (0.1.9)
Requirement already satisfied: pytest>=8.0.0 in ./.venv/lib/python3.14/site-packages (from -r api/requirements.txt (line 16)) (9.0.2)
Requirement already satisfied: pytest-asyncio>=0.23.0 in ./.venv/lib/python3.14/site-packages (from -r api/requirements.txt (line 17)) (1.3.0)
Requirement already satisfied: aiosqlite>=0.19.0 in ./.venv/lib/python3.14/site-packages (from -r api/requirements.txt (line 18)) (0.22.1)
Requirement already satisfied: hypothesis>=6.100.0 in ./.venv/lib/python3.14/site-packages (from -r api/requirements.txt (line 19)) (6.151.9)
Requirement already satisfied: pyyaml>=6.0.0 in ./.venv/lib/python3.14/site-packages (from -r api/requirements.txt (line 20)) (6.0.3)
Requirement already satisfied: respx>=0.21.0 in ./.venv/lib/python3.14/site-packages (from -r api/requirements.txt (line 21)) (0.22.0)
Requirement already satisfied: starlette>=0.46.0 in ./.venv/lib/python3.14/site-packages (from fastapi>=0.109.0->-r api/requirements.txt (line 1)) (0.52.1)
Requirement already satisfied: typing-extensions>=4.8.0 in ./.venv/lib/python3.14/site-packages (from fastapi>=0.109.0->-r api/requirements.txt (line 1)) (4.15.0)
Requirement already satisfied: typing-inspection>=0.4.2 in ./.venv/lib/python3.14/site-packages (from fastapi>=0.109.0->-r api/requirements.txt (line 1)) (0.4.2)
Requirement already satisfied: annotated-doc>=0.0.2 in ./.venv/lib/python3.14/site-packages (from fastapi>=0.109.0->-r api/requirements.txt (line 1)) (0.0.4)
Requirement already satisfied: click>=7.0 in ./.venv/lib/python3.14/site-packages (from uvicorn>=0.27.0->uvicorn[standard]>=0.27.0->-r api/requirements.txt (line 2)) (8.3.1)
Requirement already satisfied: h11>=0.8 in ./.venv/lib/python3.14/site-packages (from uvicorn>=0.27.0->uvicorn[standard]>=0.27.0->-r api/requirements.txt (line 2)) (0.16.0)
Requirement already satisfied: Mako in ./.venv/lib/python3.14/site-packages (from alembic>=1.13.0->-r api/requirements.txt (line 5)) (1.3.10)
Requirement already satisfied: ecdsa!=0.15 in ./.venv/lib/python3.14/site-packages (from python-jose>=3.3.0->python-jose[cryptography]>=3.3.0->-r api/requirements.txt (line 6)) (0.19.1)
Requirement already satisfied: rsa!=4.1.1,!=4.4,<5.0,>=4.0 in ./.venv/lib/python3.14/site-packages (from python-jose>=3.3.0->python-jose[cryptography]>=3.3.0->-r api/requirements.txt (line 6)) (4.9.1)
Requirement already satisfied: pyasn1>=0.5.0 in ./.venv/lib/python3.14/site-packages (from python-jose>=3.3.0->python-jose[cryptography]>=3.3.0->-r api/requirements.txt (line 6)) (0.6.2)
Requirement already satisfied: anyio in ./.venv/lib/python3.14/site-packages (from httpx>=0.27.0->-r api/requirements.txt (line 8)) (4.12.1)
Requirement already satisfied: certifi in ./.venv/lib/python3.14/site-packages (from httpx>=0.27.0->-r api/requirements.txt (line 8)) (2026.2.25)
Requirement already satisfied: httpcore==1.* in ./.venv/lib/python3.14/site-packages (from httpx>=0.27.0->-r api/requirements.txt (line 8)) (1.0.9)
Requirement already satisfied: idna in ./.venv/lib/python3.14/site-packages (from httpx>=0.27.0->-r api/requirements.txt (line 8)) (3.11)
Requirement already satisfied: annotated-types>=0.6.0 in ./.venv/lib/python3.14/site-packages (from pydantic>=2.0.0->-r api/requirements.txt (line 9)) (0.7.0)
Requirement already satisfied: pydantic-core==2.41.5 in ./.venv/lib/python3.14/site-packages (from pydantic>=2.0.0->-r api/requirements.txt (line 9)) (2.41.5)
Requirement already satisfied: python-dotenv>=0.21.0 in ./.venv/lib/python3.14/site-packages (from pydantic-settings>=2.0.0->-r api/requirements.txt (line 10)) (1.2.2)
Requirement already satisfied: limits>=2.3 in ./.venv/lib/python3.14/site-packages (from slowapi>=0.1.9->-r api/requirements.txt (line 13)) (5.8.0)
Requirement already satisfied: iniconfig>=1.0.1 in ./.venv/lib/python3.14/site-packages (from pytest>=8.0.0->-r api/requirements.txt (line 16)) (2.3.0)
Requirement already satisfied: packaging>=22 in ./.venv/lib/python3.14/site-packages (from pytest>=8.0.0->-r api/requirements.txt (line 16)) (26.0)
Requirement already satisfied: pluggy<2,>=1.5 in ./.venv/lib/python3.14/site-packages (from pytest>=8.0.0->-r api/requirements.txt (line 16)) (1.6.0)
Requirement already satisfied: pygments>=2.7.2 in ./.venv/lib/python3.14/site-packages (from pytest>=8.0.0->-r api/requirements.txt (line 16)) (2.19.2)
Requirement already satisfied: sortedcontainers<3.0.0,>=2.1.0 in ./.venv/lib/python3.14/site-packages (from hypothesis>=6.100.0->-r api/requirements.txt (line 19)) (2.4.0)
Requirement already satisfied: six>=1.9.0 in ./.venv/lib/python3.14/site-packages (from ecdsa!=0.15->python-jose>=3.3.0->python-jose[cryptography]>=3.3.0->-r api/requirements.txt (line 6)) (1.17.0)
Requirement already satisfied: deprecated>=1.2 in ./.venv/lib/python3.14/site-packages (from limits>=2.3->slowapi>=0.1.9->-r api/requirements.txt (line 13)) (1.3.1)
Requirement already satisfied: wrapt<3,>=1.10 in ./.venv/lib/python3.14/site-packages (from deprecated>=1.2->limits>=2.3->slowapi>=0.1.9->-r api/requirements.txt (line 13)) (2.1.1)
Requirement already satisfied: bcrypt>=3.1.0 in ./.venv/lib/python3.14/site-packages (from passlib[bcrypt]>=1.7.4->-r api/requirements.txt (line 7)) (5.0.0)
Requirement already satisfied: cryptography>=3.4.0 in ./.venv/lib/python3.14/site-packages (from python-jose[cryptography]>=3.3.0->-r api/requirements.txt (line 6)) (46.0.5)
Requirement already satisfied: cffi>=2.0.0 in ./.venv/lib/python3.14/site-packages (from cryptography>=3.4.0->python-jose[cryptography]>=3.3.0->-r api/requirements.txt (line 6)) (2.0.0)
Requirement already satisfied: pycparser in ./.venv/lib/python3.14/site-packages (from cffi>=2.0.0->cryptography>=3.4.0->python-jose[cryptography]>=3.3.0->-r api/requirements.txt (line 6)) (3.0)
Requirement already satisfied: greenlet>=1 in ./.venv/lib/python3.14/site-packages (from sqlalchemy[asyncio]>=2.0.0->-r api/requirements.txt (line 3)) (3.3.2)
Requirement already satisfied: httptools>=0.6.3 in ./.venv/lib/python3.14/site-packages (from uvicorn[standard]>=0.27.0->-r api/requirements.txt (line 2)) (0.7.1)
Requirement already satisfied: uvloop>=0.15.1 in ./.venv/lib/python3.14/site-packages (from uvicorn[standard]>=0.27.0->-r api/requirements.txt (line 2)) (0.22.1)
Requirement already satisfied: watchfiles>=0.20 in ./.venv/lib/python3.14/site-packages (from uvicorn[standard]>=0.27.0->-r api/requirements.txt (line 2)) (1.1.1)
Requirement already satisfied: websockets>=10.4 in ./.venv/lib/python3.14/site-packages (from uvicorn[standard]>=0.27.0->-r api/requirements.txt (line 2)) (16.0)
Requirement already satisfied: MarkupSafe>=0.9.2 in ./.venv/lib/python3.14/site-packages (from Mako->alembic>=1.13.0->-r api/requirements.txt (line 5)) (3.0.3)
============================= test session starts ==============================
platform darwin -- Python 3.14.3, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/shiroguchi/.codex/worktrees/04f1/yesod-auth/api
configfile: pytest.ini (WARNING: ignoring pytest config in pyproject.toml!)
testpaths: tests
plugins: anyio-4.12.1, respx-0.22.0, hypothesis-6.151.9, asyncio-1.3.0
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=function, asyncio_default_test_loop_scope=function
collected 149 items

tests/test_accounts.py .                                                 [  0%]
tests/test_auth_logout.py .                                              [  1%]
tests/test_auth_refresh.py ..                                            [  2%]
tests/test_config.py ...                                                 [  4%]
tests/test_discord_oauth.py .............                                [ 13%]
tests/test_facebook_oauth.py ............                                [ 21%]
tests/test_github_oauth.py ..............                                [ 30%]
tests/test_health.py ....                                                [ 33%]
tests/test_linkedin_oauth.py ............                                [ 41%]
tests/test_mock_oauth.py ......                                          [ 45%]
tests/test_sessions.py ...                                               [ 47%]
tests/test_sessions_api.py .                                             [ 48%]
tests/test_slack_oauth.py ................                               [ 59%]
tests/test_twitch_oauth.py ...............                               [ 69%]
tests/test_webhook_config.py .......                                     [ 73%]
tests/test_webhook_delivery.py ...                                       [ 75%]
tests/test_webhook_emitter.py .....                                      [ 79%]
tests/test_webhook_event.py ...                                          [ 81%]
tests/test_webhook_integration.py .....                                  [ 84%]
tests/test_webhook_signer.py ......                                      [ 88%]
tests/test_webhook_worker.py ......                                      [ 92%]
tests/test_x_oauth.py ...........                                        [100%]

============================= 149 passed in 3.71s ============================== (149 passed)\n\nCloses #152