### PR TITLE
docs: add minimum self-host monitoring checklist to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,17 @@ Password: (secrets/admin_password.txt の内容)
 
 ## Monitoring
 
+### セルフホスト時の最小監視項目
+
+運用開始直後は、まず次の4項目を監視対象に設定してください。
+
+| 項目 | 確認方法 | 異常の目安 |
+|------|----------|------------|
+| APIヘルス | `curl -sS -o /dev/null -w "%{http_code}\n" http://localhost:8000/health` | `200` 以外が連続 |
+| APIエラー率 | `docker logs --since 5m yesod-api \| rg " 5[0-9]{2} "` | 5分窓で5xxが継続発生 |
+| DB接続健全性 | `docker logs --since 5m yesod-db \| rg -i "error|fatal|panic"` | 接続エラー/再起動ループ |
+| OAuth失敗兆候 | `docker logs --since 10m yesod-api \| rg "invalid_client|Invalid state|OAuth callback failed"` | 同種エラーが短時間に複数回 |
+
 ### 運用時ログ確認ポイント（最小）
 
 障害切り分け時は、次の順で 1〜3 分以内に確認すると再現性が高いです。


### PR DESCRIPTION
## Summary\n- README の Monitoring セクションに、セルフホスト向けの最小監視項目を追加\n- API ヘルス/5xx/DB 接続/OAuth 失敗兆候の4観点を確認方法と異常目安つきで整理\n- 既存の運用時ログ確認ポイントを補完し、deployment/troubleshooting の記載と整合\n\n## Test\n- rg "monitor|運用" README.md\n- cd api && . .venv/bin/activate && pytest -q\n\nCloses #216