### PR TITLE
fix: admin i18n未知ロケール時のフォールバックを固定化

### DIFF
--- a/admin/i18n.py
+++ b/admin/i18n.py
@@ -19,6 +19,14 @@ DEFAULT_LANGUAGE = "en"
 _translations_cache: dict[str, dict] = {}
 
 
+def _resolve_language(lang: str) -> str:
+    """Resolve language code to a safe supported value."""
+    normalized = (lang or "").strip().lower()
+    if normalized in SUPPORTED_LANGUAGES:
+        return normalized
+    return DEFAULT_LANGUAGE
+
+
 def _get_locales_dir() -> Path:
     """Get the locales directory path."""
     return Path(__file__).parent / "locales"
@@ -26,16 +34,13 @@ def _get_locales_dir() -> Path:
 
 def _load_translations(lang: str) -> dict:
     """Load translations for a specific language."""
+    lang = _resolve_language(lang)
+
     if lang in _translations_cache:
         return _translations_cache[lang]
 
     locales_dir = _get_locales_dir()
     file_path = locales_dir / f"{lang}.json"
-
-    if not file_path.exists():
-        # Fallback to default language
-        file_path = locales_dir / f"{DEFAULT_LANGUAGE}.json"
-        lang = DEFAULT_LANGUAGE
 
     try:
         with open(file_path, "r", encoding="utf-8") as f:
@@ -102,7 +107,7 @@ class Translator:
 
     def __init__(self, lang: str = DEFAULT_LANGUAGE):
         """Initialize translator with a language."""
-        self.lang = lang if lang in SUPPORTED_LANGUAGES else DEFAULT_LANGUAGE
+        self.lang = _resolve_language(lang)
 
     def __call__(self, key: str, **kwargs: Any) -> str:
         """Get translated text."""
@@ -110,5 +115,4 @@ class Translator:
 
     def set_language(self, lang: str) -> None:
         """Set the current language."""
-        if lang in SUPPORTED_LANGUAGES:
-            self.lang = lang
+        self.lang = _resolve_language(lang)

--- a/admin/tests/test_i18n.py
+++ b/admin/tests/test_i18n.py
@@ -1,0 +1,20 @@
+"""Tests for admin i18n fallback behavior."""
+import unittest
+
+from i18n import Translator, get_text
+
+
+class I18nFallbackTests(unittest.TestCase):
+    def test_unknown_locale_falls_back_to_default_language(self) -> None:
+        self.assertEqual(get_text("nav.overview", "zz"), "📊 Overview")
+
+    def test_path_traversal_like_locale_falls_back_to_default_language(self) -> None:
+        self.assertEqual(get_text("nav.overview", "../../secrets"), "📊 Overview")
+
+    def test_known_locale_is_not_affected(self) -> None:
+        self.assertEqual(get_text("nav.overview", "ja"), "📊 概要")
+        self.assertEqual(Translator("ja").lang, "ja")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 概要
- `admin/i18n.py` で言語コードを許可リストへ正規化する `_resolve_language` を追加
- 未知ロケールや不正入力（`../../secrets` など）を `en` に固定フォールバック
- `admin/tests/test_i18n.py` を追加し、未知ロケール/不正入力/既知ロケールの3ケースを検証

## テスト
- `cd admin && python3 -m unittest -v tests/test_i18n.py`

Closes #296
