### PR TITLE
docs: api/users 更新系エンドポイントの前提条件を追記 (#189)

### DIFF
--- a/docs/api/users.md
+++ b/docs/api/users.md
@@ -10,6 +10,21 @@
 
 ---
 
+## 更新系エンドポイントの前提条件
+
+`PATCH /api/v1/users/me` と `DELETE /api/v1/users/me` を呼び出す前に、次を満たしてください。
+
+1. OAuthログイン後に取得した有効なアクセストークンを `Authorization: Bearer <access_token>` で付与する
+2. `PATCH` のリクエストボディは `Content-Type: application/json` で送る
+3. `PATCH` で更新できる項目は `display_name`（最大255文字）と `avatar_url`（最大500文字）のみ
+4. `PATCH` は指定した項目だけ更新され、`null` を送るとその項目をクリアする
+5. `DELETE` 実行後のアカウントはソフトデリート状態になり、同一トークンでの継続利用はできない
+
+!!! tip "トークン未取得時"
+    先に [認証API](./auth.md) の OAuth フローでアクセストークンを取得してください。
+
+---
+
 ## 現在のユーザー情報
 
 ```bash


### PR DESCRIPTION
## 概要\n- docs/api/users.md に更新系エンドポイント（PATCH/DELETE）の前提条件を追加\n- 入力制約（display_name/avatar_url の最大長、null でクリア可能）を明記\n- OAuthフロー未実施時の導線として docs/api/auth.md への参照を追加\n\n## テスト\n- rg "update|前提" docs/api/users.md\n- docker compose --profile default config\n\nCloses #189