### PR TITLE
docs: 初回ヘルスチェック手順をクイックスタートへ追加

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -40,6 +40,34 @@ docker compose --profile default up -d
 
 `default`プロファイルでは、Compose設定により`MOCK_OAUTH_ENABLED=1`がAPIサービスへ適用されます（アプリ既定値は`0`）。
 
+## 3.5 初回ヘルスチェック（推奨）
+
+初回起動時は、次の3点を順に確認すると原因切り分けがしやすくなります。
+
+### 1. コンテナ状態を確認
+
+```bash
+docker compose --profile default ps
+```
+
+`api` と `admin` が `Up` になっていることを確認します。
+
+### 2. APIログを確認
+
+```bash
+docker compose --profile default logs --tail=100 api
+```
+
+エラーで停止していないか、ポート `8000` で待受を開始しているかを確認します。
+
+### 3. HTTPヘルスエンドポイントを確認
+
+```bash
+curl -i http://localhost:8000/health
+```
+
+`HTTP/1.1 200 OK`（または `HTTP/2 200`）と `{"status":"healthy"}` が返れば初回ヘルスチェックは完了です。
+
 ## 4. 動作確認
 
 ### ヘルスチェック


### PR DESCRIPTION
## 概要
- `docs/getting-started.md` に初回起動向けのヘルスチェック手順を追加
- `docker compose ps` / `logs` / `curl -i /health` の3段階で確認できるよう整理

## 変更理由
- 初回セットアップ時の切り分けを短時間で行えるようにし、OAuth導入時の初期検証を容易化するため

## 検証
- `docker compose --profile default config`

## 公開時の影響
- ドキュメントのみ更新（実行コード・設定値の挙動変更なし）
