### PR TITLE
docs: getting-startedにCompose profile差分の確認手順を追加

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -40,6 +40,28 @@ docker compose --profile default up -d
 
 `default`プロファイルでは、Compose設定により`MOCK_OAUTH_ENABLED=1`がAPIサービスへ適用されます（アプリ既定値は`0`）。
 
+### Compose profile差分の確認
+
+起動前に、利用するプロファイルで有効になるサービス差分を確認できます。
+
+```bash
+# default: 最小構成（api / admin / db / redis）
+docker compose --profile default config --services
+
+# full: default + caddy
+docker compose --profile default --profile full config --services
+
+# ci: テスト用の isolated 構成
+docker compose --profile ci config --services
+```
+
+`MOCK_OAUTH_ENABLED` の適用差分は次で確認できます。
+
+```bash
+docker compose --profile default config | rg "MOCK_OAUTH_ENABLED|api:"
+docker compose --profile ci config | rg "MOCK_OAUTH_ENABLED|api-ci:"
+```
+
 ## 4. 動作確認
 
 ### ヘルスチェック


### PR DESCRIPTION
## 概要
- getting-started に Compose profile 差分確認の手順を追加
- default/full/ci の services 差分を確認するコマンドを追記
- `MOCK_OAUTH_ENABLED` の適用差分確認コマンドを追記

## テスト
- `rg "profile|MOCK_OAUTH_ENABLED" docs/getting-started.md`
- `docker compose --profile default config`

Closes #181