### PR TITLE
Improve startup warning when CORS_ORIGINS is missing

### DIFF
--- a/api/app/config.py
+++ b/api/app/config.py
@@ -3,6 +3,8 @@
 import os
 from functools import lru_cache
 
+DEFAULT_CORS_ORIGINS = "http://localhost:3000,http://localhost:5173"
+
 
 def read_secret(name: str, default: str = "") -> str:
     """Read secret from Docker secrets or environment variable."""
@@ -11,6 +13,17 @@ def read_secret(name: str, default: str = "") -> str:
         with open(secret_path) as f:
             return f.read().strip()
     return os.getenv(name.upper(), default)
+
+
+def resolve_cors_origins(raw_value: str | None) -> tuple[list[str], bool]:
+    """Resolve CORS origins and whether default values are in use."""
+    if raw_value is None or not raw_value.strip():
+        return DEFAULT_CORS_ORIGINS.split(","), True
+
+    origins = [origin.strip() for origin in raw_value.split(",") if origin.strip()]
+    if not origins:
+        return DEFAULT_CORS_ORIGINS.split(","), True
+    return origins, False
 
 
 class Settings:
@@ -77,9 +90,9 @@ class Settings:
     FRONTEND_URL: str = os.getenv("FRONTEND_URL", "http://localhost:3000")
 
     # CORS
-    CORS_ORIGINS: list[str] = os.getenv(
-        "CORS_ORIGINS", "http://localhost:3000,http://localhost:5173"
-    ).split(",")
+    _cors_origins, _cors_origins_using_default = resolve_cors_origins(os.getenv("CORS_ORIGINS"))
+    CORS_ORIGINS: list[str] = _cors_origins
+    CORS_ORIGINS_USING_DEFAULT: bool = _cors_origins_using_default
 
 
 @lru_cache

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -1,5 +1,6 @@
 """YESOD Auth - Main application."""
 
+import logging
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
@@ -21,6 +22,7 @@ from app.webhooks.router import router as webhooks_router
 from app.webhooks.worker import WebhookWorker
 
 settings = get_settings()
+logger = logging.getLogger(__name__)
 
 # Global webhook worker instance
 _webhook_worker: WebhookWorker | None = None
@@ -30,6 +32,12 @@ _webhook_worker: WebhookWorker | None = None
 async def lifespan(app: FastAPI):
     """Application lifespan - startup and shutdown."""
     global _webhook_worker
+
+    if settings.CORS_ORIGINS_USING_DEFAULT:
+        logger.warning(
+            "CORS_ORIGINS is not configured. Using development defaults: %s",
+            ",".join(settings.CORS_ORIGINS),
+        )
 
     # Load webhook configuration
     WebhookConfigLoader.load()

--- a/api/tests/test_config.py
+++ b/api/tests/test_config.py
@@ -2,7 +2,11 @@
 
 from unittest.mock import mock_open, patch
 
-from app.config import read_secret
+from app.config import (
+    DEFAULT_CORS_ORIGINS,
+    read_secret,
+    resolve_cors_origins,
+)
 
 
 def test_read_secret_prefers_secret_file_over_env(monkeypatch):
@@ -29,3 +33,24 @@ def test_read_secret_falls_back_to_default_when_secret_and_env_missing(monkeypat
 
     with patch("app.config.os.path.exists", return_value=False):
         assert read_secret("jwt_secret", "default-value") == "default-value"
+
+
+def test_resolve_cors_origins_uses_default_when_unset():
+    origins, using_default = resolve_cors_origins(None)
+
+    assert origins == DEFAULT_CORS_ORIGINS.split(",")
+    assert using_default is True
+
+
+def test_resolve_cors_origins_uses_default_when_blank():
+    origins, using_default = resolve_cors_origins(" , ")
+
+    assert origins == DEFAULT_CORS_ORIGINS.split(",")
+    assert using_default is True
+
+
+def test_resolve_cors_origins_uses_env_value_when_set():
+    origins, using_default = resolve_cors_origins("https://example.com, https://admin.example.com")
+
+    assert origins == ["https://example.com", "https://admin.example.com"]
+    assert using_default is False

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -203,6 +203,8 @@ docker compose up -d --build
 | `ACCESS_TOKEN_LIFETIME_SECONDS` | アクセストークン有効期限 | `900` |
 | `REFRESH_TOKEN_LIFETIME_DAYS` | リフレッシュトークン有効期限 | `7` |
 
+`CORS_ORIGINS` が未設定または空文字の場合、API起動時に警告ログを出し、開発用デフォルト値（`http://localhost:3000,http://localhost:5173`）で起動します。
+
 ### 環境変数・Secrets の優先順位
 
 設定元が複数ある場合は、以下の優先順位で値が決まります。


### PR DESCRIPTION
## Summary
- add `resolve_cors_origins` helper and explicit default-detection flag in settings
- emit startup warning when `CORS_ORIGINS` is unset/blank and defaults are used
- document the behavior in installation guide and add config tests

## Testing
- `/Users/shiroguchi/Documents/Github/mashirou1234/yesod-auth/.venv-codex/bin/pytest tests/test_config.py`

Closes #194
