### PR TITLE
test: add overflow handling test for /api/v1/sessions limit

### DIFF
--- a/api/app/sessions/router.py
+++ b/api/app/sessions/router.py
@@ -3,7 +3,7 @@
 import uuid
 from datetime import UTC, datetime
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import and_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -19,6 +19,7 @@ router = APIRouter(prefix="/sessions", tags=["sessions"])
 @router.get("", response_model=SessionListResponse)
 async def list_sessions(
     current_user: User = Depends(get_current_user),
+    limit: int = Query(100, ge=1, le=1000, description="Maximum results"),
     db: AsyncSession = Depends(get_db),
 ):
     """List all active sessions for current user."""
@@ -32,6 +33,7 @@ async def list_sessions(
             )
         )
         .order_by(RefreshToken.created_at.desc())
+        .limit(limit)
     )
     sessions = result.scalars().all()
 

--- a/api/tests/test_sessions.py
+++ b/api/tests/test_sessions.py
@@ -68,3 +68,19 @@ async def test_sessions_list_with_valid_token_returns_200(client: AsyncClient):
     data = response.json()
     assert "sessions" in data
     assert "total" in data
+
+
+@pytest.mark.asyncio
+async def test_sessions_list_rejects_limit_over_maximum(client: AsyncClient):
+    """Session list should reject limit above maximum."""
+    login_response = await client.get("/api/v1/auth/mock/login")
+    assert login_response.status_code == 200
+
+    token = login_response.json()["access_token"]
+
+    response = await client.get(
+        "/api/v1/sessions?limit=1001",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert response.status_code == 422


### PR DESCRIPTION
## Summary
- add `limit` query validation (`ge=1, le=1000`) to `/api/v1/sessions`
- apply SQL limit to session listing query
- add API test for `limit=1001` returning `422`

## Verification
- `UV_CACHE_DIR=/tmp/uv-cache uv run --project api --with-requirements api/requirements.txt pytest -q api/tests/test_sessions.py`

Closes #182