### PR TITLE
docs: sync codex-orch guidance and PR CI trigger

### DIFF
--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -1,7 +1,9 @@
-# required check と整合するよう、全ブランチ push で CI を実行する。
+# push(main/master) と pull_request を有効化。
 # 非Rustリポジトリで誤配布された場合は、Cargo.toml 未検出時に各ステップを成功スキップする。
 when:
+  - event: [pull_request]
   - event: [push]
+    branch: [main, master]
 
 steps:
   - name: fmt
@@ -106,7 +108,8 @@ steps:
     image: codeberg.org/l-x/woodpecker-ntfy
     when:
       - event: [push]
-      - status: [failure]
+        branch: [main, master]
+        status: [failure]
     settings:
       url:
         from_secret: ntfy_url

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,5 +2,6 @@
 
 - 日本語で簡潔に報告する
 - まず `artifacts/` を確認して前回結果を把握する
-- 必ず 1 run 1 issue を守る
+- `scripts/orch.sh` を使う自動レーンでは必ず 1 run 1 issue を守る
+- 手動レーン（Power User の直接対応）は一括処理可。ただし `codex:queue` 系ラベル遷移の整合は維持する
 - 失敗時は issue コメントと `codex:blocked` を付与する


### PR DESCRIPTION
## Summary
- sync codex-orch lane guidance from Neunzehn v1.19
- clarify that one-run-one-issue applies only to automated runs via `scripts/orch.sh`
- document manual lane batching requirements for codex label transitions
- align Woodpecker triggers with protected-branch PR required checks

## Impact
- docs update for AGENTS guidance
- CI trigger update so pull requests emit the required `ci/woodpecker/pr/woodpecker` status
- no application runtime changes
