### PR TITLE
docs: installationにsecret不足時の最短復旧手順を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ openssl rand -base64 24 > secrets/admin_password.txt
 chmod 600 secrets/*.txt
 ```
 
+初回導入で `secret ... not found` が出た場合は、[`docs/installation.md` の最短復旧コマンド](docs/installation.md#1-docker-compose-up-で-secret-未設定エラーになる) を実行してください。
+
 #### Self-hosted secret layout example
 
 `docker-compose.yml` reads from `./secrets/*.txt`. For self-hosted deployments,

--- a/docs/help/troubleshooting.md
+++ b/docs/help/troubleshooting.md
@@ -18,6 +18,8 @@ docker compose logs api --since=30m | rg -n "Invalid state|callback|invalid_clie
 
 ## 起動時のエラー
 
+`secret ... not found` の即時復旧は [`インストールガイド` の secret不足時手順](../installation.md#1-docker-compose-up-で-secret-未設定エラーになる) を先に実行してください。
+
 ### `pg_cron`関連のエラー
 
 ```

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -223,6 +223,32 @@ printf '%s\n' google_client_id google_client_secret discord_client_id discord_cl
 ls -1 secrets/*.txt 2>/dev/null | sed -E 's#^.*/##; s#\\.txt$##' | sort
 ```
 
+最短復旧コマンド（secret不足）:
+
+```bash
+# 1) まず不足している secret 名を抽出
+MISSING="$(docker compose --profile default up -d 2>&1 \
+  | rg -o 'secret [a-z0-9_]+ not found' \
+  | sed -E 's/^secret ([a-z0-9_]+) not found$/\\1/' \
+  | sort -u)"
+
+# 2) 不足分だけ secrets/<name>.txt を補完（雛形があればコピー）
+for name in $MISSING; do
+  [ -f "secrets/${name}.txt" ] || cp "secrets/${name}.txt.example" "secrets/${name}.txt"
+done
+
+# 3) jwt_secret は必須。未作成なら生成して再起動
+[ -s secrets/jwt_secret.txt ] || openssl rand -hex 32 > secrets/jwt_secret.txt
+docker compose --profile default up -d --force-recreate api
+docker compose --profile default ps
+```
+
+期待値:
+- `docker compose --profile default ps` で `api` が `Up`（または `running`）
+- `secret ... not found` が再発しない
+
+`invalid_client` が続く場合は、`secrets/*.txt` の値が実値であることを確認し、[`docs/help/troubleshooting.md` の `invalid_client` 手順](help/troubleshooting.md#invalid_client-or-401-from-provider-token-endpoint) を参照してください。
+
 対処:
 
 1. 不足している `<name>` について、`secrets/<name>.txt` を作成する


### PR DESCRIPTION
## 概要\n- docs/installation.md の `secret ... not found` 節に、不足 secret の抽出から再起動までを最短復旧コマンドとして追加\n- README.md と docs/help/troubleshooting.md から当該手順へ直接リンク\n\n## 変更テーマ\n- 1テーマのみ: 初回導入で secret 不足時の復旧導線短縮\n\n## 受け入れ基準セルフチェック\n- [x] 変更は1テーマに限定\n- [x] 根拠ファイル（installation/troubleshooting/README）の文脈と整合\n- [x] 曖昧語を避け、再実行可能なコマンド手順を追加\n- [x] 追加キーワード確認: `rg -n "最短復旧コマンド（secret不足）" docs/installation.md`\n\n## 重複回避\n- 既存 open #265 #263 #262 #261 は別ページ・別機能対象であり、本PRは installation の secret不足復旧導線に限定