### PR TITLE
[Bench-80][05] generate-types failure recovery guidance

### DIFF
--- a/scripts/generate-types.sh
+++ b/scripts/generate-types.sh
@@ -10,18 +10,59 @@
 # Example:
 #   ./scripts/generate-types.sh ./frontend/src/types
 
-set -e
+set -euo pipefail
 
 OUTPUT_DIR="${1:-./generated}"
 API_URL="${API_URL:-http://localhost:8000}"
 OPENAPI_URL="${API_URL}/openapi.json"
+DOC_REF="docs/api/auth.md"
+
+print_help_hint() {
+    echo "   次の確認手順: ${DOC_REF} を参照してください。"
+}
+
+require_cmd() {
+    local cmd="$1"
+    if ! command -v "${cmd}" >/dev/null 2>&1; then
+        echo "❌ Error: '${cmd}' コマンドが見つかりません"
+        echo "   復旧手順: 必要コマンドをインストール後に再実行してください。"
+        print_help_hint
+        exit 1
+    fi
+}
+
+require_cmd curl
+require_cmd npx
 
 echo "🔍 Fetching OpenAPI schema from ${OPENAPI_URL}..."
 
-# Check if API is running
-if ! curl -s "${OPENAPI_URL}" > /dev/null 2>&1; then
+SCHEMA_TMP="$(mktemp)"
+GEN_LOG_TMP="$(mktemp)"
+cleanup() {
+    rm -f "${SCHEMA_TMP}" "${GEN_LOG_TMP}"
+}
+trap cleanup EXIT
+
+HTTP_STATUS="$(curl -sS -o "${SCHEMA_TMP}" -w '%{http_code}' "${OPENAPI_URL}" || true)"
+
+if [ "${HTTP_STATUS}" = "000" ]; then
     echo "❌ Error: Cannot reach ${OPENAPI_URL}"
-    echo "   Make sure the API is running: docker compose up -d api"
+    echo "   復旧手順: API を起動してから再実行してください (例: docker compose up -d api)"
+    print_help_hint
+    exit 1
+fi
+
+if [ "${HTTP_STATUS}" -ne 200 ]; then
+    echo "❌ Error: OpenAPI endpoint returned HTTP ${HTTP_STATUS}"
+    echo "   復旧手順: API のログと /openapi.json 応答を確認してください。"
+    print_help_hint
+    exit 1
+fi
+
+if [ ! -s "${SCHEMA_TMP}" ] || ! grep -Eq '"(openapi|swagger)"' "${SCHEMA_TMP}"; then
+    echo "❌ Error: Invalid OpenAPI schema payload from ${OPENAPI_URL}"
+    echo "   復旧手順: /openapi.json が JSON Schema を返すか確認してください。"
+    print_help_hint
     exit 1
 fi
 
@@ -30,7 +71,18 @@ mkdir -p "${OUTPUT_DIR}"
 
 # Generate types
 echo "📝 Generating TypeScript types..."
-npx openapi-typescript "${OPENAPI_URL}" -o "${OUTPUT_DIR}/api.d.ts"
+if ! npx openapi-typescript "${OPENAPI_URL}" -o "${OUTPUT_DIR}/api.d.ts" 2>"${GEN_LOG_TMP}"; then
+    echo "❌ Error: Type generation failed"
+    if grep -Eiq 'fetch failed|ECONNREFUSED|ENOTFOUND|network' "${GEN_LOG_TMP}"; then
+        echo "   復旧手順: API 到達性と OPENAPI_URL=${OPENAPI_URL} を確認してください。"
+    else
+        echo "   復旧手順: openapi-typescript の実行ログを確認して依存とスキーマを修正してください。"
+    fi
+    print_help_hint
+    echo "   --- openapi-typescript log (tail) ---"
+    tail -n 10 "${GEN_LOG_TMP}" | sed 's/^/   /'
+    exit 1
+fi
 
 echo "✅ Types generated at ${OUTPUT_DIR}/api.d.ts"
 echo ""


### PR DESCRIPTION
## Summary
- improve `scripts/generate-types.sh` failure handling with categorized recovery messages
- add command prerequisite checks and OpenAPI payload validation
- keep success path output unchanged while adding docs reference (`docs/api/auth.md`) on failures

## Testing
- `API_URL=http://127.0.0.1:9 bash scripts/generate-types.sh /tmp/yesod-types-failtest`
- `API_URL=https://petstore3.swagger.io/api/v3 npm_config_cache=/tmp/yesod-npm-cache bash scripts/generate-types.sh /tmp/yesod-types-ok`

Closes #297
