### PR TITLE
docs: add OAuth clock skew troubleshooting guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Base URL: `http://localhost:8000/api/v1`
 
 運用時の注意点（refresh token のローテーション/再ログイン方針）は [docs/installation.md](docs/installation.md#リフレッシュトークン運用時の注意) を参照してください。
 認証エラーコードの運用向け一覧は [`docs/api/auth.md`](docs/api/auth.md) を参照してください。
+`invalid_grant` が断続的に発生する場合は、[clock skew 診断手順](docs/help/troubleshooting.md#oauth-clock-skew) を参照してください。
 
 ### Users
 

--- a/docs/guides/oauth/index.md
+++ b/docs/guides/oauth/index.md
@@ -72,6 +72,8 @@ OAuthプロバイダーを「有効化できているか」を、次の順序で
    対象プロバイダーごとに `*_client_id` と `*_client_secret` の両方を設定します。名前一覧は [インストールガイド（OAuth認証情報）](../../installation.md#oauth-credentials) を参照してください。
 5. 起動後に導線で確認する
    `GET /api/v1/auth/{provider}` で認可画面へ遷移できることを確認し、失敗時は [トラブルシューティング](../../help/troubleshooting.md) を参照します。
+6. 時刻同期を確認する（self-host）
+   OAuth認可コードは短命なため、ホスト時刻のずれで `invalid_grant` が発生します。`timedatectl status` で NTP 同期状態を確認し、ずれがある場合は [clock skew 診断](../../help/troubleshooting.md#oauth-clock-skew) を参照してください。
 
 ### config / secrets の参照関係（要点）
 

--- a/docs/help/troubleshooting.md
+++ b/docs/help/troubleshooting.md
@@ -139,6 +139,43 @@ environment:
 
 ---
 
+<a id="oauth-clock-skew"></a>
+
+### OAuth callback で `invalid_grant` が断続的に発生する（clock skew）
+
+**症状:** 同一設定でも時間帯やホストごとに `invalid_grant` / `code has expired` が発生し、再試行で一時的に成功する
+
+**原因:** APIサーバー・リバースプロキシ・ホストOSの時刻差（clock skew）により、OAuth認可コードの有効期限判定がずれる
+
+**診断手順（最小）:**
+
+1. 発生時刻の前後で callback 失敗ログを抽出する
+   ```bash
+   docker compose logs api --since=30m | rg -n "invalid_grant|code has expired|callback"
+   ```
+2. APIコンテナとホストの現在時刻を比較する（秒差を確認）
+   ```bash
+   date -u
+   docker compose exec api date -u
+   ```
+3. NTP同期状態を確認する（self-host 環境）
+   ```bash
+   timedatectl status
+   ```
+4. プロバイダー側の認可コード発行時刻と、callback受信時刻の乖離を確認する
+   - 監査ログ/アクセスログの時刻がUTC基準で連続しているか
+   - 特定ノードだけ数十秒以上ずれていないか
+
+| 想定原因 | 観測シグナル | 対処 |
+| --- | --- | --- |
+| ホスト時刻が遅延/先行 | `date -u` でノード間に秒差がある | NTP再同期後にOAuthを再試行 |
+| コンテナ時刻が固定化 | ホスト更新後も `docker compose exec api date -u` が追従しない | コンテナ再作成（`docker compose up -d --force-recreate api`） |
+| 逆プロキシ/多段環境の遅延 | callback 到達までの遅延が長い | callback 経路を短縮し、リトライ実装を見直す |
+
+**補足:** OAuth導入時は [OAuth設定ガイド](../guides/oauth/index.md) のセルフホスト手順と併せて、時刻同期を初期チェック項目に含めてください。
+
+---
+
 <a id="auth-rate-limit-429"></a>
 
 ### `429 Too Many Requests`（認証レート制限）


### PR DESCRIPTION
## 概要\n- docs/help/troubleshooting.md に clock skew 起因の OAuth callback 失敗（invalid_grant）の診断手順を追加\n- docs/guides/oauth/index.md に self-host 向け時刻同期チェックを追記\n- README.md から clock skew 診断への導線を追加\n\n## テスト\n- \（未導入のため実行不可: command not found）\n- 追加リンク/参照パスが実在することを手動確認\n\nCloses #243