### PR TITLE
feat: provider別バースト制限メトリクスを追加

### DIFF
--- a/api/app/auth/rate_limit.py
+++ b/api/app/auth/rate_limit.py
@@ -1,11 +1,30 @@
 """Rate limiting configuration."""
 
+import inspect
+
+from fastapi import Request
+from fastapi.responses import Response
 from slowapi import Limiter
+from slowapi import _rate_limit_exceeded_handler
+from slowapi.errors import RateLimitExceeded
 from slowapi.util import get_remote_address
 
 from app.config import get_settings
+from app.metrics import record_oauth_rate_limit_burst_metric
 
 settings = get_settings()
+SUPPORTED_OAUTH_PROVIDERS = frozenset(
+    {
+        "google",
+        "discord",
+        "github",
+        "x",
+        "linkedin",
+        "facebook",
+        "slack",
+        "twitch",
+    }
+)
 
 # Create limiter instance
 limiter = Limiter(
@@ -19,3 +38,30 @@ limiter = Limiter(
 def get_rate_limit_string() -> str:
     """Get current rate limit as string for dynamic updates."""
     return f"{settings.RATE_LIMIT_PER_MINUTE}/minute"
+
+
+def extract_oauth_provider_from_path(path: str) -> str | None:
+    """Extract OAuth provider from /api/v1/auth/<provider> paths."""
+    prefix = "/api/v1/auth/"
+    if not path.startswith(prefix):
+        return None
+
+    provider = path.removeprefix(prefix).split("/", 1)[0]
+    if provider in SUPPORTED_OAUTH_PROVIDERS:
+        return provider
+    return None
+
+
+async def oauth_rate_limit_exceeded_handler(
+    request: Request,
+    exc: RateLimitExceeded,
+) -> Response:
+    """Record provider-level burst rate-limit metric before returning 429."""
+    provider = extract_oauth_provider_from_path(request.url.path)
+    if provider is not None:
+        record_oauth_rate_limit_burst_metric(provider)
+
+    response = _rate_limit_exceeded_handler(request, exc)
+    if inspect.isawaitable(response):
+        return await response
+    return response

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -5,12 +5,11 @@ from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from slowapi import _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
 
 from app.accounts import router as accounts_router
 from app.auth import router as auth_router
-from app.auth.rate_limit import limiter
+from app.auth.rate_limit import limiter, oauth_rate_limit_exceeded_handler
 from app.config import get_settings
 from app.db.session import async_session_factory
 from app.metrics import router as metrics_router
@@ -95,7 +94,7 @@ Set `MOCK_OAUTH_ENABLED=1` to enable mock OAuth endpoints for testing without re
 
 # Rate limiter
 app.state.limiter = limiter
-app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+app.add_exception_handler(RateLimitExceeded, oauth_rate_limit_exceeded_handler)
 
 # CORS
 app.add_middleware(

--- a/api/app/metrics.py
+++ b/api/app/metrics.py
@@ -13,6 +13,8 @@ from app.db.session import get_db
 router = APIRouter(tags=["metrics"])
 _oauth_failure_counts: dict[tuple[str, str], int] = defaultdict(int)
 _oauth_failure_counts_lock = Lock()
+_oauth_rate_limit_burst_counts: dict[str, int] = defaultdict(int)
+_oauth_rate_limit_burst_counts_lock = Lock()
 
 
 def record_oauth_failure_metric(provider: str, reason: str) -> None:
@@ -34,6 +36,28 @@ def render_oauth_failure_metrics_lines() -> list[str]:
     return [
         f'yesod_oauth_failures_total{{provider="{provider}",reason="{reason}"}} {count}'
         for (provider, reason), count in sorted(oauth_failure_snapshot.items())
+    ]
+
+
+def record_oauth_rate_limit_burst_metric(provider: str) -> None:
+    """Record OAuth burst rate-limit events grouped by provider."""
+    with _oauth_rate_limit_burst_counts_lock:
+        _oauth_rate_limit_burst_counts[provider] += 1
+
+
+def reset_oauth_rate_limit_burst_metrics() -> None:
+    """Reset OAuth burst rate-limit counters. Used by tests for deterministic assertions."""
+    with _oauth_rate_limit_burst_counts_lock:
+        _oauth_rate_limit_burst_counts.clear()
+
+
+def render_oauth_rate_limit_burst_metrics_lines() -> list[str]:
+    """Render OAuth burst rate-limit metric lines from in-memory counters."""
+    with _oauth_rate_limit_burst_counts_lock:
+        oauth_rate_limit_snapshot = dict(_oauth_rate_limit_burst_counts)
+    return [
+        f'yesod_oauth_rate_limit_burst_total{{provider="{provider}"}} {count}'
+        for provider, count in sorted(oauth_rate_limit_snapshot.items())
     ]
 
 
@@ -78,6 +102,7 @@ async def metrics(db: AsyncSession = Depends(get_db)):
     metrics_output.append(f"yesod_deleted_users_pending {deleted_users}")
 
     metrics_output.extend(render_oauth_failure_metrics_lines())
+    metrics_output.extend(render_oauth_rate_limit_burst_metrics_lines())
 
     # Login stats (last 24h) - only if audit schema exists
     try:

--- a/api/tests/test_auth_refresh.py
+++ b/api/tests/test_auth_refresh.py
@@ -14,6 +14,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth.tokens import create_access_token, create_refresh_token, hash_refresh_token
 from app.main import app
+from app.metrics import (
+    render_oauth_rate_limit_burst_metrics_lines,
+    reset_oauth_rate_limit_burst_metrics,
+)
 from app.models.refresh_token import RefreshToken
 from app.models.user import User, UserEmail
 
@@ -238,3 +242,39 @@ async def test_refresh_rate_limited_response_includes_retry_after_header(client:
     assert retry_after is not None
     assert retry_after.isdigit()
     assert int(retry_after) >= 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.enable_rate_limiter
+async def test_oauth_provider_rate_limit_records_burst_metric(client: AsyncClient):
+    """OAuth provider endpoint 429 should increment provider-level burst metric."""
+    reset_oauth_rate_limit_burst_metrics()
+    limiter = app.state.limiter
+    limit_item = RateLimitItemPerMinute(10, 1)
+    synthetic_limit = Limit(
+        limit=limit_item,
+        key_func=limiter._key_func,
+        scope=None,
+        per_method=False,
+        methods=None,
+        error_message=None,
+        exempt_when=None,
+        cost=1,
+        override_defaults=False,
+    )
+
+    def raise_rate_limit(request, endpoint_func=None, in_middleware=True):
+        request.state.view_rate_limit = (limit_item, ["test-client"])
+        raise RateLimitExceeded(synthetic_limit)
+
+    reset_at = int(time.time()) + 60
+    with (
+        patch.object(limiter, "_check_request_limit", side_effect=raise_rate_limit),
+        patch.object(limiter.limiter, "get_window_stats", return_value=(reset_at, 0)),
+    ):
+        response = await client.get("/api/v1/auth/google")
+
+    assert response.status_code == 429
+    assert 'yesod_oauth_rate_limit_burst_total{provider="google"} 1' in (
+        render_oauth_rate_limit_burst_metrics_lines()
+    )

--- a/docs/api/auth.md
+++ b/docs/api/auth.md
@@ -25,6 +25,15 @@
 
 ---
 
+## レート制限メトリクス
+
+`GET /metrics` では OAuth 関連のレート制限を次のメトリクスで確認できます。
+
+- `yesod_oauth_rate_limit_burst_total{provider="<provider>"}`: provider 別に 429 が返った回数
+- `yesod_oauth_failures_total{provider="<provider>",reason="<reason>"}`: OAuth 処理失敗回数（既存）
+
+---
+
 ## 認可エラー方針（401 / 403）
 
 認証・認可に関するステータスコードは次の方針で使い分けます。


### PR DESCRIPTION
## 概要
- OAuth provider 別の 429 バースト制限カウンタ `yesod_oauth_rate_limit_burst_total{provider=...}` を追加
- RateLimitExceeded ハンドラで `/api/v1/auth/<provider>` を解析し provider 単位でメトリクス記録
- 既存の 429 応答仕様は維持（slowapi 既定ハンドラへ委譲）
- docs にメトリクス定義を追記

## テスト
- `cd api && . .venv/bin/activate && pytest -q tests/test_auth_refresh.py -k "oauth_provider_rate_limit_records_burst_metric"`
- `cd api && . .venv/bin/activate && pytest -q tests/test_health.py tests/test_auth_refresh.py`

Closes #345
