### PR TITLE
docs: add minimal mock oauth production cutover checklist

### DIFF
--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -57,6 +57,17 @@ organization制限が必要な場合は、`read:org`スコープとコールバ�
 開発・テスト時に、実際のOAuthプロバイダーなしで認証フローをテストできる機能です。
 `MOCK_OAUTH_ENABLED=1`で有効化できます。
 
+### Mock OAuthから本番OAuthへ切り替える最小確認は？
+
+本番切替時は次の3項目だけ先に確認してください。
+
+1. `MOCK_OAUTH_ENABLED=0` になっていること（アプリ既定値は `0`。開発用 `default`/`ci` プロファイルでは Compose 側で `1` に上書きされるため、本番運用値を再確認）
+2. 利用するOAuthプロバイダーの `*_client_id` / `*_client_secret` が本番値で設定され、不要な開発用値が混在していないこと
+3. provider管理画面の callback URL と `GET /api/v1/auth/{provider}/callback` の実運用URLが一致していること
+
+切り分け手順は [トラブルシューティング: state mismatch 診断フロー](./troubleshooting.md#state-mismatch-flow) と [トラブルシューティング: 401 Unauthorized / invalid_client](./troubleshooting.md#401-unauthorized--invalid_client) を参照してください。  
+前提の設定差分は [インストール: profile別の環境変数優先順位](../installation.md#profile別の環境変数優先順位) を参照してください。
+
 ### ローカルでテストするには？
 
 ```bash


### PR DESCRIPTION
## 概要
- `docs/help/faq.md` に Mock OAuth から本番OAuthへの最小確認チェック（3項目）を追加
- `MOCK_OAUTH_ENABLED` の開発/本番差分（アプリ既定値と profile 上書き）を明記
- `installation` と `troubleshooting` への参照導線を追加

## テスト
- `bash -lc 'set -euo pipefail; test $(sed -n "60,69p" docs/help/faq.md | rg -n "^1\\.|^2\\.|^3\\." | wc -l | tr -d " ") -ge 3; echo "faq_checklist_count_ok"'`
- `bash -lc 'set -euo pipefail; rg -n "MOCK_OAUTH_ENABLED.*既定値|MOCK_OAUTH_ENABLED" docs/installation.md >/dev/null; rg -n "state-mismatch-flow|invalid_client" docs/help/troubleshooting.md >/dev/null; echo "cross_doc_reference_ok"'`

## 補足
- `mkdocs` / `pytest` はこの実行環境では未導入のため未実行
