### PR TITLE
docs: add provider env var matrix to OAuth index

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -8,7 +8,7 @@
 ## 前提条件
 
 - Docker & Docker Compose
-- Google Cloud ConsoleまたはDiscord Developer Portalのアカウント
+- 利用するOAuth providerの開発者アカウント（Google/Discord/GitHubなど）
 
 ## 1. リポジトリのクローン
 
@@ -29,6 +29,8 @@ cp secrets/jwt_secret.txt.example secrets/jwt_secret.txt
 ```
 
 各ファイルを編集して、OAuthプロバイダーから取得したクレデンシャルを設定します。
+
+providerごとの必須 secret 名は [OAuth設定ハブの一覧](guides/oauth/index.md#provider別必須環境変数一覧) を参照してください。
 
 !!! tip "provider追加時は先にチェック"
     新しい OAuth provider を追加する場合は、先に [OAuth provider追加時の事前チェック](installation.md#oauth-provider追加時の事前チェック) を実施してから secrets を作成してください。

--- a/docs/guides/oauth/index.md
+++ b/docs/guides/oauth/index.md
@@ -15,6 +15,25 @@ YESOD Authは複数のOAuthプロバイダーに対応しています。各プ�
 | [Slack](slack.md) | - | ✅ | ✅ | |
 | [Twitch](twitch.md) | - | ✅ | ❌ | [Helix API](https://dev.twitch.tv/docs/api/){:target="_blank"} |
 
+## provider別必須環境変数一覧
+
+実OAuthで必要なのは、`jwt_secret` と「有効化して使う provider 分の `*_client_id` / `*_client_secret`」だけです。
+`MOCK_OAUTH_ENABLED=1` はローカル疎通用であり、実運用では `MOCK_OAUTH_ENABLED=0` を使用します。
+
+| provider | 必須 secret 名 | 環境変数名（secret未使用時） | 個別ガイド |
+|---|---|---|---|
+| Google | `google_client_id` / `google_client_secret` | `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` | [google.md](google.md) |
+| GitHub | `github_client_id` / `github_client_secret` | `GITHUB_CLIENT_ID` / `GITHUB_CLIENT_SECRET` | [github.md](github.md) |
+| Discord | `discord_client_id` / `discord_client_secret` | `DISCORD_CLIENT_ID` / `DISCORD_CLIENT_SECRET` | [discord.md](discord.md) |
+| X (Twitter) | `x_client_id` / `x_client_secret` | `X_CLIENT_ID` / `X_CLIENT_SECRET` | [x.md](x.md) |
+| LinkedIn | `linkedin_client_id` / `linkedin_client_secret` | `LINKEDIN_CLIENT_ID` / `LINKEDIN_CLIENT_SECRET` | [linkedin.md](linkedin.md) |
+| Facebook | `facebook_client_id` / `facebook_client_secret` | `FACEBOOK_CLIENT_ID` / `FACEBOOK_CLIENT_SECRET` | [facebook.md](facebook.md) |
+| Slack | `slack_client_id` / `slack_client_secret` | `SLACK_CLIENT_ID` / `SLACK_CLIENT_SECRET` | [slack.md](slack.md) |
+| Twitch | `twitch_client_id` / `twitch_client_secret` | `TWITCH_CLIENT_ID` / `TWITCH_CLIENT_SECRET` | [twitch.md](twitch.md) |
+
+一覧の定義元は [インストールガイド（OAuth認証情報）](../../installation.md#oauth-credentials) です。
+クイックスタートでの初回導入順は [getting-started](../../getting-started.md#2-シークレットファイルの作成) を参照してください。
+
 ### PKCEについて
 
 PKCE（Proof Key for Code Exchange）は、認可コード横取り攻撃を防ぐためのセキュリティ拡張です。

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -391,6 +391,7 @@ rg -n "REFRESH_TOKEN_LIFETIME_DAYS|/api/v1/auth/refresh|再ログイン" docs/in
 Docker Secretsまたは環境変数で設定：
 
 初回導入時は、設定後に [初回導入チェックリスト](getting-started.md#初回導入チェックリスト) を順に実行して動作確認してください。
+provider別の対応表は [OAuth設定ハブの一覧](guides/oauth/index.md#provider別必須環境変数一覧) を参照してください。
 
 | シークレット名 | 説明 |
 |---------------|------|


### PR DESCRIPTION
## Summary
- docs/guides/oauth/index.md に provider別必須環境変数一覧を追加
- docs/installation.md に一覧への導線を追加
- docs/getting-started.md の前提条件文言を provider一般化し、一覧への導線を追加

## Validation
- 最小再現: ============================= test session starts ==============================
platform darwin -- Python 3.14.3, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/shiroguchi/.codex/worktrees/43be/yesod-auth/api
configfile: pytest.ini (WARNING: ignoring pytest config in pyproject.toml!)
plugins: anyio-4.12.1, respx-0.22.0, hypothesis-6.151.9, asyncio-1.3.0
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=function, asyncio_default_test_loop_scope=function
collected 12 items

tests/test_users_delete_account.py .                                     [  8%]
tests/test_config.py ...........                                         [100%]

============================== 12 passed in 0.28s ==============================
- 回帰: ============================= test session starts ==============================
platform darwin -- Python 3.14.3, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/shiroguchi/.codex/worktrees/43be/yesod-auth/api
configfile: pytest.ini (WARNING: ignoring pytest config in pyproject.toml!)
testpaths: tests
plugins: anyio-4.12.1, respx-0.22.0, hypothesis-6.151.9, asyncio-1.3.0
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=function, asyncio_default_test_loop_scope=function
collected 192 items

tests/test_accounts.py .                                                 [  0%]
tests/test_auth_logout.py .                                              [  1%]
tests/test_auth_missing_bearer_token.py .....                            [  3%]
tests/test_auth_oauth_provider_disabled.py .........                     [  8%]
tests/test_auth_refresh.py .......                                       [ 11%]
tests/test_config.py ...........                                         [ 17%]
tests/test_discord_oauth.py .............                                [ 24%]
tests/test_facebook_oauth.py ............                                [ 30%]
tests/test_github_oauth.py ................                              [ 39%]
tests/test_health.py .....                                               [ 41%]
tests/test_linkedin_oauth.py ............                                [ 47%]
tests/test_mock_oauth.py ......                                          [ 51%]
tests/test_sessions.py ......                                            [ 54%]
tests/test_sessions_api.py .                                             [ 54%]
tests/test_slack_oauth.py ................                               [ 63%]
tests/test_twitch_oauth.py ...............                               [ 70%]
tests/test_users_delete_account.py .                                     [ 71%]
tests/test_users_me_auth.py .                                            [ 71%]
tests/test_webhook_config.py .........                                   [ 76%]
tests/test_webhook_delivery.py ...                                       [ 78%]
tests/test_webhook_emitter.py .....                                      [ 80%]
tests/test_webhook_event.py ...                                          [ 82%]
tests/test_webhook_integration.py .....                                  [ 84%]
tests/test_webhook_signer.py ..........                                  [ 90%]
tests/test_webhook_worker.py ........                                    [ 94%]
tests/test_x_oauth.py ...........                                        [100%]

============================= 192 passed in 3.09s ==============================
- docs運用三点同期チェック: docs/installation.md:250:`invalid_client` が続く場合は、`secrets/*.txt` の値が実値であることを確認し、[`docs/help/troubleshooting.md` の `invalid_client` 手順](help/troubleshooting.md#invalid_client-or-401-from-provider-token-endpoint) を参照してください。
docs/installation.md:338:| `<provider>_client_id` / `<provider>_client_secret` | OAuth provider資格情報 | 該当providerで`invalid_client`や認証失敗が発生 | 有効化して使うprovider分のみ必須 |
docs/installation.md:437:   - callback 後に `invalid_client` / `Invalid or expired state` が出ないこと
docs/installation.md:449:rg -n "/api/v1/auth/\\{provider\\}/callback|invalid_client|Invalid or expired state" docs/guides/oauth/index.md docs/help/troubleshooting.md
docs/help/faq.md:38:必須なのは`jwt_secret`と、実際に有効化して使うOAuthプロバイダーの`*_client_id`/`*_client_secret`だけです。
docs/help/faq.md:100:切り分け手順は [トラブルシューティング: state mismatch 診断フロー](./troubleshooting.md#state-mismatch-flow) と [トラブルシューティング: 401 Unauthorized / invalid_client](./troubleshooting.md#401-unauthorized--invalid_client) を参照してください。  
docs/help/troubleshooting.md:16:docker compose logs api --since=30m | rg -n "Invalid state|callback|invalid_client|401"
docs/help/troubleshooting.md:128:### `401 Unauthorized` / `invalid_client`
docs/help/troubleshooting.md:131:{"detail":"OAuth callback failed: invalid_client"}
docs/help/troubleshooting.md:145:   docker compose logs --tail=100 api | rg -n "invalid_client|401|client_secret|client_id"
docs/help/troubleshooting.md:157:#### invalid_client 再発防止チェック（デプロイ前後で毎回実施）
docs/help/troubleshooting.md:169:3. API 再作成後に `invalid_client` が新規発生していないことを確認する
docs/help/troubleshooting.md:172:   docker compose logs api --since=10m | rg -n "invalid_client|401"

Closes #342