### PR TITLE
[Bench-80][05] state不整合ログへrequest-idを必須化

### DIFF
--- a/api/app/auth/router.py
+++ b/api/app/auth/router.py
@@ -1,6 +1,7 @@
 """Auth router with security enhancements."""
 
 import secrets
+import uuid
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from fastapi.responses import RedirectResponse
@@ -64,6 +65,19 @@ def _get_client_info(request: Request) -> tuple[str | None, str | None]:
     return device_info, ip_address
 
 
+def _get_request_id(request: Request) -> str:
+    """Extract request-id header or generate a fallback ID."""
+    request_id = request.headers.get("X-Request-Id")
+    if request_id:
+        return request_id
+    return str(uuid.uuid4())
+
+
+def _invalid_state_reason(request: Request) -> str:
+    """Build a fixed invalid-state reason format for audit logs."""
+    return f"Invalid state [request-id={_get_request_id(request)}]"
+
+
 def _ensure_provider_enabled(provider: str) -> None:
     """Ensure OAuth provider credentials exist before starting auth flow."""
     credential_fields = OAUTH_PROVIDER_CREDENTIAL_FIELDS.get(provider)
@@ -122,7 +136,7 @@ async def google_callback(
     state_data = await OAuthStateStore.get_and_delete(state)
     if not state_data or state_data.get("provider") != "google":
         await AuditLogger.log_login(
-            db, None, "google", False, ip_address, device_info, "Invalid state"
+            db, None, "google", False, ip_address, device_info, _invalid_state_reason(request)
         )
         raise HTTPException(status_code=400, detail="Invalid or expired state")
 
@@ -218,7 +232,7 @@ async def discord_callback(
     state_data = await OAuthStateStore.get_and_delete(state)
     if not state_data or state_data.get("provider") != "discord":
         await AuditLogger.log_login(
-            db, None, "discord", False, ip_address, device_info, "Invalid state"
+            db, None, "discord", False, ip_address, device_info, _invalid_state_reason(request)
         )
         raise HTTPException(status_code=400, detail="Invalid or expired state")
 
@@ -315,7 +329,7 @@ async def github_callback(
     if not state_data or state_data.get("provider") != "github":
         record_oauth_failure_metric("github", "invalid_state")
         await AuditLogger.log_login(
-            db, None, "github", False, ip_address, device_info, "Invalid state"
+            db, None, "github", False, ip_address, device_info, _invalid_state_reason(request)
         )
         raise HTTPException(status_code=400, detail="Invalid or expired state")
 
@@ -412,7 +426,9 @@ async def x_callback(
     # Verify and consume state
     state_data = await OAuthStateStore.get_and_delete(state)
     if not state_data or state_data.get("provider") != "x":
-        await AuditLogger.log_login(db, None, "x", False, ip_address, device_info, "Invalid state")
+        await AuditLogger.log_login(
+            db, None, "x", False, ip_address, device_info, _invalid_state_reason(request)
+        )
         raise HTTPException(status_code=400, detail="Invalid or expired state")
 
     code_verifier = state_data.get("code_verifier")
@@ -511,7 +527,7 @@ async def linkedin_callback(
     state_data = await OAuthStateStore.get_and_delete(state)
     if not state_data or state_data.get("provider") != "linkedin":
         await AuditLogger.log_login(
-            db, None, "linkedin", False, ip_address, device_info, "Invalid state"
+            db, None, "linkedin", False, ip_address, device_info, _invalid_state_reason(request)
         )
         raise HTTPException(status_code=400, detail="Invalid or expired state")
 
@@ -607,7 +623,7 @@ async def facebook_callback(
     state_data = await OAuthStateStore.get_and_delete(state)
     if not state_data or state_data.get("provider") != "facebook":
         await AuditLogger.log_login(
-            db, None, "facebook", False, ip_address, device_info, "Invalid state"
+            db, None, "facebook", False, ip_address, device_info, _invalid_state_reason(request)
         )
         raise HTTPException(status_code=400, detail="Invalid or expired state")
 
@@ -704,7 +720,7 @@ async def slack_callback(
     state_data = await OAuthStateStore.get_and_delete(state)
     if not state_data or state_data.get("provider") != "slack":
         await AuditLogger.log_login(
-            db, None, "slack", False, ip_address, device_info, "Invalid state"
+            db, None, "slack", False, ip_address, device_info, _invalid_state_reason(request)
         )
         raise HTTPException(status_code=400, detail="Invalid or expired state")
 
@@ -801,7 +817,7 @@ async def twitch_callback(
     state_data = await OAuthStateStore.get_and_delete(state)
     if not state_data or state_data.get("provider") != "twitch":
         await AuditLogger.log_login(
-            db, None, "twitch", False, ip_address, device_info, "Invalid state"
+            db, None, "twitch", False, ip_address, device_info, _invalid_state_reason(request)
         )
         raise HTTPException(status_code=400, detail="Invalid or expired state")
 

--- a/api/tests/test_github_oauth.py
+++ b/api/tests/test_github_oauth.py
@@ -285,3 +285,24 @@ class TestGitHubOAuthCallback:
 
         assert response.status_code == 400
         assert response.json() == {"detail": "Invalid or expired state"}
+
+    @pytest.mark.asyncio
+    async def test_callback_mismatched_state_logs_request_id(self, client):
+        """State mismatch audit log must include request-id for traceability."""
+        with (
+            patch("app.auth.rate_limit.limiter._check_request_limit", return_value=None),
+            patch(
+                "app.auth.router.OAuthStateStore.get_and_delete",
+                new=AsyncMock(return_value=None),
+            ),
+            patch("app.auth.router.AuditLogger.log_login", new=AsyncMock()) as mock_log_login,
+        ):
+            response = await client.get(
+                "/api/v1/auth/github/callback?code=test-code&state=unexpected-state",
+                headers={"X-Request-Id": "req-test-123"},
+            )
+
+        assert response.status_code == 400
+        assert response.json() == {"detail": "Invalid or expired state"}
+        assert mock_log_login.await_count == 1
+        assert mock_log_login.await_args.args[6] == "Invalid state [request-id=req-test-123]"


### PR DESCRIPTION
## 概要
- OAuth callback の state 不整合時ログを固定フォーマット化
- request-id ヘッダが無い場合は UUID を自動生成
- GitHub callback の異常系テストを追加

## 変更点
- `api/app/auth/router.py`
  - `_get_request_id` と `_invalid_state_reason` を追加
  - 全OAuth provider callback の invalid state ログを `Invalid state [request-id=...]` に統一
- `api/tests/test_github_oauth.py`
  - request-id ヘッダを含む不整合時に監査ログへ反映されることを検証するテスト追加

## テスト
- `cd api && UV_CACHE_DIR=/tmp/.uv-cache uv run --with-requirements requirements.txt pytest -q tests/test_github_oauth.py::TestGitHubOAuthCallback::test_callback_rejects_mismatched_state tests/test_github_oauth.py::TestGitHubOAuthCallback::test_callback_mismatched_state_logs_request_id`
- `cd api && UV_CACHE_DIR=/tmp/.uv-cache uv run --with-requirements requirements.txt pytest -q tests/test_github_oauth.py`

Closes #316