### PR TITLE
test: cover webhook signer timestamp skew boundaries

### DIFF
--- a/api/app/webhooks/signer.py
+++ b/api/app/webhooks/signer.py
@@ -9,6 +9,7 @@ class WebhookSigner:
     """Signs webhook payloads for verification."""
 
     SIGNATURE_PREFIX = "sha256="
+    DEFAULT_MAX_TIMESTAMP_SKEW_SECONDS = 300
 
     @staticmethod
     def sign(payload: str, secret: str, timestamp: int | None = None) -> tuple[str, int]:
@@ -42,6 +43,8 @@ class WebhookSigner:
         secret: str,
         timestamp: int,
         signature: str,
+        current_timestamp: int | None = None,
+        max_timestamp_skew_seconds: int = DEFAULT_MAX_TIMESTAMP_SKEW_SECONDS,
     ) -> bool:
         """
         Verify a webhook signature.
@@ -51,10 +54,18 @@ class WebhookSigner:
             secret: The shared secret key
             timestamp: The timestamp from X-Webhook-Timestamp header
             signature: The signature from X-Webhook-Signature header
+            current_timestamp: The current Unix timestamp used for skew checks
+            max_timestamp_skew_seconds: Maximum allowed skew in seconds
 
         Returns:
             True if signature is valid, False otherwise
         """
+        if current_timestamp is None:
+            current_timestamp = int(time.time())
+
+        if abs(current_timestamp - timestamp) > max_timestamp_skew_seconds:
+            return False
+
         expected_signature, _ = WebhookSigner.sign(payload, secret, timestamp)
         return hmac.compare_digest(expected_signature, signature)
 

--- a/api/tests/test_webhook_signer.py
+++ b/api/tests/test_webhook_signer.py
@@ -3,6 +3,7 @@
 import json
 import uuid
 
+import pytest
 from hypothesis import given, settings
 from hypothesis import strategies as st
 
@@ -65,7 +66,7 @@ class TestWebhookSigner:
         assert signature.startswith("sha256=")
 
         # Verification with same inputs should succeed
-        assert WebhookSigner.verify(payload, secret, timestamp, signature) is True
+        assert WebhookSigner.verify(payload, secret, timestamp, signature, current_timestamp=timestamp) is True
 
     @settings(max_examples=50)
     @given(payload=payloads, secret=secrets, timestamp=timestamps)
@@ -139,7 +140,51 @@ class TestWebhookSigner:
 
         # Verify with wrong secret
         wrong_secret = secret + "wrong"
-        assert WebhookSigner.verify(payload, wrong_secret, timestamp, signature) is False
+        assert WebhookSigner.verify(
+            payload,
+            wrong_secret,
+            timestamp,
+            signature,
+            current_timestamp=timestamp,
+        ) is False
+
+    @pytest.mark.parametrize("timestamp_offset", (-300, 300))
+    def test_verification_accepts_timestamp_at_skew_boundary(self, timestamp_offset: int):
+        payload = json.dumps({"event_id": str(uuid.uuid4()), "data": {}})
+        secret = "test-secret-key"
+        current_timestamp = 1_700_000_000
+        timestamp = current_timestamp + timestamp_offset
+        signature, _ = WebhookSigner.sign(payload, secret, timestamp)
+
+        assert (
+            WebhookSigner.verify(
+                payload,
+                secret,
+                timestamp,
+                signature,
+                current_timestamp=current_timestamp,
+            )
+            is True
+        )
+
+    @pytest.mark.parametrize("timestamp_offset", (-301, 301))
+    def test_verification_rejects_timestamp_outside_skew_boundary(self, timestamp_offset: int):
+        payload = json.dumps({"event_id": str(uuid.uuid4()), "data": {}})
+        secret = "test-secret-key"
+        current_timestamp = 1_700_000_000
+        timestamp = current_timestamp + timestamp_offset
+        signature, _ = WebhookSigner.sign(payload, secret, timestamp)
+
+        assert (
+            WebhookSigner.verify(
+                payload,
+                secret,
+                timestamp,
+                signature,
+                current_timestamp=current_timestamp,
+            )
+            is False
+        )
 
     def test_get_headers_includes_all_required_headers(self):
         """


### PR DESCRIPTION
## Summary
- add timestamp skew checks to `WebhookSigner.verify()`
- cover the accepted boundary at ±300 seconds and rejection at ±301 seconds
- run signer and webhook integration tests to guard against regressions

Closes #344

## Testing
- `uv run --with-requirements requirements.txt pytest tests/test_webhook_signer.py tests/test_webhook_integration.py -q`