### PR TITLE
chore: gitignore generated artifacts and hypothesis cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ config/webhooks.yaml
 
 .codex-orch/
 /artifacts/
+artifacts/**
+api/.hypothesis/


### PR DESCRIPTION
## Summary\n- add explicit ignore for `artifacts/**`\n- add explicit ignore for `api/.hypothesis/`\n\n## Validation\n- `git check-ignore -v artifacts/run.log api/.hypothesis/examples/db/example.db`\n\n## Notes\n- Existing `/artifacts/` and root `.hypothesis/` are kept; this PR adds explicit project-level patterns for weekly triage clarity.