### PR TITLE
[Bench-80][07] Token refresh失敗時の再試行上限を設定可能にする

### DIFF
--- a/api/app/auth/router.py
+++ b/api/app/auth/router.py
@@ -64,6 +64,25 @@ def _get_client_info(request: Request) -> tuple[str | None, str | None]:
     return device_info, ip_address
 
 
+async def _rotate_refresh_token_with_retry(
+    db: AsyncSession,
+    refresh_token: str,
+    device_info: str | None,
+    ip_address: str | None,
+):
+    """Retry refresh token rotation on transient failures."""
+    max_retries = max(0, int(getattr(settings, "TOKEN_REFRESH_MAX_RETRIES", 3)))
+    last_error = None
+    for _attempt in range(max_retries + 1):
+        try:
+            return await rotate_refresh_token(db, refresh_token, device_info, ip_address)
+        except Exception as exc:  # noqa: BLE001
+            last_error = exc
+    if last_error is not None:
+        raise last_error
+    return None
+
+
 def _ensure_provider_enabled(provider: str) -> None:
     """Ensure OAuth provider credentials exist before starting auth flow."""
     credential_fields = OAUTH_PROVIDER_CREDENTIAL_FIELDS.get(provider)
@@ -874,7 +893,9 @@ async def refresh_tokens(
     """Refresh access token using refresh token (with rotation)."""
     device_info, ip_address = _get_client_info(request)
 
-    result = await rotate_refresh_token(db, body.refresh_token, device_info, ip_address)
+    result = await _rotate_refresh_token_with_retry(
+        db, body.refresh_token, device_info, ip_address
+    )
 
     if not result:
         await AuditLogger.log_event(

--- a/api/app/config.py
+++ b/api/app/config.py
@@ -46,6 +46,7 @@ class Settings:
     JWT_ALGORITHM: str = "HS256"
     ACCESS_TOKEN_LIFETIME_SECONDS: int = int(os.getenv("ACCESS_TOKEN_LIFETIME_SECONDS", "900"))
     REFRESH_TOKEN_LIFETIME_DAYS: int = int(os.getenv("REFRESH_TOKEN_LIFETIME_DAYS", "7"))
+    TOKEN_REFRESH_MAX_RETRIES: int = int(os.getenv("TOKEN_REFRESH_MAX_RETRIES", "3"))
 
     # OAuth State TTL (seconds)
     OAUTH_STATE_TTL: int = int(os.getenv("OAUTH_STATE_TTL", "300"))

--- a/api/tests/test_auth_refresh.py
+++ b/api/tests/test_auth_refresh.py
@@ -1,8 +1,10 @@
 """Refresh token endpoint tests."""
 
 import time
+import importlib
+from types import SimpleNamespace
 from datetime import UTC, datetime, timedelta
-from unittest.mock import PropertyMock, patch
+from unittest.mock import AsyncMock, PropertyMock, patch
 
 import pytest
 from httpx import AsyncClient
@@ -16,6 +18,8 @@ from app.auth.tokens import create_access_token, create_refresh_token, hash_refr
 from app.main import app
 from app.models.refresh_token import RefreshToken
 from app.models.user import User, UserEmail
+
+auth_router = importlib.import_module("app.auth.router")
 
 
 class FrozenDateTime(datetime):
@@ -238,3 +242,35 @@ async def test_refresh_rate_limited_response_includes_retry_after_header(client:
     assert retry_after is not None
     assert retry_after.isdigit()
     assert int(retry_after) >= 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("max_retries", "expected_attempts"),
+    [
+        (1, 2),
+        (3, 4),
+        (5, 6),
+    ],
+)
+async def test_refresh_retry_limit_is_configurable(monkeypatch, max_retries: int, expected_attempts: int):
+    rotate_mock = AsyncMock(side_effect=RuntimeError("temporary failure"))
+    monkeypatch.setattr(auth_router, "rotate_refresh_token", rotate_mock)
+    monkeypatch.setattr(auth_router.settings, "TOKEN_REFRESH_MAX_RETRIES", max_retries)
+
+    with pytest.raises(RuntimeError, match="temporary failure"):
+        await auth_router._rotate_refresh_token_with_retry(None, "token", None, None)
+
+    assert rotate_mock.await_count == expected_attempts
+
+
+@pytest.mark.asyncio
+async def test_refresh_retry_limit_uses_default_when_setting_missing(monkeypatch):
+    rotate_mock = AsyncMock(side_effect=RuntimeError("temporary failure"))
+    monkeypatch.setattr(auth_router, "rotate_refresh_token", rotate_mock)
+    monkeypatch.setattr(auth_router, "settings", SimpleNamespace())
+
+    with pytest.raises(RuntimeError, match="temporary failure"):
+        await auth_router._rotate_refresh_token_with_retry(None, "token", None, None)
+
+    assert rotate_mock.await_count == 4

--- a/docs/api/auth.md
+++ b/docs/api/auth.md
@@ -95,6 +95,9 @@ curl -H "Authorization: Bearer <access_token>" \
 
 ## トークンリフレッシュ
 
+`/api/v1/auth/refresh` の内部再試行上限は `TOKEN_REFRESH_MAX_RETRIES`（既定: `3`）で設定できます。
+一時的な DB 障害などで refresh 処理が失敗した場合、この上限まで再試行します。
+
 ```bash
 POST /api/v1/auth/refresh
 Content-Type: application/json


### PR DESCRIPTION
## 概要
- `/api/v1/auth/refresh` の内部再試行上限を `TOKEN_REFRESH_MAX_RETRIES` で設定可能化（既定: 3）
- refresh トークンローテーション処理に再試行ヘルパーを追加
- 境界値 (1/3/5) および既定値フォールバックのテストを追加
- 認証APIドキュメントへ設定値を追記

## テスト
- `cd api && ../.venv/bin/python -m pytest -q tests/test_auth_refresh.py`

Closes #318
