### PR TITLE
Fix #321: missing bearer token response consistency

### DIFF
--- a/api/app/auth/jwt.py
+++ b/api/app/auth/jwt.py
@@ -15,14 +15,28 @@ from app.models import User
 from .tokens import decode_access_token
 
 settings = get_settings()
-security = HTTPBearer()
+security = HTTPBearer(auto_error=False)
+
+MISSING_BEARER_TOKEN_DETAIL = "Not authenticated"
+
+
+def _missing_bearer_token_exception() -> HTTPException:
+    """Return a fixed auth error for missing Authorization bearer token."""
+    return HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail=MISSING_BEARER_TOKEN_DETAIL,
+        headers={"WWW-Authenticate": "Bearer"},
+    )
 
 
 async def get_current_user(
-    credentials: HTTPAuthorizationCredentials = Depends(security),
+    credentials: HTTPAuthorizationCredentials | None = Depends(security),
     db: AsyncSession = Depends(get_db),
 ) -> User:
     """Get the current authenticated user."""
+    if credentials is None:
+        raise _missing_bearer_token_exception()
+
     token = credentials.credentials
     payload = decode_access_token(token)
 

--- a/api/tests/test_auth_missing_bearer_token.py
+++ b/api/tests/test_auth_missing_bearer_token.py
@@ -1,0 +1,26 @@
+"""Missing bearer token contract tests across protected endpoints."""
+
+import pytest
+from httpx import AsyncClient
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("method", "path", "kwargs"),
+    [
+        ("get", "/api/v1/users/me", {}),
+        ("get", "/api/v1/sessions", {}),
+        ("delete", "/api/v1/sessions", {}),
+        ("get", "/api/v1/accounts", {}),
+        ("post", "/api/v1/auth/logout", {"json": {"refresh_token": "dummy"}}),
+    ],
+)
+async def test_missing_bearer_token_returns_fixed_contract(
+    client: AsyncClient, method: str, path: str, kwargs: dict
+):
+    """All protected endpoints should return the same 401 contract when token is missing."""
+    response = await getattr(client, method)(path, **kwargs)
+
+    assert response.status_code == 401
+    assert response.json() == {"detail": "Not authenticated"}
+


### PR DESCRIPTION
## 概要
- `HTTPBearer(auto_error=False)` に変更し、missing bearer token 時の 401 応答を共通関数で固定化
- 保護 endpoint 横断の回帰テストを追加（users/sessions/accounts/logout）
- 既存の invalid token 応答は維持

## テスト
- `cd api && UV_CACHE_DIR=/tmp/uv-cache uv pip install --python .venv/bin/python -r requirements.txt`
- `cd api && UV_CACHE_DIR=/tmp/uv-cache uv run pytest -q tests/test_auth_missing_bearer_token.py tests/test_sessions.py tests/test_users_me_auth.py`

## 公開時の影響
- missing bearer token 応答が全保護 endpoint で `401 {"detail":"Not authenticated"}` に統一されます
- OAuth 導入時のクライアント実装で endpoint ごとの分岐が不要になり、セルフホスト運用時の障害切り分けが簡単になります
- 既存の token 無効/期限切れ系（`Invalid or expired token`）の挙動は変わりません
