### PR TITLE
[Bench-80][11] Warn when admin session SameSite is unset

### DIFF
--- a/admin/app.py
+++ b/admin/app.py
@@ -5,9 +5,10 @@ import graphviz
 import hashlib
 import hmac
 import base64
+import logging
 from pathlib import Path
 from datetime import datetime, timedelta, timezone
-from config import settings
+from config import settings, warn_if_session_cookie_samesite_unset
 from i18n import (
     Translator,
     SUPPORTED_LANGUAGES,
@@ -18,6 +19,7 @@ import valkey_client
 
 # Path to static icons directory
 ICONS_DIR = Path(__file__).parent / "static" / "icons"
+logger = logging.getLogger(__name__)
 
 
 def load_svg_icon(name: str) -> str:
@@ -33,6 +35,12 @@ st.set_page_config(
     page_title="YESOD Admin",
     page_icon="🔐",
     layout="wide",
+)
+
+warn_if_session_cookie_samesite_unset(
+    logger,
+    environment=settings.ENVIRONMENT,
+    session_cookie_samesite=settings.SESSION_COOKIE_SAMESITE,
 )
 
 

--- a/admin/config.py
+++ b/admin/config.py
@@ -1,5 +1,6 @@
 """Admin configuration."""
 import os
+from typing import Protocol
 
 
 def read_secret(name: str, default: str = "") -> str:
@@ -26,9 +27,32 @@ class Settings:
     
     # Session persistence (hours)
     SESSION_EXPIRY_HOURS: int = int(os.getenv("SESSION_EXPIRY_HOURS", "24"))
+    SESSION_COOKIE_SAMESITE: str = os.getenv("SESSION_COOKIE_SAMESITE", "").strip()
 
     # Default language (en, ja, fr, ko, de)
     DEFAULT_LANGUAGE: str = os.getenv("DEFAULT_LANGUAGE", "en")
 
 
 settings = Settings()
+
+
+class WarningLogger(Protocol):
+    def warning(self, msg: str, *args) -> None: ...
+
+
+def warn_if_session_cookie_samesite_unset(
+    logger: WarningLogger,
+    *,
+    environment: str,
+    session_cookie_samesite: str,
+) -> bool:
+    """Emit warning when SameSite is not configured for admin session cookie."""
+    if session_cookie_samesite.strip():
+        return False
+
+    env_name = environment.strip() or "production"
+    logger.warning(
+        "SESSION_COOKIE_SAMESITE is not configured for admin session cookie (environment=%s)",
+        env_name,
+    )
+    return True

--- a/admin/tests/test_session_cookie_samesite.py
+++ b/admin/tests/test_session_cookie_samesite.py
@@ -1,0 +1,38 @@
+"""Tests for SESSION_COOKIE_SAMESITE warning behavior."""
+import unittest
+from unittest.mock import Mock
+
+from config import warn_if_session_cookie_samesite_unset
+
+
+class SessionCookieSameSiteWarningTests(unittest.TestCase):
+    def test_warns_when_samesite_is_unset(self) -> None:
+        logger = Mock()
+
+        warned = warn_if_session_cookie_samesite_unset(
+            logger,
+            environment="staging",
+            session_cookie_samesite="",
+        )
+
+        self.assertTrue(warned)
+        logger.warning.assert_called_once_with(
+            "SESSION_COOKIE_SAMESITE is not configured for admin session cookie (environment=%s)",
+            "staging",
+        )
+
+    def test_does_not_warn_when_samesite_is_set(self) -> None:
+        logger = Mock()
+
+        warned = warn_if_session_cookie_samesite_unset(
+            logger,
+            environment="staging",
+            session_cookie_samesite="lax",
+        )
+
+        self.assertFalse(warned)
+        logger.warning.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add SESSION_COOKIE_SAMESITE setting for admin config
- log warning only when SameSite is unset, with environment name
- add unit tests for unset/set behavior

## Test
- cd admin && python3 -m unittest -v tests/test_session_cookie_samesite.py
- cd api && .venv/bin/python -m pytest -q tests/test_mock_oauth.py

Refs #322
