### PR TITLE
docs: users API に認証・認可エラー例を追記

### DIFF
--- a/docs/api/users.md
+++ b/docs/api/users.md
@@ -10,6 +10,29 @@
 
 ---
 
+## 認証・認可エラー例
+
+`/api/v1/users/me` 系エンドポイントは Bearer トークン必須です。  
+トークン未指定・期限切れ・不正トークン時は `401 Unauthorized` を返します。
+
+```json
+{
+  "detail": "Not authenticated"
+}
+```
+
+```json
+{
+  "detail": "Invalid or expired token"
+}
+```
+
+!!! tip "確認の目安"
+    `Authorization` ヘッダーを外して `GET /api/v1/users/me` を実行すると、
+    上記いずれかの `401` レスポンスを再現できます。
+
+---
+
 ## 現在のユーザー情報
 
 ```bash


### PR DESCRIPTION
## 概要
- docs/api/users.md に `/api/v1/users/me` 系の認証・認可エラー例を追加
- 未認証(`Not authenticated`)と不正/期限切れトークン(`Invalid or expired token`)の `401` 例を明記
- 再現手順（Authorizationヘッダーを外す）を追記

## テスト
- `cd api && pytest -q tests/test_sessions.py` (失敗: `pytest` コマンド未導入)
- `rg -n "認証・認可エラー例|Not authenticated|Invalid or expired token" docs/api/users.md`

Closes #186
