### PR TITLE
docs: clarify generated artifacts handling for weekly inventory

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,6 +376,16 @@ pip install -r requirements.txt
 pytest
 ```
 
+### Generated Artifacts Policy
+
+`artifacts/` と `api/.hypothesis/` は再生成可能な生成物のため、Git 管理対象に含めません。
+週次棚卸しやレビュー時に未追跡で残っていても、コミット対象へ含めない運用を推奨します。
+
+```bash
+# 必須エントリの確認（出力されれば設定済み）
+rg -n '^/artifacts/$|^artifacts/\\*\\*$|^api/.hypothesis/$' .gitignore
+```
+
 ## PR Auto-Approve + Auto-Merge
 
 This repository includes GitHub Actions workflows for automatic PR approval and merge:


### PR DESCRIPTION
## Summary
- add a Generated Artifacts Policy section to README
- document that `artifacts/` and `api/.hypothesis/` are generated and should stay untracked
- add a quick verification command for required `.gitignore` entries

## Test
- `rg -n '^/artifacts/$|^artifacts/\*\*$|^api/.hypothesis/$' .gitignore`

Closes #252
