### PR TITLE
docs: add mock-to-real OAuth switch checklist

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -160,6 +160,28 @@ curl -fsS -o /dev/null -w '%{http_code}\n' \
 curl "http://localhost:8000/api/v1/auth/mock/login?user=alice&provider=google"
 ```
 
+### Mock OAuthから実OAuthへ切り替える最小チェック
+
+Mock 検証が完了したら、実 OAuth へ切り替える前に次の3点だけ確認します。
+
+1. モード切替: `MOCK_OAUTH_ENABLED=0`（または未設定）になっている
+2. 秘密情報: 利用する provider の `client_id` / `client_secret` を `secrets/*.txt` に設定済み
+3. redirect URI: provider 管理画面の callback URL が `https://<api-domain>/api/v1/auth/<provider>/callback` と一致している
+
+切替後の最小確認コマンド:
+
+```bash
+# 1) APIの生存確認
+curl -fsS http://localhost:8000/health
+
+# 2) 実OAuth開始導線の到達確認（302 を期待）
+curl -fsS -o /dev/null -w '%{http_code}\n' \
+  "http://localhost:8000/api/v1/auth/google"
+```
+
+`invalid_client` や `redirect_uri_mismatch` が出る場合は
+[トラブルシューティング](help/troubleshooting.md) を参照してください。
+
 ### セッション失効時の再ログイン手順
 
 アクセストークン失効で `401 Unauthorized` が返る場合は、次の順序で復旧します。


### PR DESCRIPTION
## 概要
- `docs/getting-started.md` に「Mock OAuthから実OAuthへ切り替える最小チェック」を追加
- チェック項目をモード/秘密情報/redirect URI の3点に限定
- 切替後の最小確認コマンド（health + `/api/v1/auth/google`）と troubleshooting 導線を追加

## テスト
- `rg -n "MOCK_OAUTH_ENABLED|redirect URI|troubleshooting" docs/getting-started.md`
- `rg -n "MOCK_OAUTH_ENABLED|default|full|ci" docs/installation.md docs/getting-started.md`
- `cd api && /Users/shiroguchi/Documents/Github/mashirou1234/yesod-auth/api/.venv/bin/python -m pytest -q`

Closes #266