### PR TITLE
test: add MOCK_OAUTH_ENABLED profile override checks

### DIFF
--- a/api/tests/test_config.py
+++ b/api/tests/test_config.py
@@ -1,6 +1,10 @@
 """Tests for configuration helpers."""
 
+from pathlib import Path
 from unittest.mock import mock_open, patch
+
+import pytest
+import yaml
 
 from app.config import (
     DEFAULT_CORS_ORIGINS,
@@ -54,3 +58,33 @@ def test_resolve_cors_origins_uses_env_value_when_set():
 
     assert origins == ["https://example.com", "https://admin.example.com"]
     assert using_default is False
+
+
+def _load_compose_services() -> dict:
+    compose_path = Path(__file__).resolve().parents[2] / "docker-compose.yml"
+    with compose_path.open() as f:
+        compose = yaml.safe_load(f)
+    return compose["services"]
+
+
+def _environment_values(service: dict) -> list[str]:
+    environment = service.get("environment", [])
+    if isinstance(environment, dict):
+        return [f"{key}={value}" for key, value in environment.items()]
+    return [str(value) for value in environment]
+
+
+@pytest.mark.parametrize(
+    ("profile", "service_name"),
+    [
+        ("default", "api"),
+        ("full", "api"),
+        ("ci", "api-ci"),
+    ],
+)
+def test_mock_oauth_enabled_is_overridden_to_true_for_each_profile(profile, service_name):
+    services = _load_compose_services()
+    service = services[service_name]
+
+    assert profile in service.get("profiles", [])
+    assert "MOCK_OAUTH_ENABLED=1" in _environment_values(service)


### PR DESCRIPTION
## Summary
- add profile-based checks for `MOCK_OAUTH_ENABLED` in `api/tests/test_config.py`
- cover `default` / `full` / `ci` cases against `docker-compose.yml` service definitions
- normalize service environment reading for both list/dict format

## Test
- `cd api && UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_config.py -q` (pass)
- `cd api && UV_CACHE_DIR=/tmp/uv-cache uv run pytest -q` (2 known failures in current branch: Redis connection required test and Hypothesis deadline flake)

Closes #347
