### PR TITLE
fix(webhooks): include hash algo in signature failure logs

### DIFF
--- a/api/app/webhooks/worker.py
+++ b/api/app/webhooks/worker.py
@@ -36,6 +36,7 @@ class DeliveryResult:
     error_message: str | None = None
     latency_ms: int | None = None
     attempt_count: int = 1
+    signature_algorithm: str | None = None
 
 
 class WebhookWorker:
@@ -158,9 +159,13 @@ class WebhookWorker:
             # Don't retry on 4xx errors (client errors)
             if result.http_status and 400 <= result.http_status < 500:
                 logger.warning(
-                    "Webhook delivery to %s failed with client error %d, not retrying",
+                    (
+                        "Webhook delivery to %s failed with client error %d, not retrying "
+                        "(signature_algo=%s)"
+                    ),
                     endpoint.id,
                     result.http_status,
+                    result.signature_algorithm,
                 )
                 break
 
@@ -168,7 +173,7 @@ class WebhookWorker:
             logger.error(
                 (
                     "%s delivery_id=%s endpoint_id=%s event_id=%s attempts=%d "
-                    "max_attempts=%d http_status=%s error=%s"
+                    "max_attempts=%d signature_algo=%s http_status=%s error=%s"
                 ),
                 MAX_RETRY_EXHAUSTED_LOG_KEY,
                 delivery_id,
@@ -176,6 +181,7 @@ class WebhookWorker:
                 event.event_id,
                 result.attempt_count,
                 max_retries + 1,
+                result.signature_algorithm,
                 result.http_status,
                 result.error_message,
             )
@@ -204,6 +210,7 @@ class WebhookWorker:
             event.event_type,
             endpoint.id,
         )
+        signature_algorithm = WebhookSigner.SIGNATURE_PREFIX.removesuffix("=")
 
         start_time = time.time()
 
@@ -222,6 +229,7 @@ class WebhookWorker:
                     success=True,
                     http_status=response.status_code,
                     latency_ms=latency_ms,
+                    signature_algorithm=signature_algorithm,
                 )
             else:
                 return DeliveryResult(
@@ -229,17 +237,20 @@ class WebhookWorker:
                     http_status=response.status_code,
                     error_message=response.text[:500] if response.text else None,
                     latency_ms=latency_ms,
+                    signature_algorithm=signature_algorithm,
                 )
 
         except httpx.TimeoutException:
             return DeliveryResult(
                 success=False,
                 error_message="Request timeout",
+                signature_algorithm=signature_algorithm,
             )
         except httpx.RequestError as e:
             return DeliveryResult(
                 success=False,
                 error_message=str(e)[:500],
+                signature_algorithm=signature_algorithm,
             )
 
     async def _log_delivery(

--- a/api/tests/test_webhook_worker.py
+++ b/api/tests/test_webhook_worker.py
@@ -147,6 +147,47 @@ class TestWebhookWorkerRetry:
             assert result.attempt_count == 1
 
     @pytest.mark.asyncio
+    async def test_no_retry_on_4xx_logs_signature_algorithm(
+        self,
+        caplog,
+        sample_endpoint,
+        sample_event,
+        sample_config,
+    ):
+        """4xx の失敗ログに署名アルゴリズム名を含める。"""
+        worker = WebhookWorker()
+
+        mock_response = AsyncMock()
+        mock_response.status_code = 401
+        mock_response.text = "invalid signature"
+
+        with (
+            patch(
+                "app.webhooks.worker.WebhookConfigLoader.get_config",
+                return_value=sample_config,
+            ),
+            patch("httpx.AsyncClient") as mock_client_class,
+            caplog.at_level("WARNING", logger="app.webhooks.worker"),
+        ):
+            mock_client = AsyncMock()
+            mock_client.post = AsyncMock(return_value=mock_response)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=None)
+            mock_client_class.return_value = mock_client
+
+            result = await worker._deliver_to_endpoint(sample_event, sample_endpoint)
+
+        assert result.success is False
+        assert result.attempt_count == 1
+        assert result.signature_algorithm == "sha256"
+        client_error_log = next(
+            record.getMessage()
+            for record in caplog.records
+            if "failed with client error" in record.getMessage()
+        )
+        assert "signature_algo=sha256" in client_error_log
+
+    @pytest.mark.asyncio
     async def test_retry_on_5xx(self, sample_endpoint, sample_event, sample_config):
         """Test that 5xx errors trigger retries."""
         worker = WebhookWorker()
@@ -229,6 +270,7 @@ class TestWebhookWorkerRetry:
         assert f"endpoint_id={sample_endpoint.id}" in exhausted_log
         assert f"event_id={sample_event.event_id}" in exhausted_log
         assert "attempts=3" in exhausted_log
+        assert "signature_algo=sha256" in exhausted_log
         assert "error=Server Error" in exhausted_log
 
 


### PR DESCRIPTION
## Summary
- add `signature_algorithm` to delivery result and propagate it through failure paths
- include `signature_algo` in 4xx no-retry warning and retry-exhausted error logs
- add abnormal-case test to assert algorithm is present in failure logs

## Tests
- `cd api && . ./.venv/bin/activate && pytest -q tests/test_webhook_worker.py::TestWebhookWorkerRetry::test_no_retry_on_4xx_logs_signature_algorithm`
- `cd api && . ./.venv/bin/activate && pytest -q tests/test_webhook_worker.py`

Refs #320