### PR TITLE
fix(admin): SameSite=None + Secure=False の境界警告を追加

### DIFF
--- a/admin/app.py
+++ b/admin/app.py
@@ -41,6 +41,7 @@ warn_if_session_cookie_samesite_unset(
     logger,
     environment=settings.ENVIRONMENT,
     session_cookie_samesite=settings.SESSION_COOKIE_SAMESITE,
+    session_cookie_secure=settings.SESSION_COOKIE_SECURE,
 )
 
 

--- a/admin/config.py
+++ b/admin/config.py
@@ -27,6 +27,14 @@ class Settings:
     
     # Session persistence (hours)
     SESSION_EXPIRY_HOURS: int = int(os.getenv("SESSION_EXPIRY_HOURS", "24"))
+    # SameSite(None) is only valid when Secure=true.
+    SESSION_COOKIE_SECURE: bool = os.getenv("SESSION_COOKIE_SECURE", "false").lower() in (
+        "1",
+        "true",
+        "yes",
+        "on",
+    )
+    # Empty means "use framework default" and emit a warning for visibility.
     SESSION_COOKIE_SAMESITE: str = os.getenv("SESSION_COOKIE_SAMESITE", "").strip()
 
     # Default language (en, ja, fr, ko, de)
@@ -45,14 +53,23 @@ def warn_if_session_cookie_samesite_unset(
     *,
     environment: str,
     session_cookie_samesite: str,
+    session_cookie_secure: bool = True,
 ) -> bool:
-    """Emit warning when SameSite is not configured for admin session cookie."""
-    if session_cookie_samesite.strip():
-        return False
-
     env_name = environment.strip() or "production"
-    logger.warning(
-        "SESSION_COOKIE_SAMESITE is not configured for admin session cookie (environment=%s)",
-        env_name,
-    )
-    return True
+    samesite = session_cookie_samesite.strip().lower()
+
+    if not samesite:
+        logger.warning(
+            "SESSION_COOKIE_SAMESITE is not configured for admin session cookie (environment=%s)",
+            env_name,
+        )
+        return True
+
+    if samesite == "none" and not session_cookie_secure:
+        logger.warning(
+            "SESSION_COOKIE_SAMESITE=None requires SESSION_COOKIE_SECURE=true for admin session cookie (environment=%s)",
+            env_name,
+        )
+        return True
+
+    return False

--- a/admin/tests/test_session_cookie_samesite.py
+++ b/admin/tests/test_session_cookie_samesite.py
@@ -33,6 +33,22 @@ class SessionCookieSameSiteWarningTests(unittest.TestCase):
         self.assertFalse(warned)
         logger.warning.assert_not_called()
 
+    def test_warns_when_samesite_none_and_secure_is_false(self) -> None:
+        logger = Mock()
+
+        warned = warn_if_session_cookie_samesite_unset(
+            logger,
+            environment="staging",
+            session_cookie_samesite="None",
+            session_cookie_secure=False,
+        )
+
+        self.assertTrue(warned)
+        logger.warning.assert_called_once_with(
+            "SESSION_COOKIE_SAMESITE=None requires SESSION_COOKIE_SECURE=true for admin session cookie (environment=%s)",
+            "staging",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## 概要
- `SESSION_COOKIE_SAMESITE=None` かつ `SESSION_COOKIE_SECURE=false` の組み合わせを警告対象に追加
- `admin/app.py` から `session_cookie_secure` を渡すように更新
- 回帰テストを1件追加

## テスト
- `cd admin && python3 -m unittest -v tests/test_session_cookie_samesite.py tests/test_i18n.py`

Closes #429
