### PR TITLE
docs: webhook署名検証失敗時の監査ログ項目を明文化

### DIFF
--- a/docs/api/auth.md
+++ b/docs/api/auth.md
@@ -123,3 +123,9 @@ GET /api/v1/auth/mock/login?user=alice&provider=google
 ```bash
 GET /api/v1/auth/mock/users
 ```
+
+---
+
+## 関連運用ドキュメント
+
+- [Webhook設定ガイド: 署名検証失敗時の監査ログ項目](../guides/webhooks.md#署名検証失敗時の監査ログ項目)

--- a/docs/guides/webhooks.md
+++ b/docs/guides/webhooks.md
@@ -135,6 +135,35 @@ function verifySignature(payload, secret, timestamp, signature) {
 }
 ```
 
+### 署名検証失敗時の監査ログ項目
+
+署名検証に失敗した場合は、再現性のある調査のために最低限以下を記録してください。
+
+| 項目 | 例 | 用途 |
+|------|----|------|
+| `event_type` | `webhook.signature_verification_failed` | 監査イベント種別の統一 |
+| `verified_at` | `2026-03-05T08:55:12Z` | 発生時刻の特定 |
+| `webhook_id` | `my-service` | 対象エンドポイントの特定 |
+| `x_webhook_event` | `user.login` | 通知イベント種別の特定 |
+| `x_webhook_timestamp` | `1730787312` | リプレイ判定と時刻ずれ調査 |
+| `signature_prefix` | `sha256` | 署名方式の判定 |
+| `payload_sha256` | `8d1f...` | 本文改ざん有無の比較用（本文は生保存しない） |
+| `failure_reason` | `hmac_mismatch` | 失敗理由の分類 |
+| `source_ip` | `203.0.113.10` | 送信元調査 |
+| `request_id` | `req-7f9d...` | アプリログとの突合 |
+
+`failure_reason` は次のように固定値化しておくと運用しやすくなります。
+
+- `missing_signature_header`
+- `missing_timestamp_header`
+- `timestamp_skew`
+- `invalid_signature_format`
+- `hmac_mismatch`
+- `replay_detected`
+
+!!! warning "記録しない情報"
+    共有シークレット、平文の署名値、受信ペイロード全文（PII を含む可能性）は監査ログへ保存しないでください。
+
 ## リトライ動作
 
 配信失敗時は指数バックオフでリトライします：


### PR DESCRIPTION
## 概要\n- webhook署名検証失敗時に記録すべき監査ログ項目を docs/guides/webhooks.md に追加\n- failure_reason の推奨固定値を追加し、運用で集計しやすい形式を明記\n- docs/api/auth.md から関連運用ドキュメントへのリンクを追加\n\n## テスト\n- docker compose --profile ci run --rm api-ci pytest -q tests/test_webhook_signer.py\n\n## 公開時の影響\n- ドキュメント変更のみ（ランタイム挙動変更なし）\n- webhook受信側の監査ログ設計が標準化され、セルフホスト運用時の障害調査を容易化\n\nCloses #190