### PR TITLE
[Bench-80][04] webhook retry interval cap を設定で固定

### DIFF
--- a/api/app/webhooks/config.py
+++ b/api/app/webhooks/config.py
@@ -40,6 +40,7 @@ class WebhookSettings:
 
     max_retries: int = 5
     retry_base_delay_seconds: int = 2
+    retry_max_delay_seconds: int = 60
     delivery_timeout_seconds: int = 30
     log_retention_days: int = 30
 
@@ -92,6 +93,7 @@ class WebhookConfigLoader:
         settings = WebhookSettings(
             max_retries=settings_data.get("max_retries", 5),
             retry_base_delay_seconds=settings_data.get("retry_base_delay_seconds", 2),
+            retry_max_delay_seconds=settings_data.get("retry_max_delay_seconds", 60),
             delivery_timeout_seconds=settings_data.get("delivery_timeout_seconds", 30),
             log_retention_days=settings_data.get("log_retention_days", 30),
         )

--- a/api/app/webhooks/worker.py
+++ b/api/app/webhooks/worker.py
@@ -123,6 +123,7 @@ class WebhookWorker:
         config = WebhookConfigLoader.get_config()
         max_retries = config.settings.max_retries
         base_delay = config.settings.retry_base_delay_seconds
+        max_delay = config.settings.retry_max_delay_seconds
         timeout = config.settings.delivery_timeout_seconds
         delivery_id = uuid.uuid4()
 
@@ -133,13 +134,19 @@ class WebhookWorker:
 
             if attempt > 0:
                 # Exponential backoff
-                delay = base_delay * (2 ** (attempt - 1))
+                raw_delay = base_delay * (2 ** (attempt - 1))
+                delay = min(raw_delay, max_delay)
                 logger.info(
-                    "Retrying webhook delivery to %s (attempt %d/%d) after %ds",
+                    (
+                        "Retrying webhook delivery to %s (attempt %d/%d) after %ds "
+                        "(raw_delay=%ds, max_delay=%ds)"
+                    ),
                     endpoint.id,
                     attempt + 1,
                     max_retries + 1,
                     delay,
+                    raw_delay,
+                    max_delay,
                 )
                 await asyncio.sleep(delay)
 

--- a/api/tests/test_webhook_config.py
+++ b/api/tests/test_webhook_config.py
@@ -354,3 +354,50 @@ class TestWebhookConfigValidation:
                 assert len(endpoints) == 0
         finally:
             config_path.unlink()
+
+    def test_retry_max_delay_setting_defaults_and_override(self):
+        """retry_max_delay_seconds は既定値と設定値の両方を反映する。"""
+        default_config = {
+            "endpoints": [
+                {
+                    "id": "default-endpoint",
+                    "url": "https://example.com/webhook",
+                    "secret": "secret",
+                    "events": ["user.created"],
+                }
+            ]
+        }
+        override_config = {
+            "endpoints": [
+                {
+                    "id": "override-endpoint",
+                    "url": "https://example.com/webhook",
+                    "secret": "secret",
+                    "events": ["user.created"],
+                }
+            ],
+            "settings": {
+                "retry_max_delay_seconds": 7,
+            },
+        }
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f_default:
+            yaml.dump(default_config, f_default)
+            default_path = Path(f_default.name)
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f_override:
+            yaml.dump(override_config, f_override)
+            override_path = Path(f_override.name)
+
+        try:
+            with patch.object(config_module, "CONFIG_PATH", default_path):
+                WebhookConfigLoader._config = None
+                result_default = WebhookConfigLoader.load()
+            assert result_default.settings.retry_max_delay_seconds == 60
+
+            with patch.object(config_module, "CONFIG_PATH", override_path):
+                WebhookConfigLoader._config = None
+                result_override = WebhookConfigLoader.load()
+            assert result_override.settings.retry_max_delay_seconds == 7
+        finally:
+            default_path.unlink()
+            override_path.unlink()

--- a/api/tests/test_webhook_worker.py
+++ b/api/tests/test_webhook_worker.py
@@ -2,7 +2,7 @@
 
 import re
 import uuid
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, call, patch
 
 import pytest
 from hypothesis import given, settings
@@ -272,6 +272,44 @@ class TestWebhookWorkerRetry:
         assert "attempts=3" in exhausted_log
         assert "signature_algo=sha256" in exhausted_log
         assert "error=Server Error" in exhausted_log
+
+    @pytest.mark.asyncio
+    async def test_retry_backoff_respects_max_delay(self, sample_endpoint, sample_event):
+        """指数バックオフ遅延は retry_max_delay_seconds で上限化される。"""
+        worker = WebhookWorker()
+        capped_config = WebhookConfig(
+            endpoints=[sample_endpoint],
+            settings=WebhookSettings(
+                max_retries=4,
+                retry_base_delay_seconds=10,
+                retry_max_delay_seconds=15,
+                delivery_timeout_seconds=5,
+            ),
+        )
+
+        mock_response = AsyncMock()
+        mock_response.status_code = 500
+        mock_response.text = "Server Error"
+
+        with (
+            patch(
+                "app.webhooks.worker.WebhookConfigLoader.get_config",
+                return_value=capped_config,
+            ),
+            patch("httpx.AsyncClient") as mock_client_class,
+            patch("app.webhooks.worker.asyncio.sleep", new_callable=AsyncMock) as mock_sleep,
+        ):
+            mock_client = AsyncMock()
+            mock_client.post = AsyncMock(return_value=mock_response)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=None)
+            mock_client_class.return_value = mock_client
+
+            result = await worker._deliver_to_endpoint(sample_event, sample_endpoint)
+
+        assert result.success is False
+        assert result.attempt_count == 5
+        assert mock_sleep.await_args_list == [call(10), call(15), call(15), call(15)]
 
 
 class TestWebhookWorkerOrdering:

--- a/config/webhooks.yaml.example
+++ b/config/webhooks.yaml.example
@@ -57,5 +57,6 @@ endpoints:
 settings:
   max_retries: 5                    # Maximum delivery retry attempts
   retry_base_delay_seconds: 2       # Base delay for exponential backoff
+  retry_max_delay_seconds: 60       # Maximum delay cap for exponential backoff
   delivery_timeout_seconds: 30      # HTTP request timeout
   log_retention_days: 30            # How long to keep delivery logs

--- a/docs/guides/webhooks.md
+++ b/docs/guides/webhooks.md
@@ -35,6 +35,7 @@ endpoints:
 settings:
   max_retries: 5
   retry_base_delay_seconds: 2
+  retry_max_delay_seconds: 60
   delivery_timeout_seconds: 30
 ```
 


### PR DESCRIPTION
## 概要
- `retry_max_delay_seconds` をWebhook設定に追加（既定60秒）
- ワーカーの指数バックオフ遅延を上限でcap
- 設定読込テストと遅延capテストを追加
- 設定例/ガイドへ新設定を追記

## テスト
- `cd api && UV_CACHE_DIR=/tmp/uv-cache-b716 uv run --with-requirements requirements.txt --with pytest --with pytest-asyncio --with hypothesis pytest -q tests/test_webhook_worker.py::TestWebhookWorkerRetry::test_retry_backoff_respects_max_delay tests/test_webhook_config.py::TestWebhookConfigValidation::test_retry_max_delay_setting_defaults_and_override`
- `cd api && UV_CACHE_DIR=/tmp/uv-cache-b716 uv run --with-requirements requirements.txt --with pytest --with pytest-asyncio --with hypothesis pytest -q tests/test_webhook_worker.py tests/test_webhook_config.py`

Closes #380
