### PR TITLE
fix: deterministic OAuth provider registry initialization order

### DIFF
--- a/api/app/auth/rate_limit.py
+++ b/api/app/auth/rate_limit.py
@@ -11,20 +11,10 @@ from slowapi.util import get_remote_address
 
 from app.config import get_settings
 from app.metrics import record_oauth_rate_limit_burst_metric
+from app.oauth_providers import OAUTH_PROVIDER_ORDER
 
 settings = get_settings()
-SUPPORTED_OAUTH_PROVIDERS = frozenset(
-    {
-        "google",
-        "discord",
-        "github",
-        "x",
-        "linkedin",
-        "facebook",
-        "slack",
-        "twitch",
-    }
-)
+SUPPORTED_OAUTH_PROVIDERS = frozenset(OAUTH_PROVIDER_ORDER)
 
 # Create limiter instance
 limiter = Limiter(

--- a/api/app/auth/router.py
+++ b/api/app/auth/router.py
@@ -16,6 +16,10 @@ from app.config import get_settings
 from app.db.session import get_db
 from app.metrics import record_oauth_failure_metric
 from app.models import OAuthAccount, User
+from app.oauth_providers import (
+    OAUTH_PROVIDER_CREDENTIAL_FIELDS,
+    OAUTH_PROVIDER_ORDER,
+)
 from app.valkey import OAuthStateStore
 from app.webhooks.emitter import WebhookEmitter
 
@@ -49,16 +53,17 @@ logger = logging.getLogger(__name__)
 
 # API prefix for building URLs
 API_V1_PREFIX = "/api/v1"
-OAUTH_PROVIDER_CREDENTIAL_FIELDS = {
-    "google": ("GOOGLE_CLIENT_ID", "GOOGLE_CLIENT_SECRET"),
-    "discord": ("DISCORD_CLIENT_ID", "DISCORD_CLIENT_SECRET"),
-    "github": ("GITHUB_CLIENT_ID", "GITHUB_CLIENT_SECRET"),
-    "x": ("X_CLIENT_ID", "X_CLIENT_SECRET"),
-    "linkedin": ("LINKEDIN_CLIENT_ID", "LINKEDIN_CLIENT_SECRET"),
-    "facebook": ("FACEBOOK_CLIENT_ID", "FACEBOOK_CLIENT_SECRET"),
-    "slack": ("SLACK_CLIENT_ID", "SLACK_CLIENT_SECRET"),
-    "twitch": ("TWITCH_CLIENT_ID", "TWITCH_CLIENT_SECRET"),
-}
+
+
+def _log_provider_registry_order() -> None:
+    """Emit provider registry initialization order for diagnostics."""
+    logger.info(
+        "OAuth provider registry initialized in deterministic order: %s",
+        " -> ".join(OAUTH_PROVIDER_ORDER),
+    )
+
+
+_log_provider_registry_order()
 
 
 def _get_client_info(request: Request) -> tuple[str | None, str | None]:
@@ -1152,19 +1157,11 @@ async def mock_login(
             status_code=403, detail="Mock OAuth is disabled. Set MOCK_OAUTH_ENABLED=1 to enable."
         )
 
-    if provider not in [
-        "google",
-        "discord",
-        "github",
-        "x",
-        "linkedin",
-        "facebook",
-        "slack",
-        "twitch",
-    ]:
+    if provider not in OAUTH_PROVIDER_ORDER:
+        provider_choices = "', '".join(OAUTH_PROVIDER_ORDER[:-1])
         raise HTTPException(
             status_code=400,
-            detail="Provider must be 'google', 'discord', 'github', 'x', 'linkedin', 'facebook', 'slack', or 'twitch'",
+            detail=f"Provider must be '{provider_choices}', or '{OAUTH_PROVIDER_ORDER[-1]}'",
         )
 
     device_info, ip_address = _get_client_info(request)

--- a/api/app/config.py
+++ b/api/app/config.py
@@ -3,17 +3,9 @@
 import os
 from functools import lru_cache
 
+from app.oauth_providers import OAUTH_PROVIDER_CREDENTIAL_KEYS
+
 DEFAULT_CORS_ORIGINS = "http://localhost:3000,http://localhost:5173"
-OAUTH_PROVIDER_CREDENTIAL_KEYS: tuple[tuple[str, str], ...] = (
-    ("GOOGLE_CLIENT_ID", "GOOGLE_CLIENT_SECRET"),
-    ("DISCORD_CLIENT_ID", "DISCORD_CLIENT_SECRET"),
-    ("GITHUB_CLIENT_ID", "GITHUB_CLIENT_SECRET"),
-    ("X_CLIENT_ID", "X_CLIENT_SECRET"),
-    ("LINKEDIN_CLIENT_ID", "LINKEDIN_CLIENT_SECRET"),
-    ("FACEBOOK_CLIENT_ID", "FACEBOOK_CLIENT_SECRET"),
-    ("SLACK_CLIENT_ID", "SLACK_CLIENT_SECRET"),
-    ("TWITCH_CLIENT_ID", "TWITCH_CLIENT_SECRET"),
-)
 
 
 def read_secret(name: str, default: str = "") -> str:

--- a/api/app/oauth_providers.py
+++ b/api/app/oauth_providers.py
@@ -1,0 +1,22 @@
+"""OAuth provider registry definitions with deterministic order."""
+
+from types import MappingProxyType
+
+_OAUTH_PROVIDER_REGISTRY: tuple[tuple[str, tuple[str, str]], ...] = (
+    ("google", ("GOOGLE_CLIENT_ID", "GOOGLE_CLIENT_SECRET")),
+    ("discord", ("DISCORD_CLIENT_ID", "DISCORD_CLIENT_SECRET")),
+    ("github", ("GITHUB_CLIENT_ID", "GITHUB_CLIENT_SECRET")),
+    ("x", ("X_CLIENT_ID", "X_CLIENT_SECRET")),
+    ("linkedin", ("LINKEDIN_CLIENT_ID", "LINKEDIN_CLIENT_SECRET")),
+    ("facebook", ("FACEBOOK_CLIENT_ID", "FACEBOOK_CLIENT_SECRET")),
+    ("slack", ("SLACK_CLIENT_ID", "SLACK_CLIENT_SECRET")),
+    ("twitch", ("TWITCH_CLIENT_ID", "TWITCH_CLIENT_SECRET")),
+)
+
+OAUTH_PROVIDER_ORDER: tuple[str, ...] = tuple(
+    provider for provider, _ in _OAUTH_PROVIDER_REGISTRY
+)
+OAUTH_PROVIDER_CREDENTIAL_KEYS: tuple[tuple[str, str], ...] = tuple(
+    credential_keys for _, credential_keys in _OAUTH_PROVIDER_REGISTRY
+)
+OAUTH_PROVIDER_CREDENTIAL_FIELDS = MappingProxyType(dict(_OAUTH_PROVIDER_REGISTRY))

--- a/api/tests/test_auth_oauth_provider_disabled.py
+++ b/api/tests/test_auth_oauth_provider_disabled.py
@@ -3,25 +3,14 @@
 import importlib
 
 import pytest
+from app.oauth_providers import OAUTH_PROVIDER_CREDENTIAL_FIELDS
 
 auth_router_module = importlib.import_module("app.auth.router")
 
-PROVIDER_CREDENTIAL_FIELDS = {
-    "google": ("GOOGLE_CLIENT_ID", "GOOGLE_CLIENT_SECRET"),
-    "discord": ("DISCORD_CLIENT_ID", "DISCORD_CLIENT_SECRET"),
-    "github": ("GITHUB_CLIENT_ID", "GITHUB_CLIENT_SECRET"),
-    "x": ("X_CLIENT_ID", "X_CLIENT_SECRET"),
-    "linkedin": ("LINKEDIN_CLIENT_ID", "LINKEDIN_CLIENT_SECRET"),
-    "facebook": ("FACEBOOK_CLIENT_ID", "FACEBOOK_CLIENT_SECRET"),
-    "slack": ("SLACK_CLIENT_ID", "SLACK_CLIENT_SECRET"),
-    "twitch": ("TWITCH_CLIENT_ID", "TWITCH_CLIENT_SECRET"),
-}
-
-
-@pytest.mark.parametrize("provider", list(PROVIDER_CREDENTIAL_FIELDS.keys()))
+@pytest.mark.parametrize("provider", list(OAUTH_PROVIDER_CREDENTIAL_FIELDS.keys()))
 def test_oauth_provider_disabled_raises_503(monkeypatch, provider: str):
     """Disabled provider must raise stable 503 contract."""
-    client_id_field, client_secret_field = PROVIDER_CREDENTIAL_FIELDS[provider]
+    client_id_field, client_secret_field = OAUTH_PROVIDER_CREDENTIAL_FIELDS[provider]
     monkeypatch.setattr(auth_router_module.settings, client_id_field, "")
     monkeypatch.setattr(auth_router_module.settings, client_secret_field, "")
 

--- a/api/tests/test_auth_provider_registry.py
+++ b/api/tests/test_auth_provider_registry.py
@@ -1,0 +1,37 @@
+"""OAuth provider registry deterministic-order tests."""
+
+import importlib
+import logging
+
+from app.oauth_providers import (
+    OAUTH_PROVIDER_CREDENTIAL_FIELDS,
+    OAUTH_PROVIDER_CREDENTIAL_KEYS,
+    OAUTH_PROVIDER_ORDER,
+)
+
+auth_router_module = importlib.import_module("app.auth.router")
+
+
+def test_provider_registry_order_is_stable() -> None:
+    """Provider registry order must stay deterministic across modules."""
+    assert OAUTH_PROVIDER_ORDER == (
+        "google",
+        "discord",
+        "github",
+        "x",
+        "linkedin",
+        "facebook",
+        "slack",
+        "twitch",
+    )
+    assert tuple(OAUTH_PROVIDER_CREDENTIAL_FIELDS.keys()) == OAUTH_PROVIDER_ORDER
+    assert OAUTH_PROVIDER_CREDENTIAL_KEYS == tuple(OAUTH_PROVIDER_CREDENTIAL_FIELDS.values())
+
+
+def test_provider_registry_order_is_logged(caplog) -> None:
+    """Registry initialization order should be emitted to logs."""
+    with caplog.at_level(logging.INFO, logger=auth_router_module.__name__):
+        auth_router_module._log_provider_registry_order()
+
+    assert "OAuth provider registry initialized in deterministic order" in caplog.text
+    assert "google -> discord -> github -> x -> linkedin -> facebook -> slack -> twitch" in caplog.text


### PR DESCRIPTION
## Summary\n- centralize OAuth provider registry into a single deterministic ordered definition\n- use shared registry for auth router validation and rate-limit provider recognition\n- add tests for deterministic order and initialization-order logging\n\n## Test\n- cd api && /Users/shiroguchi/Documents/Github/mashirou1234/yesod-auth/api/.venv/bin/python -m pytest -q tests/test_auth_provider_registry.py tests/test_auth_oauth_provider_disabled.py\n\nCloses #326