### PR TITLE
fix: clarify pagination overflow error for sessions API (closes #323)

### DIFF
--- a/api/app/sessions/router.py
+++ b/api/app/sessions/router.py
@@ -14,15 +14,27 @@ from app.models import RefreshToken, User
 from .schemas import RevokeResponse, SessionListResponse, SessionResponse
 
 router = APIRouter(prefix="/sessions", tags=["sessions"])
+SESSIONS_LIMIT_MAX = 1000
+SESSIONS_LIMIT_EXCEEDED_CODE = "SESSIONS_LIMIT_EXCEEDED"
 
 
 @router.get("", response_model=SessionListResponse)
 async def list_sessions(
     current_user: User = Depends(get_current_user),
-    limit: int = Query(100, ge=1, le=1000, description="Maximum results"),
+    limit: int = Query(100, ge=1, description="Maximum results"),
     db: AsyncSession = Depends(get_db),
 ):
     """List all active sessions for current user."""
+    if limit > SESSIONS_LIMIT_MAX:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "code": SESSIONS_LIMIT_EXCEEDED_CODE,
+                "message": f"limit must be less than or equal to {SESSIONS_LIMIT_MAX}",
+                "max_limit": SESSIONS_LIMIT_MAX,
+            },
+        )
+
     result = await db.execute(
         select(RefreshToken)
         .where(

--- a/api/tests/test_sessions.py
+++ b/api/tests/test_sessions.py
@@ -101,4 +101,27 @@ async def test_sessions_list_rejects_limit_over_maximum(client: AsyncClient):
         headers={"Authorization": f"Bearer {token}"},
     )
 
-    assert response.status_code == 422
+    assert response.status_code == 400
+    assert response.json() == {
+        "detail": {
+            "code": "SESSIONS_LIMIT_EXCEEDED",
+            "message": "limit must be less than or equal to 1000",
+            "max_limit": 1000,
+        }
+    }
+
+
+@pytest.mark.asyncio
+async def test_sessions_list_accepts_limit_at_maximum(client: AsyncClient):
+    """Session list should accept limit at maximum boundary."""
+    login_response = await client.get("/api/v1/auth/mock/login")
+    assert login_response.status_code == 200
+
+    token = login_response.json()["access_token"]
+
+    response = await client.get(
+        "/api/v1/sessions?limit=1000",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert response.status_code == 200

--- a/docs/api/users.md
+++ b/docs/api/users.md
@@ -34,6 +34,18 @@ curl -sS -H "Authorization: Bearer ${TOKEN}" \
 2. `.items | length` が指定した `limit` を超えない
 3. 同一トークンで `GET /api/v1/users/me` も継続して成功する
 
+上限超過時（`limit > 1000`）は `400 Bad Request` を返し、専用エラーコードと上限値を本文に含みます。
+
+```json
+{
+  "detail": {
+    "code": "SESSIONS_LIMIT_EXCEEDED",
+    "message": "limit must be less than or equal to 1000",
+    "max_limit": 1000
+  }
+}
+```
+
 !!! tip "切り分け導線"
     `limit=1/100` で期待どおりにならない場合は、[トラブルシューティングの確認手順](../help/troubleshooting.md#users-pagination-limit-check) を参照してください。
 


### PR DESCRIPTION
## Summary
- `/api/v1/sessions` の `limit` 上限超過時に専用エラーコード `SESSIONS_LIMIT_EXCEEDED` を返すように変更
- エラーレスポンス本文に `max_limit: 1000` を含め、利用者が修正しやすいメッセージに統一
- 境界値テスト（`limit=1000` 成功、`limit=1001` 専用エラー）を追加し、`docs/api/users.md` に仕様を追記

## Test
- `UV_CACHE_DIR=/tmp/uv-cache-yesod-auth uv run --python api/.venv/bin/python pytest -q api/tests/test_sessions.py`

## Public impact
- API利用者は上限超過時に専用コードで原因判別できるようになります。
- OAuth導入やセルフホスト運用時の API 連携診断がしやすくなります（OSS向けドキュメント記載あり）。
