### PR TITLE
[Bench-80][14] unknown OAuth error code を metrics 化

### DIFF
--- a/api/app/auth/router.py
+++ b/api/app/auth/router.py
@@ -59,6 +59,17 @@ OAUTH_PROVIDER_CREDENTIAL_FIELDS = {
     "slack": ("SLACK_CLIENT_ID", "SLACK_CLIENT_SECRET"),
     "twitch": ("TWITCH_CLIENT_ID", "TWITCH_CLIENT_SECRET"),
 }
+KNOWN_OAUTH_CALLBACK_ERROR_CODES = {
+    "access_denied",
+    "invalid_request",
+    "invalid_client",
+    "invalid_grant",
+    "unauthorized_client",
+    "unsupported_grant_type",
+    "invalid_scope",
+    "server_error",
+    "temporarily_unavailable",
+}
 
 
 def _get_client_info(request: Request) -> tuple[str | None, str | None]:
@@ -93,6 +104,13 @@ def _normalize_callback_url(url: str) -> str:
 def _build_oauth_redirect_uri(provider: str) -> str:
     """Build canonical OAuth redirect URI for provider callback."""
     return f"{settings.API_URL.rstrip('/')}{API_V1_PREFIX}/auth/{provider}/callback"
+
+
+def _record_unknown_oauth_error_code_metric(provider: str, error_code: str) -> None:
+    """Record metric only when provider returned an unclassified OAuth error code."""
+    normalized_error_code = error_code.strip().lower()
+    if normalized_error_code and normalized_error_code not in KNOWN_OAUTH_CALLBACK_ERROR_CODES:
+        record_oauth_failure_metric(provider, "unknown_error_code")
 
 
 async def _validate_callback_url_or_raise(
@@ -388,12 +406,23 @@ async def github_login(request: Request):
 @limiter.limit("10/minute")
 async def github_callback(
     request: Request,
-    code: str,
-    state: str,
+    code: str | None = None,
+    state: str | None = None,
+    error: str | None = None,
     db: AsyncSession = Depends(get_db),
 ):
     """Handle GitHub OAuth callback."""
     device_info, ip_address = _get_client_info(request)
+
+    if error:
+        _record_unknown_oauth_error_code_metric("github", error)
+        await AuditLogger.log_login(
+            db, None, "github", False, ip_address, device_info, f"OAuth callback failed: {error}"
+        )
+        raise HTTPException(status_code=400, detail=f"OAuth callback failed: {error}")
+
+    if not code or not state:
+        raise HTTPException(status_code=400, detail="Missing code or state")
 
     # Verify and consume state
     state_data = await OAuthStateStore.get_and_delete(state)

--- a/api/tests/test_github_oauth.py
+++ b/api/tests/test_github_oauth.py
@@ -306,3 +306,35 @@ class TestGitHubOAuthCallback:
         assert response.json() == {"detail": "Invalid or expired state"}
         assert mock_log_login.await_count == 1
         assert mock_log_login.await_args.args[6] == "Invalid state [request-id=req-test-123]"
+
+    @pytest.mark.asyncio
+    async def test_callback_unknown_error_code_records_metric(self, client):
+        """Unknown OAuth error code should increment dedicated classification metric."""
+        with (
+            patch("app.auth.rate_limit.limiter._check_request_limit", return_value=None),
+            patch("app.auth.router.record_oauth_failure_metric") as mock_metric,
+            patch("app.auth.router.AuditLogger.log_login", new=AsyncMock()) as mock_log_login,
+        ):
+            response = await client.get("/api/v1/auth/github/callback?error=provider_outage&state=s1")
+
+        assert response.status_code == 400
+        assert response.json() == {"detail": "OAuth callback failed: provider_outage"}
+        mock_metric.assert_called_once_with("github", "unknown_error_code")
+        assert mock_log_login.await_count == 1
+        assert mock_log_login.await_args.args[6] == "OAuth callback failed: provider_outage"
+
+    @pytest.mark.asyncio
+    async def test_callback_known_error_code_does_not_record_unknown_metric(self, client):
+        """Known OAuth error code should not be counted as unknown classification."""
+        with (
+            patch("app.auth.rate_limit.limiter._check_request_limit", return_value=None),
+            patch("app.auth.router.record_oauth_failure_metric") as mock_metric,
+            patch("app.auth.router.AuditLogger.log_login", new=AsyncMock()) as mock_log_login,
+        ):
+            response = await client.get("/api/v1/auth/github/callback?error=access_denied&state=s1")
+
+        assert response.status_code == 400
+        assert response.json() == {"detail": "OAuth callback failed: access_denied"}
+        mock_metric.assert_not_called()
+        assert mock_log_login.await_count == 1
+        assert mock_log_login.await_args.args[6] == "OAuth callback failed: access_denied"

--- a/docs/api/auth.md
+++ b/docs/api/auth.md
@@ -31,6 +31,7 @@
 
 - `yesod_oauth_rate_limit_burst_total{provider="<provider>"}`: provider 別に 429 が返った回数
 - `yesod_oauth_failures_total{provider="<provider>",reason="<reason>"}`: OAuth 処理失敗回数（既存）
+  - `reason="unknown_error_code"`: provider callback で未知の OAuth error code を受けた回数（provider ラベル付き）
 
 ---
 
@@ -247,6 +248,7 @@ Content-Type: application/json
 | HTTP | 条件 | 原因の目安 | 対処の目安 |
 |------|------|-----------|-----------|
 | 400 | `Invalid or expired state` | state 不一致/期限切れ | 認証フローを最初から再実行 |
+| 400 | `OAuth callback failed: <error_code>` | provider が `error` を返却 | provider 側設定とエラー内容を確認（未知コードは metrics 監視） |
 | 400 | `Failed to exchange code` | 認可コード交換失敗 | provider 設定・redirect URI を確認 |
 | 400 | `Failed to get user info` | provider API 取得失敗 | provider 側障害・スコープ設定を確認 |
 | 429 | レート制限超過 | callback/API 連打 | 一定時間待って再試行 |


### PR DESCRIPTION
## 概要
- GitHub OAuth callback の `error` パラメータ処理を追加
- 既知コード以外は `yesod_oauth_failures_total{provider="github",reason="unknown_error_code"}` を加算
- callback エラー契約と metrics 説明を docs/api/auth.md に追記
- unknown/known error code の回帰テストを追加

## テスト
- `cd api && .venv/bin/python -m pytest -q tests/test_github_oauth.py tests/test_health.py`

Closes #325
