### PR TITLE
[Bench-80][20] Add request-id backfill rule in audit service

### DIFF
--- a/api/app/audit/service.py
+++ b/api/app/audit/service.py
@@ -34,6 +34,25 @@ class AuditLogger:
     """Audit logging service for authentication events."""
 
     @staticmethod
+    def _normalize_event_details(details: dict | None) -> dict:
+        """Ensure request-id is always present in auth event details."""
+        normalized = dict(details or {})
+        request_id = None
+        for key in ("request_id", "request-id"):
+            value = normalized.get(key)
+            if isinstance(value, str) and value.strip():
+                request_id = value
+                break
+
+        if request_id is None:
+            normalized["request_id"] = str(uuid.uuid4())
+            normalized["request_id_backfilled"] = True
+        else:
+            normalized["request_id_backfilled"] = False
+
+        return normalized
+
+    @staticmethod
     async def log_login(
         db: AsyncSession,
         user_id: uuid.UUID | None,
@@ -78,6 +97,7 @@ class AuditLogger:
             return  # Skip audit logging in test environment
 
         import json
+        normalized_details = AuditLogger._normalize_event_details(details)
 
         await db.execute(
             text("""
@@ -88,7 +108,7 @@ class AuditLogger:
             {
                 "user_id": str(user_id) if user_id else None,
                 "event_type": event_type.value,
-                "details": json.dumps(details) if details else None,
+                "details": json.dumps(normalized_details),
                 "ip_address": ip_address,
                 "user_agent": user_agent[:500] if user_agent else None,
             },

--- a/api/tests/test_audit_service.py
+++ b/api/tests/test_audit_service.py
@@ -1,0 +1,50 @@
+"""Contract tests for audit service request-id backfill behavior."""
+
+import json
+from unittest.mock import AsyncMock
+from uuid import UUID
+
+import pytest
+
+from app.audit.service import AuditLogger, AuthEventType
+
+
+@pytest.mark.asyncio
+async def test_log_event_backfills_request_id_when_missing(monkeypatch):
+    """Missing request-id should be backfilled and marked explicitly."""
+    monkeypatch.setenv("TESTING", "0")
+    db = AsyncMock()
+
+    await AuditLogger.log_event(
+        db=db,
+        event_type=AuthEventType.LOGIN_SUCCESS,
+        details={"provider": "github"},
+        ip_address="127.0.0.1",
+    )
+
+    payload = json.loads(db.execute.await_args.args[1]["details"])
+    assert payload["provider"] == "github"
+    assert payload["request_id_backfilled"] is True
+    assert "request_id" in payload
+    UUID(payload["request_id"])
+    db.commit.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_log_event_preserves_existing_request_id(monkeypatch):
+    """Existing request-id value should remain unchanged."""
+    monkeypatch.setenv("TESTING", "0")
+    db = AsyncMock()
+    details = {"provider": "google", "request_id": "req-fixed-123"}
+
+    await AuditLogger.log_event(
+        db=db,
+        event_type=AuthEventType.LOGIN_SUCCESS,
+        details=details,
+    )
+
+    payload = json.loads(db.execute.await_args.args[1]["details"])
+    assert payload["request_id"] == "req-fixed-123"
+    assert payload["request_id_backfilled"] is False
+    db.commit.assert_awaited_once()
+


### PR DESCRIPTION
## Summary
- add request-id normalization in `AuditLogger.log_event` so missing IDs are backfilled with UUID
- add `request_id_backfilled` flag to details payload for explicit traceability
- preserve existing request-id values when already present
- add audit service unit tests for backfill and non-backfill paths

## Test
- `UV_CACHE_DIR=/tmp/.uv-cache uv run --with-requirements requirements.txt pytest -q tests/test_audit_service.py`
- `UV_CACHE_DIR=/tmp/.uv-cache uv run --with-requirements requirements.txt pytest -q tests/test_auth_refresh.py tests/test_sessions.py`

Closes #411
