### PR TITLE
chore: fix weekly git inventory ignore rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,8 @@ logs/
 # Test
 .pytest_cache/
 .hypothesis/
+api/.hypothesis/constants/
+api/.hypothesis/unicode_data/
 .coverage
 htmlcov/
 
@@ -41,3 +43,7 @@ config/webhooks.yaml
 
 .codex-orch/
 /artifacts/
+artifacts/codex_last_message.md
+artifacts/knowledge/
+artifacts/orch_result.json
+artifacts/time_guard.json


### PR DESCRIPTION
## Summary\n- add explicit ignore entries for weekly inventory noise under  and \n- keep repository clean from recurring generated operational files\n\n## Test\n- .gitignore:32:.hypothesis/	api/.hypothesis/constants/example\n- .gitignore:32:.hypothesis/	api/.hypothesis/unicode_data/char\n- .gitignore:45:/artifacts/	artifacts/codex_last_message.md\n\nCloses #250