### PR TITLE
docs: add users pagination limit boundary check examples

### DIFF
--- a/docs/api/users.md
+++ b/docs/api/users.md
@@ -10,6 +10,35 @@
 
 ---
 
+## ページング境界値（`limit=1/100`）の検証例
+
+`/api/v1/users/me` 自体はページング対象ではありません。  
+ただし、ユーザー認証後の一覧系確認を同一トークンで実施する場合は、`/api/v1/sessions` の `limit` 境界値をあわせて確認できます。
+
+```bash
+# 前提: OAuthログイン済みトークンを利用
+TOKEN="<access_token>"
+
+# 最小件数境界
+curl -sS -H "Authorization: Bearer ${TOKEN}" \
+  "http://localhost:8000/api/v1/sessions?limit=1" | jq '.items | length'
+
+# 実運用でよく使う上限確認（100件）
+curl -sS -H "Authorization: Bearer ${TOKEN}" \
+  "http://localhost:8000/api/v1/sessions?limit=100" | jq '.items | length'
+```
+
+確認観点:
+
+1. どちらも `200 OK` で返る
+2. `.items | length` が指定した `limit` を超えない
+3. 同一トークンで `GET /api/v1/users/me` も継続して成功する
+
+!!! tip "切り分け導線"
+    `limit=1/100` で期待どおりにならない場合は、[トラブルシューティングの確認手順](../help/troubleshooting.md#users-pagination-limit-check) を参照してください。
+
+---
+
 ## 更新系エンドポイントの前提条件
 
 `PATCH /api/v1/users/me` と `DELETE /api/v1/users/me` を呼び出す前に、次を満たしてください。

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -247,6 +247,9 @@ TOKEN=$(curl -s "http://localhost:8000/api/v1/auth/mock/login?user=alice&provide
 curl -H "Authorization: Bearer ${TOKEN}" \
   "http://localhost:8000/api/v1/users/me"
 ```
+
+`limit=1/100` の境界値を含む一覧系確認を同じトークンで行う場合は、[ユーザーAPIの検証例](api/users.md#ページング境界値limit1100の検証例) を参照してください。
+
 ### エラーレスポンスの確認
 
 未認証でログアウトAPIを呼ぶと、`401 Unauthorized` とエラーボディを確認できます。

--- a/docs/help/troubleshooting.md
+++ b/docs/help/troubleshooting.md
@@ -178,6 +178,37 @@ environment:
 - 設定値が過小: `RATE_LIMIT_PER_MINUTE` を運用実態に合わせて調整
 - Valkey 障害が疑われる: Valkey 復旧後に再試行し、429/接続エラーの再発有無を確認
 
+<a id="users-pagination-limit-check"></a>
+
+### `/api/v1/sessions` で `limit=1/100` の結果が不安定
+
+**症状:** 同一トークンで `GET /api/v1/users/me` は成功するが、`/api/v1/sessions?limit=1` または `limit=100` の件数/応答が期待とずれる
+
+**確認手順:**
+
+1. 同じアクセストークンで `users/me` が成功することを先に確認する
+   ```bash
+   curl -i -H "Authorization: Bearer <access_token>" \
+     "http://localhost:8000/api/v1/users/me"
+   ```
+2. `limit=1` と `limit=100` を連続実行し、HTTPステータスと件数を比較する
+   ```bash
+   curl -sS -H "Authorization: Bearer <access_token>" \
+     "http://localhost:8000/api/v1/sessions?limit=1" | jq '.items | length'
+   curl -sS -H "Authorization: Bearer <access_token>" \
+     "http://localhost:8000/api/v1/sessions?limit=100" | jq '.items | length'
+   ```
+3. 期待値から外れる場合は API ログを確認する
+   ```bash
+   docker compose logs api --since=30m | rg -n "/api/v1/sessions|401|422"
+   ```
+
+**期待値:**
+
+- 両方とも `200` を返す
+- 返却件数は指定 `limit` を超えない
+- `401` が混在する場合はトークン失効を疑い、再ログイン後に再検証する
+
 ### 管理者トークン失効で管理APIが `401 Unauthorized` になる
 
 **症状:** 管理画面操作や `GET /api/v1/admin/*` 呼び出しが `401 Unauthorized` を返す


### PR DESCRIPTION
## Summary
- docs/api/users.md に limit=1/100 の境界値検証例を追加
- docs/getting-started.md から検証例への導線を追加
- docs/help/troubleshooting.md に切り分け手順を追加

## Testing
- mkdocs build --strict (failed: command not found)
- 追加リンク/アンカーの存在確認（rg）

Closes #242