### PR TITLE
docs: GitHub OAuth organization制限時の挙動を明記

### DIFF
--- a/docs/api/auth.md
+++ b/docs/api/auth.md
@@ -6,7 +6,7 @@
 |---------|------|------|
 | GET | `/api/v1/auth/google` | Google OAuth開始 |
 | GET | `/api/v1/auth/google/callback` | Googleコールバック |
-| GET | `/api/v1/auth/github` | GitHub OAuth開始 |
+| GET | `/api/v1/auth/github` | GitHub OAuth開始（organization所属の制限判定は未実装） |
 | GET | `/api/v1/auth/github/callback` | GitHubコールバック |
 | GET | `/api/v1/auth/discord` | Discord OAuth開始 |
 | GET | `/api/v1/auth/discord/callback` | Discordコールバック |

--- a/docs/guides/oauth/github.md
+++ b/docs/guides/oauth/github.md
@@ -27,6 +27,15 @@ echo "your-client-secret" > secrets/github_client_secret.txt
     YESOD Authは`read:user`と`user:email`スコープを使用します。
     これにより、ユーザーの基本情報とメールアドレスを取得できます。
 
+## organization制限時の挙動
+
+- 現在のGitHub OAuth実装は`read:user user:email`のみを要求し、organization所属チェックは行いません。
+- そのため、organization制限を有効化したい場合は、アプリ側で追加実装が必要です。
+- 追加実装の例:
+  - 認可スコープに`read:org`を追加
+  - コールバック後にGitHub APIで所属organizationを検証
+  - 未所属ユーザーはログイン完了前に拒否
+
 ## 技術仕様
 
 | 項目 | 値 |

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -38,6 +38,11 @@ YESOD AuthはGoogle OAuthでPKCEを自動的に使用します。
 必須なのは`jwt_secret`と、実際に有効化して使うOAuthプロバイダーの`*_client_id`/`*_client_secret`だけです。
 たとえばGoogleのみ使う最小構成ならGoogle分だけ、複数プロバイダー運用なら有効化した各プロバイダー分を追加してください。
 
+### GitHubログインをorganizationメンバーだけに制限できる？
+
+現状のYESOD AuthはGitHub OAuthでorganization所属チェックを行いません。
+organization制限が必要な場合は、`read:org`スコープとコールバック後の所属検証を追加実装してください。
+
 ---
 
 ## 開発


### PR DESCRIPTION
## 概要\n- GitHub OAuthガイドに organization制限時の現状挙動（未実装）を追記\n- organization制限が必要な場合の実装方針（read:org + コールバック後検証）を追記\n- API/FAQの関連記述を更新してドキュメント間の整合を確保\n\n## テスト\n- rg "organization|org" docs/guides/oauth/github.md\n- docker compose --profile default config\n\nCloses #200