### PR TITLE
docs: FAQに認証失敗の一次分類表を追加

### DIFF
--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -48,6 +48,19 @@ YESOD AuthはGoogle OAuthでPKCEを自動的に使用します。
 現状のYESOD AuthはGitHub OAuthでorganization所属チェックを行いません。
 organization制限が必要な場合は、`read:org`スコープとコールバック後の所属検証を追加実装してください。
 
+### 認証失敗時の一次分類は？
+
+まずは HTTP ステータスと代表メッセージで次の4分類に分けると切り分けが速くなります。
+
+| 一次分類 | 典型シグナル | 主な原因 | 最初に見る場所 |
+| --- | --- | --- | --- |
+| 入力不正（422） | `Field required` / `Input should be a valid string` | `refresh_token` の欠落・型不正 | [`認証API: refresh失敗時エラー分類`](../api/auth.md#refresh失敗時エラー分類) |
+| 認証失敗（401） | `Not authenticated` / `Could not validate credentials` | access/refresh token の期限切れ・失効・改ざん | [`トラブルシューティング: 認証エラー`](./troubleshooting.md#認証エラー) |
+| state不整合（400） | `Invalid or expired state` | callback 二重実行、Valkey不安定、環境不一致 | [`トラブルシューティング: state mismatch 診断フロー`](./troubleshooting.md#state-mismatch-flow) |
+| レート制限（429） | `Rate limit exceeded` / `Too Many Requests` | 短時間の連続アクセス、制限値過小 | [`トラブルシューティング: 429 Too Many Requests`](./troubleshooting.md#auth-rate-limit-429) |
+
+運用メモとして、分類時は「発生時刻」「対象エンドポイント」「利用プロバイダー（mock/google/github等）」をセットで記録すると再現調査が容易です。
+
 ---
 
 ## 開発


### PR DESCRIPTION
## 概要\n- docs/help/faq.md の認証セクションに、認証失敗時の一次分類表を追加\n- 422/401/400(state)/429 の4分類で、初動参照先への導線を明記\n- 発生時刻・対象エンドポイント・利用プロバイダーの記録ポイントを追記\n\n## テスト\n- # FAQ
YESOD Authは、OAuth 2.0認証を簡単に実装するためのオープンソース認証基盤です。
## 認証
認証レート制限の切り分け手順を [トラブルシューティング: 429 Too Many Requests](./troubleshooting.md#auth-rate-limit-429) にまとめています。  
### 認証失敗時の一次分類は？
| 入力不正（422） | `Field required` / `Input should be a valid string` | `refresh_token` の欠落・型不正 | [`認証API: refresh失敗時エラー分類`](../api/auth.md#refresh失敗時エラー分類) |
| 認証失敗（401） | `Not authenticated` / `Could not validate credentials` | access/refresh token の期限切れ・失効・改ざん | [`トラブルシューティング: 認証エラー`](./troubleshooting.md#認証エラー) |
開発・テスト時に、実際のOAuthプロバイダーなしで認証フローをテストできる機能です。\n- ============================= test session starts ==============================
platform darwin -- Python 3.14.3, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/shiroguchi/.codex/worktrees/ef45/yesod-auth/api
configfile: pytest.ini (WARNING: ignoring pytest config in pyproject.toml!)
plugins: anyio-4.12.1, respx-0.22.0, hypothesis-6.151.9, asyncio-1.3.0
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=function, asyncio_default_test_loop_scope=function
collected 3 items

tests/test_auth_refresh.py ...                                           [100%]

============================== 3 passed in 0.55s ===============================\n\nCloses #210