### PR TITLE
[Bench-80][03] OAuth失敗分類メトリクスを追加

### DIFF
--- a/api/app/auth/router.py
+++ b/api/app/auth/router.py
@@ -11,6 +11,7 @@ from sqlalchemy.orm import selectinload
 from app.audit import AuditLogger, AuthEventType
 from app.config import get_settings
 from app.db.session import get_db
+from app.metrics import record_oauth_failure_metric
 from app.models import OAuthAccount, User
 from app.valkey import OAuthStateStore
 from app.webhooks.emitter import WebhookEmitter
@@ -305,6 +306,7 @@ async def github_callback(
     # Verify and consume state
     state_data = await OAuthStateStore.get_and_delete(state)
     if not state_data or state_data.get("provider") != "github":
+        record_oauth_failure_metric("github", "invalid_state")
         await AuditLogger.log_login(
             db, None, "github", False, ip_address, device_info, "Invalid state"
         )
@@ -316,6 +318,7 @@ async def github_callback(
     # Exchange code for tokens
     token_data = await GitHubOAuth.exchange_code(code, redirect_uri, code_verifier)
     if not token_data:
+        record_oauth_failure_metric("github", "code_exchange_failed")
         await AuditLogger.log_login(
             db, None, "github", False, ip_address, device_info, "Code exchange failed"
         )
@@ -324,6 +327,7 @@ async def github_callback(
     # Get user info
     user_info = await GitHubOAuth.get_user_info(token_data["access_token"])
     if not user_info:
+        record_oauth_failure_metric("github", "user_info_failed")
         await AuditLogger.log_login(
             db, None, "github", False, ip_address, device_info, "Failed to get user info"
         )

--- a/api/app/metrics.py
+++ b/api/app/metrics.py
@@ -1,5 +1,8 @@
 """Prometheus metrics endpoint."""
 
+from collections import defaultdict
+from threading import Lock
+
 from fastapi import APIRouter, Depends
 from fastapi.responses import PlainTextResponse
 from sqlalchemy import text
@@ -8,6 +11,30 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.db.session import get_db
 
 router = APIRouter(tags=["metrics"])
+_oauth_failure_counts: dict[tuple[str, str], int] = defaultdict(int)
+_oauth_failure_counts_lock = Lock()
+
+
+def record_oauth_failure_metric(provider: str, reason: str) -> None:
+    """Record OAuth failure counter grouped by provider and failure reason."""
+    with _oauth_failure_counts_lock:
+        _oauth_failure_counts[(provider, reason)] += 1
+
+
+def reset_oauth_failure_metrics() -> None:
+    """Reset OAuth failure counters. Used by tests for deterministic assertions."""
+    with _oauth_failure_counts_lock:
+        _oauth_failure_counts.clear()
+
+
+def render_oauth_failure_metrics_lines() -> list[str]:
+    """Render OAuth failure metric lines from in-memory counters."""
+    with _oauth_failure_counts_lock:
+        oauth_failure_snapshot = dict(_oauth_failure_counts)
+    return [
+        f'yesod_oauth_failures_total{{provider="{provider}",reason="{reason}"}} {count}'
+        for (provider, reason), count in sorted(oauth_failure_snapshot.items())
+    ]
 
 
 @router.get("/metrics", response_class=PlainTextResponse)
@@ -49,6 +76,8 @@ async def metrics(db: AsyncSession = Depends(get_db)):
     result = await db.execute(text("SELECT COUNT(*) FROM deleted_users"))
     deleted_users = result.scalar()
     metrics_output.append(f"yesod_deleted_users_pending {deleted_users}")
+
+    metrics_output.extend(render_oauth_failure_metrics_lines())
 
     # Login stats (last 24h) - only if audit schema exists
     try:

--- a/api/tests/test_health.py
+++ b/api/tests/test_health.py
@@ -3,6 +3,12 @@
 import pytest
 from httpx import AsyncClient
 
+from app.metrics import (
+    record_oauth_failure_metric,
+    render_oauth_failure_metrics_lines,
+    reset_oauth_failure_metrics,
+)
+
 
 @pytest.mark.asyncio
 async def test_root(client: AsyncClient):
@@ -37,3 +43,14 @@ async def test_openapi_schema(client: AsyncClient):
     schema = response.json()
     assert schema["info"]["title"] == "YESOD Auth"
     assert "paths" in schema
+
+
+@pytest.mark.asyncio
+async def test_metrics_include_oauth_failure_classification_counter(client: AsyncClient):
+    """OAuth failure counter should be exposed with provider/reason labels."""
+    reset_oauth_failure_metrics()
+    record_oauth_failure_metric("github", "invalid_state")
+    record_oauth_failure_metric("github", "invalid_state")
+    assert 'yesod_oauth_failures_total{provider="github",reason="invalid_state"} 2' in (
+        render_oauth_failure_metrics_lines()
+    )


### PR DESCRIPTION
## 概要
- `yesod_oauth_failures_total{provider,reason}` を追加
- GitHub OAuth callback の失敗3分類（`invalid_state`/`code_exchange_failed`/`user_info_failed`）で計測呼び出しを追加
- メトリクス行レンダリングのテストを追加

## テスト
- `cd api && UV_CACHE_DIR=/tmp/uv-cache uv run pytest -q tests/test_health.py tests/test_auth_refresh.py`
- `cd api && UV_CACHE_DIR=/tmp/uv-cache uv run pytest -q tests/test_github_oauth.py`

Closes #295