### PR TITLE
docs: LinkedIn OAuth 必要scope一覧を追記 (#206)

### DIFF
--- a/docs/guides/oauth/linkedin.md
+++ b/docs/guides/oauth/linkedin.md
@@ -42,6 +42,20 @@ echo "your-client-secret" > secrets/linkedin_client_secret.txt
     YESOD Authは`openid`、`profile`、`email`スコープを要求し、
     ユーザー情報は`/v2/userinfo`エンドポイントから取得します。
 
+## 6. 必要権限（scope）一覧
+
+YESOD Auth の LinkedIn ログインで要求する最小 scope は次の 3 つです。
+
+| scope | 用途 | 未付与時の主な症状 |
+|------|------|------------------|
+| `openid` | OpenID Connect の ID トークン取得 | コールバック後に認証が完了しない |
+| `profile` | 表示名などの基本プロフィール取得 | `display_name` が空、またはプロフィール取得に失敗 |
+| `email` | メールアドレス取得 | メール未取得でユーザー作成/照合に失敗 |
+
+!!! warning "scopeは削らない"
+    `openid profile email` の 3 つはセットで必要です。
+    一部のみを要求すると、`/v2/userinfo` から必要情報を取得できずログイン失敗の原因になります。
+
 ## 技術仕様
 
 | 項目 | 値 |


### PR DESCRIPTION
## 概要
- `docs/guides/oauth/linkedin.md` に LinkedIn OAuth の必須 scope 一覧を追加
- 各 scope の用途と、未付与時に起きる症状を明記
- `openid profile email` をセットで要求すべき注意点を追記

## テスト
- `rg "permission|scope" docs/guides/oauth/linkedin.md`
- `docker compose --profile default config >/dev/null`

## 公開時の影響
- ドキュメント変更のみ（アプリ挙動の変更なし）
- OAuth 導入時の設定漏れを事前に防止しやすくなる

Closes #206
