### PR TITLE
docs: add secrets permission recovery runbook

### DIFF
--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -57,6 +57,20 @@ YESOD AuthはGoogle OAuthでPKCEを自動的に使用します。
 シークレットの配置方針は [インストールガイド: OAuth認証情報](../installation.md#oauth認証情報)、
 プロバイダー別の有効化手順は [OAuth設定ガイド](../guides/oauth/index.md#セルフホスト向け最短手順) を参照してください。
 
+<a id="oauth-secret-permission-recovery"></a>
+
+### OAuth secret の権限不備を最短で復旧するには？
+
+次の順に実施してください（症状→確認→復旧）。
+
+1. `docker compose logs --tail=100 api | rg -n "permission denied|/run/secrets"` で症状を確認する
+2. Linux: `stat -c '%n %a %U:%G' secrets/*.txt` / macOS: `stat -f '%N %Lp %Su:%Sg' secrets/*.txt` で権限と所有者を確認する
+3. `chmod 600 secrets/*.txt` と `sudo chown "$(id -un):$(id -gn)" secrets/*.txt` で復旧する
+4. `docker compose up -d --force-recreate api worker` 後に `curl -fsS http://localhost:8000/health` を確認する
+
+詳細手順は [トラブルシューティング: secrets 権限不備で `Permission denied` が出る](./troubleshooting.md#secrets-permission-recovery) を参照してください。  
+受け入れ時は FAQ / installation / troubleshooting の3点で、コマンドと手順順が一致していることを確認してください。
+
 ### 429（Too Many Requests）が出たときの確認手順は？
 
 認証レート制限の切り分け手順を [トラブルシューティング: 429 Too Many Requests](./troubleshooting.md#auth-rate-limit-429) にまとめています。  

--- a/docs/help/troubleshooting.md
+++ b/docs/help/troubleshooting.md
@@ -179,6 +179,55 @@ environment:
 
 ---
 
+<a id="secrets-permission-recovery"></a>
+
+### secrets 権限不備で `Permission denied` が出る
+
+**症状:** `docker compose up -d` 実行時に `permission denied` が出て起動できない。`/run/secrets/*` の読み込みエラーが API ログに残る。
+
+**確認手順（Linux/macOS）:**
+
+1. 対象 secret の所有者とパーミッションを確認する
+   ```bash
+   ls -l secrets/*.txt
+   ```
+2. Linux の詳細確認
+   ```bash
+   stat -c '%n %a %U:%G' secrets/*.txt
+   ```
+3. macOS の詳細確認
+   ```bash
+   stat -f '%N %Lp %Su:%Sg' secrets/*.txt
+   ```
+
+**復旧手順:**
+
+1. パーミッションを `600` に戻す
+   ```bash
+   chmod 600 secrets/*.txt
+   ```
+2. 所有者が現在ユーザーでない場合は修正する（Linux/macOS 共通）
+   ```bash
+   sudo chown \"$(id -un):$(id -gn)\" secrets/*.txt
+   ```
+3. API を再作成して反映する
+   ```bash
+   docker compose up -d --force-recreate api worker
+   ```
+4. 再確認する
+   ```bash
+   docker compose logs --tail=100 api | rg -n \"permission denied|/run/secrets|invalid_client\"
+   curl -fsS http://localhost:8000/health
+   ```
+
+**受け入れ時の三点同期チェック:**
+
+1. FAQ: [OAuth secret の権限不備を最短で復旧するには？](./faq.md#oauth-secret-の権限不備を最短で復旧するには) の手順順序と一致していること
+2. Installation: [OAuth secret ファイル権限の復旧手順](../installation.md#oauth-secret-ファイル権限の復旧手順) のコマンドと一致していること
+3. 本節（troubleshooting）では症状→確認→復旧の順序になっていること
+
+---
+
 <a id="oauth-clock-skew"></a>
 
 ### OAuth callback で `invalid_grant` が断続的に発生する（clock skew）

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -249,6 +249,30 @@ docker compose --profile default ps
 
 `invalid_client` が続く場合は、`secrets/*.txt` の値が実値であることを確認し、[`docs/help/troubleshooting.md` の `invalid_client` 手順](help/troubleshooting.md#invalid_client-or-401-from-provider-token-endpoint) を参照してください。
 
+### OAuth secret ファイル権限の復旧手順
+
+`permission denied` で起動に失敗する場合は、次の順で復旧してください。
+
+1. 症状確認
+   ```bash
+   docker compose logs --tail=100 api | rg -n "permission denied|/run/secrets"
+   ```
+2. 権限確認（Linux/macOS）
+   ```bash
+   # Linux
+   stat -c '%n %a %U:%G' secrets/*.txt
+   # macOS
+   stat -f '%N %Lp %Su:%Sg' secrets/*.txt
+   ```
+3. 復旧
+   ```bash
+   chmod 600 secrets/*.txt
+   sudo chown "$(id -un):$(id -gn)" secrets/*.txt
+   docker compose up -d --force-recreate api worker
+   ```
+
+詳細な切り分けは [トラブルシューティング: secrets 権限不備で `Permission denied` が出る](./help/troubleshooting.md#secrets-permission-recovery) を参照してください。
+
 対処:
 
 1. 不足している `<name>` について、`secrets/<name>.txt` を作成する
@@ -390,9 +414,9 @@ docker compose --profile ci config | rg -n "MOCK_OAUTH_ENABLED"
 3. 利用する provider の secrets（`<provider>_client_id` / `<provider>_client_secret`）が揃っている
 4. provider 管理画面の callback URL と `GET /api/v1/auth/{provider}/callback` が一致している
 5. FAQ / installation / troubleshooting の3点同期を確認する  
-   - FAQ: [Mock OAuthから本番OAuthへ切り替える最小確認は？](./help/faq.md#mock-oauthから本番oauthへ切り替える最小確認は)  
+   - FAQ: [OAuth secret の権限不備を最短で復旧するには？](./help/faq.md#oauth-secret-の権限不備を最短で復旧するには)  
    - Installation: [profile別の環境変数優先順位](#profile別の環境変数優先順位)  
-   - Troubleshooting: [401 Unauthorized / invalid_client](./help/troubleshooting.md#401-unauthorized--invalid_client)
+   - Troubleshooting: [secrets 権限不備で `Permission denied` が出る](./help/troubleshooting.md#secrets-permission-recovery)
 
 ## リフレッシュトークン運用時の注意
 


### PR DESCRIPTION
## 概要
- `docs/help/troubleshooting.md` に secrets 権限不備 (`Permission denied`) の復旧手順を追加
- `docs/help/faq.md` に最短復旧の Q&A を追加
- `docs/installation.md` に Linux/macOS 両対応の権限確認・復旧手順を追加

## 変更理由
OAuth 導入時に発生しやすい secrets 権限不備を、セルフホスト運用で再現しやすい形で短手順化するため。

## テスト
- `rg -n "secrets-permission-recovery|OAuth secret の権限不備を最短で復旧するには|OAuth secret ファイル権限の復旧手順" docs/help/troubleshooting.md docs/help/faq.md docs/installation.md`
- `rg -n "FAQ / installation / troubleshooting|permission denied|chmod 600|stat -c|stat -f" docs/help/troubleshooting.md docs/help/faq.md docs/installation.md`
- `mkdocs build --strict` は `mkdocs` コマンド未導入のためスキップ

## 公開時影響
- 変更はドキュメントのみでアプリ実行バイナリ/設定仕様の破壊的変更なし
- 運用者向け手順の明確化により、OAuth secrets 権限起因の復旧時間短縮を見込む
