### PR TITLE
test: cover mock oauth profile overrides

### DIFF
--- a/api/tests/test_config.py
+++ b/api/tests/test_config.py
@@ -1,12 +1,33 @@
 """Tests for configuration helpers."""
 
+import importlib
+from pathlib import Path
 from unittest.mock import mock_open, patch
+
+import pytest
+import yaml
 
 from app.config import (
     DEFAULT_CORS_ORIGINS,
     read_secret,
     resolve_cors_origins,
 )
+
+COMPOSE_FILE = Path(__file__).resolve().parents[2] / "docker-compose.yml"
+PROFILE_SERVICE_CASES = (
+    ("default", "api"),
+    ("full", "api"),
+    ("ci", "api-ci"),
+)
+
+
+def _reload_config_module():
+    return importlib.reload(importlib.import_module("app.config"))
+
+
+def _compose_service(service_name: str) -> dict:
+    compose = yaml.safe_load(COMPOSE_FILE.read_text())
+    return compose["services"][service_name]
 
 
 def test_read_secret_prefers_secret_file_over_env(monkeypatch):
@@ -54,3 +75,38 @@ def test_resolve_cors_origins_uses_env_value_when_set():
 
     assert origins == ["https://example.com", "https://admin.example.com"]
     assert using_default is False
+
+
+def test_mock_oauth_enabled_defaults_to_disabled_when_env_is_unset(monkeypatch):
+    monkeypatch.delenv("MOCK_OAUTH_ENABLED", raising=False)
+
+    config_module = _reload_config_module()
+
+    assert config_module.Settings.MOCK_OAUTH_ENABLED is False
+
+
+def test_mock_oauth_enabled_is_enabled_when_env_requests_it(monkeypatch):
+    monkeypatch.setenv("MOCK_OAUTH_ENABLED", "1")
+
+    config_module = _reload_config_module()
+
+    assert config_module.Settings.MOCK_OAUTH_ENABLED is True
+
+
+@pytest.mark.parametrize(("profile_name", "service_name"), PROFILE_SERVICE_CASES)
+@patch("app.config.os.path.exists", return_value=False)
+def test_compose_profiles_override_mock_oauth_enabled(_mock_exists, monkeypatch, profile_name, service_name):
+    monkeypatch.delenv("MOCK_OAUTH_ENABLED", raising=False)
+    config_module = _reload_config_module()
+
+    assert config_module.Settings.MOCK_OAUTH_ENABLED is False
+
+    compose_service = _compose_service(service_name)
+
+    assert profile_name in compose_service["profiles"]
+    assert "MOCK_OAUTH_ENABLED=1" in compose_service.get("environment", [])
+
+    monkeypatch.setenv("MOCK_OAUTH_ENABLED", "1")
+    config_module = _reload_config_module()
+
+    assert config_module.Settings.MOCK_OAUTH_ENABLED is True


### PR DESCRIPTION
## Summary
- add config tests for the application default when `MOCK_OAUTH_ENABLED` is unset
- add a positive env-driven config case for `MOCK_OAUTH_ENABLED=1`
- verify `default`, `full`, and `ci` compose profiles each expose the expected override

Closes #347

## Testing
- `uv run --with-requirements requirements.txt pytest tests/test_config.py -q`
- `docker compose --profile default config | rg -n "MOCK_OAUTH_ENABLED|api:"`
- `docker compose --profile full config | rg -n "MOCK_OAUTH_ENABLED|api:"`
- `docker compose --profile ci config | rg -n "MOCK_OAUTH_ENABLED|api-ci:"`