### PR TITLE
docs: add profile-specific initial check command table

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -95,6 +95,18 @@ docker compose --profile ci config --services
 docker compose --profile default config | rg "MOCK_OAUTH_ENABLED|api:"
 docker compose --profile ci config | rg "MOCK_OAUTH_ENABLED|api-ci:"
 ```
+
+### profile別の初回確認コマンド表
+
+初回導入では、使う profile を1つ決めてから次の表の順で実行すると、確認漏れを防げます。
+
+| profile | 使う場面 | 初回確認コマンド（順番どおり） | 合格基準 |
+| --- | --- | --- | --- |
+| `default` | API と Docs の最短導入確認 | `docker compose --profile default up -d`<br>`docker compose --profile default ps`<br>`curl -fsS http://localhost:8000/health` | `db` `valkey` `api` `docs` が `Up`、`{"status":"healthy"}` が返る |
+| `full` | 管理画面 (`admin`) を含めて確認 | `ls -l secrets/admin_password.txt`<br>`docker compose --profile full up -d`<br>`docker compose --profile full config --services` | `secrets/admin_password.txt` が存在し、`admin` が services 一覧に出る |
+| `ci` | CI相当の軽量構成で確認 | `docker compose --profile ci up -d`<br>`docker compose --profile ci config --services`<br>`docker compose --profile ci ps` | `db-ci` `valkey` `api-ci` が起動し、不要な `admin` が含まれない |
+
+詳細な profile 判定観点は [インストール: profile選択チェック表](installation.md#profile選択チェック表) を参照してください。
 ## 3.5 初回ヘルスチェック（推奨）
 
 初回起動時は、次の3点を順に確認すると原因切り分けがしやすくなります。


### PR DESCRIPTION
## 概要
- `docs/getting-started.md` に `default/full/ci` の profile 別初回確認コマンド表を追加
- 各 profile の実行順と合格基準を明記して再実行可能な手順に統一
- 詳細判断は `docs/installation.md#profile選択チェック表` へ導線追加

## テスト
- `rg -n "profile別の初回確認コマンド表|初回確認コマンド（順番どおり）|profile選択チェック表" docs/getting-started.md`
- `cd api && source .venv/bin/activate && pytest -q tests/test_health.py tests/test_mock_oauth.py`
- `cd api && UV_CACHE_DIR=/tmp/uv-cache uv run pytest -q`（環境要因で `tests/test_users_delete_account.py` が Redis 未起動により失敗: `localhost:6379 Connection refused`）

Closes #287