### PR TITLE
docs: deploymentにロールバック時の最小確認項目を追加

### DIFF
--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -93,6 +93,29 @@ curl https://api.your-domain.com/health
 docker compose logs -f api
 ```
 
+## ロールバック時の最小確認項目
+
+デプロイ直後に不具合が発生してロールバックした場合は、次の最小確認を順に実施してください。
+
+1. 稼働コンテナがロールバック対象の構成で起動している
+   ```bash
+   docker compose ps
+   ```
+2. APIヘルスチェックが成功する
+   ```bash
+   curl -sS -o /dev/null -w "%{http_code}\n" https://api.your-domain.com/health
+   # 期待値: 200
+   ```
+3. 直近ログに致命的な起動失敗がない
+   ```bash
+   docker compose logs --since=10m api | rg -n "ERROR|Traceback|FATAL" || true
+   ```
+4. OAuthコールバックURLが意図した環境を向いている
+   - `https://api.your-domain.com/api/v1/auth/google/callback`
+   - `https://api.your-domain.com/api/v1/auth/discord/callback`
+
+障害の切り分けが必要な場合は、`docs/help/troubleshooting.md` の認証・起動時エラー項目を参照してください。
+
 ## バックアップ
 
 PostgreSQLのバックアップ：


### PR DESCRIPTION
## 概要
-  にロールバック時の最小確認項目を追加
- ヘルスチェック、ログ確認、OAuth callback URL確認の最小手順を明文化
-  への参照を追加

## テスト
- ## ロールバック時の最小確認項目
デプロイ直後に不具合が発生してロールバックした場合は、次の最小確認を順に実施してください。
1. 稼働コンテナがロールバック対象の構成で起動している
- name: yesod-auth
services:
  api:
    profiles:
      - default
      - full
    build:
      context: /Users/shiroguchi/.codex/worktrees/85ac/yesod-auth/api
      dockerfile: Dockerfile
    command:
      - sh
      - -c
      - alembic upgrade head && uvicorn app.main:app --host 0.0.0.0 --port 8000
    container_name: yesod-api
    depends_on:
      db:
        condition: service_healthy
        required: true
      valkey:
        condition: service_healthy
        required: true
    environment:
      ACCESS_TOKEN_LIFETIME_SECONDS: "900"
      CORS_ORIGINS: http://localhost:3000,http://localhost:5173
      DATABASE_URL: postgresql+asyncpg://yesod_user:yesod_password@db:5432/yesod
      FRONTEND_URL: http://localhost:3000
      MOCK_OAUTH_ENABLED: "1"
      RATE_LIMIT_PER_MINUTE: "20"
      REFRESH_TOKEN_LIFETIME_DAYS: "7"
      VALKEY_URL: redis://valkey:6379/0
    networks:
      default: null
    ports:
      - mode: ingress
        target: 8000
        published: "8000"
        protocol: tcp
    secrets:
      - source: google_client_id
        target: /run/secrets/google_client_id
      - source: google_client_secret
        target: /run/secrets/google_client_secret
      - source: discord_client_id
        target: /run/secrets/discord_client_id
      - source: discord_client_secret
        target: /run/secrets/discord_client_secret
      - source: jwt_secret
        target: /run/secrets/jwt_secret
    volumes:
      - type: bind
        source: /Users/shiroguchi/.codex/worktrees/85ac/yesod-auth/config
        target: /app/config
        read_only: true
        bind: {}
  db:
    profiles:
      - default
      - full
    build:
      context: /Users/shiroguchi/.codex/worktrees/85ac/yesod-auth/db
      dockerfile: Dockerfile
    command:
      - postgres
      - -c
      - shared_preload_libraries=pg_cron
      - -c
      - cron.database_name=yesod
    container_name: yesod-db
    environment:
      POSTGRES_DB: yesod
      POSTGRES_PASSWORD: yesod_password
      POSTGRES_USER: yesod_user
    healthcheck:
      test:
        - CMD-SHELL
        - pg_isready -U yesod_user -d yesod
      timeout: 5s
      interval: 10s
      retries: 5
    networks:
      default: null
    ports:
      - mode: ingress
        target: 5432
        published: "5432"
        protocol: tcp
    volumes:
      - type: volume
        source: postgres_data
        target: /var/lib/postgresql/data
        volume: {}
      - type: bind
        source: /Users/shiroguchi/.codex/worktrees/85ac/yesod-auth/db/init.sql
        target: /docker-entrypoint-initdb.d/init.sql
        bind: {}
  docs:
    profiles:
      - default
      - full
    command:
      - serve
      - -a
      - 0.0.0.0:8000
    container_name: yesod-docs
    image: squidfunk/mkdocs-material:latest
    networks:
      default: null
    ports:
      - mode: ingress
        target: 8000
        published: "8080"
        protocol: tcp
    volumes:
      - type: bind
        source: /Users/shiroguchi/.codex/worktrees/85ac/yesod-auth/docs
        target: /docs/docs
        read_only: true
        bind: {}
      - type: bind
        source: /Users/shiroguchi/.codex/worktrees/85ac/yesod-auth/mkdocs.yml
        target: /docs/mkdocs.yml
        read_only: true
        bind: {}
    working_dir: /docs
  valkey:
    container_name: yesod-valkey
    healthcheck:
      test:
        - CMD
        - valkey-cli
        - ping
      timeout: 5s
      interval: 10s
      retries: 5
    image: valkey/valkey:alpine
    networks:
      default: null
    ports:
      - mode: ingress
        target: 6379
        published: "6379"
        protocol: tcp
    volumes:
      - type: volume
        source: valkey_data
        target: /data
        volume: {}
networks:
  default:
    name: yesod-auth_default
volumes:
  postgres_data:
    name: yesod-auth_postgres_data
  valkey_data:
    name: yesod-auth_valkey_data
secrets:
  discord_client_id:
    name: yesod-auth_discord_client_id
    file: /Users/shiroguchi/.codex/worktrees/85ac/yesod-auth/secrets/discord_client_id.txt
  discord_client_secret:
    name: yesod-auth_discord_client_secret
    file: /Users/shiroguchi/.codex/worktrees/85ac/yesod-auth/secrets/discord_client_secret.txt
  google_client_id:
    name: yesod-auth_google_client_id
    file: /Users/shiroguchi/.codex/worktrees/85ac/yesod-auth/secrets/google_client_id.txt
  google_client_secret:
    name: yesod-auth_google_client_secret
    file: /Users/shiroguchi/.codex/worktrees/85ac/yesod-auth/secrets/google_client_secret.txt
  jwt_secret:
    name: yesod-auth_jwt_secret
    file: /Users/shiroguchi/.codex/worktrees/85ac/yesod-auth/secrets/jwt_secret.txt

## 影響
- ドキュメントのみ変更（実装コード・実行バイナリ影響なし）
- セルフホスト運用時の復旧手順の初動を短縮
