### PR TITLE
test: fix invalid JWT response contract for /api/v1/users/me

### DIFF
--- a/api/tests/test_users_me_auth.py
+++ b/api/tests/test_users_me_auth.py
@@ -1,0 +1,16 @@
+"""Users /me authentication contract tests."""
+
+import pytest
+from httpx import AsyncClient
+
+
+@pytest.mark.asyncio
+async def test_users_me_requires_valid_token(client: AsyncClient):
+    """GET /api/v1/users/me returns fixed 401 contract for invalid JWT."""
+    response = await client.get(
+        "/api/v1/users/me",
+        headers={"Authorization": "Bearer invalid.token.value"},
+    )
+
+    assert response.status_code == 401
+    assert response.json() == {"detail": "Invalid or expired token"}


### PR DESCRIPTION
## Summary
- add API test for invalid JWT on GET /api/v1/users/me
- fix response contract expectation to 401 with {"detail": "Invalid or expired token"}
- keep change minimal (test-only) to avoid functional side effects

## Verification
- python3 -m venv .venv
- . .venv/bin/activate && pip install -r api/requirements.txt
- pytest -q api/tests/test_users_me_auth.py

## Public impact
- no runtime behavior change; response contract is now explicitly guarded by test
- helps maintain OAuth/JWT integration stability for OSS consumers
