### PR TITLE
[Bench-80][06] provider未設定時の最短スキップ導線を同期

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -40,6 +40,27 @@ providerごとの必須 secret 名は [OAuth設定ハブの一覧](guides/oauth/
     openssl rand -base64 32 > secrets/jwt_secret.txt
     ```
 
+### provider 未設定時の最短スキップ手順
+
+未設定の provider がある場合でも、初回起動確認は中断せずに進められます。
+
+1. 起動対象を `default` profile に固定する（Mock OAuth 前提）
+2. 必須 secret は `jwt_secret` と、今回有効化する provider 分だけ作成する
+3. 未設定 provider は触らず、[3. 起動](#3-起動) と [4. 動作確認](#4-動作確認) まで先に完了させる
+4. 実 OAuth を使うタイミングで、対象 provider の `*_client_id` / `*_client_secret` を追加して再起動する
+
+再開ポイント:
+- 起動確認を先に進める場合は [4. 動作確認](#4-動作確認)
+- 実 OAuth を再開する場合は [Mock OAuthから実OAuthへ切り替える最小チェック](#mock-oauthから実oauthへ切り替える最小チェック)
+- 失敗時の切り分けは [トラブルシューティング](help/troubleshooting.md#provider-未設定のまま認証導線を実行した) を参照
+
+### FAQ / installation / troubleshooting 同期チェックコマンド
+
+```bash
+rg -n "provider 未設定時の最短スキップ手順|再開ポイント" \
+  docs/getting-started.md docs/installation.md docs/help/faq.md docs/help/troubleshooting.md
+```
+
 ### OAuthガイドへの導線
 
 クイックスタートで起動確認した後、利用するプロバイダーの設定を進めてください。

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -38,6 +38,17 @@ YESOD AuthはGoogle OAuthでPKCEを自動的に使用します。
 必須なのは`jwt_secret`と、実際に有効化して使うOAuthプロバイダーの`*_client_id`/`*_client_secret`だけです。
 たとえばGoogleのみ使う最小構成ならGoogle分だけ、複数プロバイダー運用なら有効化した各プロバイダー分を追加してください。
 
+### provider 未設定のまま初回導入を進めてもよい？
+
+可能です。次の順で進めると最短で起動確認できます。
+
+1. `default` profile で起動し、`jwt_secret` と有効化する provider 分だけ先に設定する
+2. 未設定 provider の認証導線は呼ばず、`/health` と `/docs` の到達確認を先に完了する
+3. OAuth 設定がそろった時点で `docker compose --profile default up -d --force-recreate api` を実行して再開する
+
+再開ポイントは [クイックスタート: provider 未設定時の最短スキップ手順](../getting-started.md#provider-未設定時の最短スキップ手順) を参照してください。  
+導線全体は [インストール](../installation.md#provider-未設定時の最短スキップ手順) と [トラブルシューティング](./troubleshooting.md#provider-未設定のまま認証導線を実行した) で同期しています。
+
 ### OAuth secretを更新したら再起動は必要？
 
 必要です。YESOD Auth は起動時に `/run/secrets/*` を読み込むため、`secrets/*.txt` を更新した直後は、対象コンテナを再作成して新しい値を読み込ませてください。

--- a/docs/help/troubleshooting.md
+++ b/docs/help/troubleshooting.md
@@ -123,6 +123,22 @@ environment:
   - MOCK_OAUTH_ENABLED=1
 ```
 
+<a id="provider-未設定のまま認証導線を実行した"></a>
+
+### provider 未設定のまま認証導線を実行した
+
+**症状:** `GET /api/v1/auth/<provider>` 実行時に `invalid_client` や secret 読み込みエラーが発生する。
+
+**最短対応:**
+
+1. 未設定 provider の導線呼び出しを一度止める
+2. `curl -fsS http://localhost:8000/health` と `curl -fsS -o /dev/null -w '%{http_code}\n' http://localhost:8000/docs` で起動確認を先に完了する
+3. 対象 provider の `*_client_id` / `*_client_secret` を追加し、`docker compose --profile default up -d --force-recreate api` で再開する
+
+再開ポイント:
+- [クイックスタート: provider 未設定時の最短スキップ手順](../getting-started.md#provider-未設定時の最短スキップ手順)
+- [インストール: provider 未設定時の最短スキップ手順](../installation.md#provider-未設定時の最短スキップ手順)
+
 ---
 
 ### `401 Unauthorized` / `invalid_client`

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -31,6 +31,20 @@ YESOD Authは3つのプロファイルを提供しています：
 | `full` | 管理画面 (`admin`) まで含めて導入確認したい | `ls -l secrets/admin_password.txt`<br>`docker compose --profile full up -d`<br>`docker compose --profile full config --services` |
 | `ci` | CI 相当の軽量構成だけ確認したい | `docker compose --profile ci up -d`<br>`docker compose --profile ci config --services`<br>`docker compose --profile ci ps` |
 
+### provider 未設定時の最短スキップ手順
+
+OAuth provider をまだ一部用意できていない場合は、次の手順で初回確認を進めます。
+
+1. `default` profile で起動し、Mock OAuth で疎通確認する
+2. 必須 secret は `jwt_secret` と、今回有効化する provider 分だけ作成する
+3. 未設定 provider は `GET /api/v1/auth/<provider>` を呼ばず、先に health/docs 到達確認を完了する
+4. OAuth 設定完了後に provider の secret を追加し、`docker compose --profile default up -d --force-recreate api` で再開する
+
+再開ポイント:
+- 起動確認の継続: [docker compose利用時の最小確認手順](#docker-compose利用時の最小確認手順)
+- 実 OAuth の再開: [クイックスタート: Mock OAuthから実OAuthへ切り替える最小チェック](./getting-started.md#mock-oauthから実oauthへ切り替える最小チェック)
+- 失敗時: [トラブルシューティング: provider 未設定のまま認証導線を実行した](./help/troubleshooting.md#provider-未設定のまま認証導線を実行した)
+
 ## Docker起動前チェック項目
 
 `docker compose up` 実行前に、次の4項目を確認してください。


### PR DESCRIPTION
## 概要
- getting-started に「provider 未設定時の最短スキップ手順」を追加
- OAuth 設定完了後の再開ポイントを getting-started / installation / faq / troubleshooting で同期
- 三点同期確認用の最小コマンド（`rg`）を getting-started に追加

## 変更ファイル
- docs/getting-started.md
- docs/installation.md
- docs/help/faq.md
- docs/help/troubleshooting.md

## テスト・確認
- `rg -n "provider 未設定時の最短スキップ手順|再開ポイント" docs/getting-started.md docs/installation.md docs/help/faq.md docs/help/troubleshooting.md` ✅
- `cd api && UV_CACHE_DIR=/tmp/uv-cache uv run pytest -q` ⚠️ 1件失敗（`tests/test_users_delete_account.py` が `localhost:6379` への接続拒否。Valkey 未起動依存）

## Issue
- Closes #339
