### PR TITLE
fix: fail startup when provider secret is empty (fix #317)

### DIFF
--- a/api/app/config.py
+++ b/api/app/config.py
@@ -4,6 +4,16 @@ import os
 from functools import lru_cache
 
 DEFAULT_CORS_ORIGINS = "http://localhost:3000,http://localhost:5173"
+OAUTH_PROVIDER_CREDENTIAL_KEYS: tuple[tuple[str, str], ...] = (
+    ("GOOGLE_CLIENT_ID", "GOOGLE_CLIENT_SECRET"),
+    ("DISCORD_CLIENT_ID", "DISCORD_CLIENT_SECRET"),
+    ("GITHUB_CLIENT_ID", "GITHUB_CLIENT_SECRET"),
+    ("X_CLIENT_ID", "X_CLIENT_SECRET"),
+    ("LINKEDIN_CLIENT_ID", "LINKEDIN_CLIENT_SECRET"),
+    ("FACEBOOK_CLIENT_ID", "FACEBOOK_CLIENT_SECRET"),
+    ("SLACK_CLIENT_ID", "SLACK_CLIENT_SECRET"),
+    ("TWITCH_CLIENT_ID", "TWITCH_CLIENT_SECRET"),
+)
 
 
 def read_secret(name: str, default: str = "") -> str:
@@ -93,6 +103,18 @@ class Settings:
     _cors_origins, _cors_origins_using_default = resolve_cors_origins(os.getenv("CORS_ORIGINS"))
     CORS_ORIGINS: list[str] = _cors_origins
     CORS_ORIGINS_USING_DEFAULT: bool = _cors_origins_using_default
+
+    def __init__(self) -> None:
+        self._validate_oauth_provider_secrets()
+
+    def _validate_oauth_provider_secrets(self) -> None:
+        for client_id_key, client_secret_key in OAUTH_PROVIDER_CREDENTIAL_KEYS:
+            client_id = str(getattr(self, client_id_key, "")).strip()
+            client_secret = str(getattr(self, client_secret_key, "")).strip()
+            if client_id and not client_secret:
+                raise ValueError(
+                    f"OAuth provider secret is empty. Set non-empty value for {client_secret_key}."
+                )
 
 
 @lru_cache

--- a/api/tests/test_config.py
+++ b/api/tests/test_config.py
@@ -8,6 +8,7 @@ import yaml
 
 from app.config import (
     DEFAULT_CORS_ORIGINS,
+    Settings,
     read_secret,
     resolve_cors_origins,
 )
@@ -58,6 +59,25 @@ def test_resolve_cors_origins_uses_env_value_when_set():
 
     assert origins == ["https://example.com", "https://admin.example.com"]
     assert using_default is False
+
+
+def test_settings_raises_when_provider_client_id_exists_but_secret_is_empty(monkeypatch):
+    monkeypatch.setattr(Settings, "GITHUB_CLIENT_ID", "github-client-id")
+    monkeypatch.setattr(Settings, "GITHUB_CLIENT_SECRET", "")
+
+    with pytest.raises(
+        ValueError, match="GITHUB_CLIENT_SECRET"
+    ):
+        Settings()
+
+
+def test_settings_allows_when_provider_secret_is_non_empty(monkeypatch):
+    monkeypatch.setattr(Settings, "GITHUB_CLIENT_ID", "github-client-id")
+    monkeypatch.setattr(Settings, "GITHUB_CLIENT_SECRET", "github-client-secret")
+
+    settings = Settings()
+
+    assert settings.GITHUB_CLIENT_SECRET == "github-client-secret"
 
 
 def _load_compose_services() -> dict:


### PR DESCRIPTION
## Summary\n- validate OAuth provider credentials at startup\n- raise clear error including secret key name when client_id exists but secret is empty\n- add config tests for failure/success paths\n\n## Test\n- .venv/bin/python -m pytest -q api/tests/test_config.py\n\n## Impact\n- deployments with empty provider secret now fail fast at startup\n- self-hosted operators get immediate key-level feedback for misconfiguration\n