### PR TITLE
fix: unknown provider input contract for auth provider check

### DIFF
--- a/api/app/auth/router.py
+++ b/api/app/auth/router.py
@@ -65,7 +65,14 @@ def _get_client_info(request: Request) -> tuple[str | None, str | None]:
 
 def _ensure_provider_enabled(provider: str) -> None:
     """Ensure OAuth provider credentials exist before starting auth flow."""
-    client_id_field, client_secret_field = OAUTH_PROVIDER_CREDENTIAL_FIELDS[provider]
+    credential_fields = OAUTH_PROVIDER_CREDENTIAL_FIELDS.get(provider)
+    if credential_fields is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Unsupported OAuth provider '{provider}'.",
+        )
+
+    client_id_field, client_secret_field = credential_fields
     client_id = getattr(settings, client_id_field, "")
     client_secret = getattr(settings, client_secret_field, "")
 

--- a/api/tests/test_auth_oauth_provider_disabled.py
+++ b/api/tests/test_auth_oauth_provider_disabled.py
@@ -33,3 +33,12 @@ def test_oauth_provider_disabled_raises_503(monkeypatch, provider: str):
         f"OAuth provider '{provider}' is disabled. "
         f"Configure {client_id_field} and {client_secret_field}."
     )
+
+
+def test_oauth_unknown_provider_raises_400():
+    """Unknown provider input must return stable 400 contract."""
+    with pytest.raises(auth_router_module.HTTPException) as exc_info:
+        auth_router_module._ensure_provider_enabled("unknown")
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail == "Unsupported OAuth provider 'unknown'."

--- a/docs/api/auth.md
+++ b/docs/api/auth.md
@@ -62,6 +62,18 @@ GET /api/v1/auth/google
 }
 ```
 
+### 未知 provider 入力時
+
+- 条件: サポート対象外の provider 名が入力された場合
+- 応答: `400 Bad Request`
+- 例:
+
+```json
+{
+  "detail": "Unsupported OAuth provider 'unknown'."
+}
+```
+
 ### 2. コールバック
 
 認証成功後、フロントエンドにリダイレクト：


### PR DESCRIPTION
## Summary
- add explicit unsupported-provider guard in `_ensure_provider_enabled`
- return stable `400 Bad Request` with detail for unknown provider input
- add regression test for unknown provider case
- document the contract in `docs/api/auth.md`

## Test
- `cd api && source .venv/bin/activate && pytest -q tests/test_auth_oauth_provider_disabled.py`
- `cd api && source .venv/bin/activate && pytest -q tests/test_auth_refresh.py tests/test_auth_logout.py tests/test_mock_oauth.py`

Closes #293
