### PR TITLE
fix: セッション revoke 後の refresh token 再利用を防止

### DIFF
--- a/api/app/auth/tokens.py
+++ b/api/app/auth/tokens.py
@@ -88,7 +88,7 @@ async def validate_refresh_token(
         select(RefreshToken).where(
             and_(
                 RefreshToken.token_hash == token_hash,
-                not RefreshToken.is_revoked,
+                RefreshToken.is_revoked.is_(False),
                 RefreshToken.expires_at > datetime.now(UTC),
             )
         )
@@ -138,7 +138,7 @@ async def revoke_all_user_tokens(db: AsyncSession, user_id: uuid.UUID) -> int:
         select(RefreshToken).where(
             and_(
                 RefreshToken.user_id == user_id,
-                not RefreshToken.is_revoked,
+                RefreshToken.is_revoked.is_(False),
             )
         )
     )

--- a/api/app/sessions/router.py
+++ b/api/app/sessions/router.py
@@ -28,7 +28,7 @@ async def list_sessions(
         .where(
             and_(
                 RefreshToken.user_id == current_user.id,
-                not RefreshToken.is_revoked,
+                RefreshToken.is_revoked.is_(False),
                 RefreshToken.expires_at > datetime.now(UTC),
             )
         )
@@ -65,7 +65,7 @@ async def revoke_session(
             and_(
                 RefreshToken.id == session_id,
                 RefreshToken.user_id == current_user.id,
-                not RefreshToken.is_revoked,
+                RefreshToken.is_revoked.is_(False),
             )
         )
     )
@@ -93,7 +93,7 @@ async def revoke_all_sessions(
         select(RefreshToken).where(
             and_(
                 RefreshToken.user_id == current_user.id,
-                not RefreshToken.is_revoked,
+                RefreshToken.is_revoked.is_(False),
             )
         )
     )

--- a/api/tests/test_auth_refresh.py
+++ b/api/tests/test_auth_refresh.py
@@ -7,7 +7,7 @@ from httpx import AsyncClient
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.auth.tokens import create_refresh_token, hash_refresh_token
+from app.auth.tokens import create_access_token, create_refresh_token, hash_refresh_token
 from app.main import app
 from app.models.refresh_token import RefreshToken
 from app.models.user import User
@@ -60,3 +60,39 @@ async def test_refresh_rejects_expired_token(client: AsyncClient, db_session: As
 
     assert response.status_code == 401
     assert response.json() == {"detail": "Invalid or expired refresh token"}
+
+
+@pytest.mark.asyncio
+async def test_refresh_rejects_revoked_session_token(
+    client: AsyncClient, db_session: AsyncSession
+):
+    """Revoked session refresh token should not be reusable."""
+    user = User()
+    db_session.add(user)
+    await db_session.commit()
+    await db_session.refresh(user)
+
+    refresh_token = await create_refresh_token(db_session, user.id)
+    access_token = create_access_token(str(user.id), "revoke-test@example.com")
+    auth_header = {"Authorization": f"Bearer {access_token}"}
+
+    token_record = await db_session.scalar(
+        select(RefreshToken).where(
+            RefreshToken.token_hash == hash_refresh_token(refresh_token)
+        )
+    )
+    assert token_record is not None
+    session_id = token_record.id
+
+    revoke_response = await client.delete(
+        f"/api/v1/sessions/{session_id}",
+        headers=auth_header,
+    )
+    assert revoke_response.status_code == 200
+
+    refresh_response = await client.post(
+        "/api/v1/auth/refresh",
+        json={"refresh_token": refresh_token},
+    )
+    assert refresh_response.status_code == 401
+    assert refresh_response.json() == {"detail": "Invalid or expired refresh token"}


### PR DESCRIPTION
## 概要
- `RefreshToken.is_revoked` の判定を SQLAlchemy の `is_(False)` へ修正
- セッション一覧/個別revoke/全revoke と refresh token 検証の共通条件を修正
- セッション revoke 後に同一 refresh token で `/auth/refresh` が `401` になる回帰テストを追加

## テスト
- `cd api && ../.venv/bin/python -m pytest -q tests/test_auth_refresh.py tests/test_sessions.py tests/test_sessions_api.py`

Closes #203
