### PR TITLE
fix(auth): normalize oauth provider name resolution (#319)

### DIFF
--- a/api/app/auth/router.py
+++ b/api/app/auth/router.py
@@ -64,9 +64,15 @@ def _get_client_info(request: Request) -> tuple[str | None, str | None]:
     return device_info, ip_address
 
 
+def _normalize_provider_name(provider: str) -> str:
+    """Normalize provider input to support case-insensitive resolution."""
+    return provider.strip().lower()
+
+
 def _ensure_provider_enabled(provider: str) -> None:
     """Ensure OAuth provider credentials exist before starting auth flow."""
-    credential_fields = OAUTH_PROVIDER_CREDENTIAL_FIELDS.get(provider)
+    normalized_provider = _normalize_provider_name(provider)
+    credential_fields = OAUTH_PROVIDER_CREDENTIAL_FIELDS.get(normalized_provider)
     if credential_fields is None:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -83,7 +89,7 @@ def _ensure_provider_enabled(provider: str) -> None:
     raise HTTPException(
         status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
         detail=(
-            f"OAuth provider '{provider}' is disabled. "
+            f"OAuth provider '{normalized_provider}' is disabled. "
             f"Configure {client_id_field} and {client_secret_field}."
         ),
     )

--- a/api/tests/test_auth_oauth_provider_disabled.py
+++ b/api/tests/test_auth_oauth_provider_disabled.py
@@ -42,3 +42,27 @@ def test_oauth_unknown_provider_raises_400():
 
     assert exc_info.value.status_code == 400
     assert exc_info.value.detail == "Unsupported OAuth provider 'unknown'."
+
+
+@pytest.mark.parametrize("provider_variant", ["GitHub", "GITHUB", "gItHuB"])
+def test_oauth_provider_name_is_case_insensitive(monkeypatch, provider_variant: str):
+    """Provider name resolution should ignore letter case."""
+    monkeypatch.setattr(auth_router_module.settings, "GITHUB_CLIENT_ID", "")
+    monkeypatch.setattr(auth_router_module.settings, "GITHUB_CLIENT_SECRET", "")
+
+    with pytest.raises(auth_router_module.HTTPException) as exc_info:
+        auth_router_module._ensure_provider_enabled(provider_variant)
+
+    assert exc_info.value.status_code == 503
+    assert exc_info.value.detail == (
+        "OAuth provider 'github' is disabled. "
+        "Configure GITHUB_CLIENT_ID and GITHUB_CLIENT_SECRET."
+    )
+
+
+def test_oauth_provider_case_variant_passes_when_credentials_exist(monkeypatch):
+    """Case variant should resolve to the same provider when configured."""
+    monkeypatch.setattr(auth_router_module.settings, "GITHUB_CLIENT_ID", "dummy-id")
+    monkeypatch.setattr(auth_router_module.settings, "GITHUB_CLIENT_SECRET", "dummy-secret")
+
+    auth_router_module._ensure_provider_enabled("GitHub")


### PR DESCRIPTION
## Summary
- normalize provider name input in `_ensure_provider_enabled` to lowercase
- keep unsupported-provider 400 contract while allowing case-insensitive known provider resolution
- add unit tests for mixed-case provider inputs and configured-provider regression

## Test
- `cd api && pytest -q tests/test_auth_oauth_provider_disabled.py`

## Impact
- OAuth導入時の設定値に大小文字ゆれがあっても既知providerとして解決可能
- 未知providerは従来どおり400で明示エラー