### PR TITLE
[Bench-80][58] getting-startedにcurlベース最小スモーク手順を追加

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -49,9 +49,26 @@ curl http://localhost:8000/health
 # {"status":"healthy"}
 ```
 
-### APIドキュメント
+### curlだけで行う最小スモーク手順（GUI不要）
 
-ブラウザで http://localhost:8000/docs を開きます。
+初期導入後は、次の3コマンドだけでAPIの疎通を確認できます。
+
+```bash
+# 1) APIの生存確認（200 + healthy）
+curl -fsS http://localhost:8000/health
+
+# 2) APIドキュメント到達確認（200）
+curl -fsS -o /dev/null -w '%{http_code}\n' http://localhost:8000/docs
+
+# 3) Mock OAuth開始エンドポイントの到達確認（302）
+curl -fsS -o /dev/null -w '%{http_code}\n' \
+  "http://localhost:8000/api/v1/auth/mock/login?user=alice&provider=google"
+```
+
+期待値:
+- 1) `{"status":"healthy"}`
+- 2) `200`
+- 3) `302`
 
 ### Mock OAuthでテスト
 


### PR DESCRIPTION
## 概要
- `docs/getting-started.md` に GUI不要の curl 最小スモーク手順を追加
- `/health`・`/docs`・`/api/v1/auth/mock/login` の期待値を明記
- 変更対象を getting-started の1成果に限定

## テスト
- `cd api && . .venv/bin/activate && pytest -q tests/test_mock_oauth.py`
- `cd api && . .venv/bin/activate && pytest -q`

Closes #249
