### PR TITLE
docs(agents): document stale pr-opened handling for multi-orch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,3 +5,4 @@
 - `scripts/orch.sh` を使う自動レーンでは必ず 1 run 1 issue を守る
 - 手動レーン（Power User の直接対応）は一括処理可。ただし `codex:queue` 系ラベル遷移の整合は維持する
 - 失敗時は issue コメントと `codex:blocked` を付与する
+- マルチオーケストレーションでは `codex:pr-opened` の滞留を成功扱いで放置しない。required check 未到着、auto-merge 未成立、競合を切り分け、必要なら `codex:blocked`・再キュー・手動介入へ進める


### PR DESCRIPTION
## Summary\n- document that multi-orch must not leave stale \ issues untriaged\n- require follow-up for missing required checks, failed auto-merge, and conflicts\n\n## Testing\n- git diff --check (AGENTS.md)
