### PR TITLE
chore: ignore local generated artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ logs/
 
 # Test
 .pytest_cache/
+.hypothesis/
 .coverage
 htmlcov/
 
@@ -39,3 +40,4 @@ htmlcov/
 config/webhooks.yaml
 
 .codex-orch/
+/artifacts/


### PR DESCRIPTION
## Summary
- ignore Hypothesis-generated cache files
- ignore repository-local Codex orchestration artifacts

## Background
- `api/.hypothesis/` is generated by Hypothesis during local test runs and should not be committed
- `artifacts/` is used for local run inspection in this repository workflow, but its generated files are operational outputs rather than source files

## Key Changes
- add `.hypothesis/` to `.gitignore`
- add `/artifacts/` to `.gitignore`

## Impact & Risk
- affects Git tracking only
- no runtime, application, CI, or test behavior changes
- existing tracked files are not altered

## Testing
- not run (gitignore-only change)
