### PR TITLE
docs: add webhook signature failure investigation flow

### DIFF
--- a/docs/guides/webhooks.md
+++ b/docs/guides/webhooks.md
@@ -135,6 +135,29 @@ function verifySignature(payload, secret, timestamp, signature) {
 }
 ```
 
+## 署名検証失敗時の調査順
+
+`X-Webhook-Signature` が一致しない場合は、以下の順で原因を切り分けます。
+
+1. 受信側が参照しているシークレットと `config/webhooks.yaml` のシークレット参照先が一致しているか確認する。
+2. `X-Webhook-Timestamp` と生のリクエストボディ（JSON再シリアライズ前）で検証しているか確認する。
+3. 受信側の実装で `timestamp + "." + raw_body` の形式を使っているか確認する。
+4. API 側で配信失敗ログを確認し、対象 endpoint とイベントを特定する。
+5. 必要に応じて設定を再読み込みし、同じイベントを再送して再検証する。
+
+```bash
+# API側のWebhook失敗ログを確認
+docker compose logs api --since=30m | rg "webhook|signature|delivery"
+
+# 現在のWebhook設定を確認
+curl http://localhost:8000/api/v1/admin/webhooks/endpoints
+
+# 設定変更後の再読み込み
+curl -X POST http://localhost:8000/api/v1/admin/webhooks/reload
+```
+
+詳細な障害対応は [トラブルシューティング](../help/troubleshooting.md#署名検証に失敗する) も参照してください。
+
 ## リトライ動作
 
 配信失敗時は指数バックオフでリトライします：


### PR DESCRIPTION
## Summary
- docs/guides/webhooks.md に署名検証失敗時の調査順を追加
- APIログ確認/設定確認/リロードの実行コマンドを追記
- troubleshooting セクションへの参照リンクを追加

## Test
- rg "署名|signature" docs/guides/webhooks.md
- cd api && .venv/bin/pytest -q

Closes #218