### PR TITLE
[Codex] [Bench-80][01] refresh token 再利用時の失効ログ項目をテストで固定する

### DIFF
--- a/api/app/auth/router.py
+++ b/api/app/auth/router.py
@@ -37,6 +37,7 @@ from .schemas import (
     TokenPairResponse,
 )
 from .tokens import (
+    classify_refresh_token_failure,
     create_access_token,
     create_refresh_token,
     revoke_refresh_token,
@@ -1041,11 +1042,12 @@ async def refresh_tokens(
     result = await rotate_refresh_token(db, body.refresh_token, device_info, ip_address)
 
     if not result:
+        token_status = await classify_refresh_token_failure(db, body.refresh_token)
         await AuditLogger.log_event(
             db,
             AuthEventType.TOKEN_REFRESH_FAILED,
             None,
-            {"reason": "Invalid or expired token"},
+            {"reason": "Invalid or expired token", "token_status": token_status},
             ip_address,
             device_info,
         )

--- a/api/app/auth/tokens.py
+++ b/api/app/auth/tokens.py
@@ -132,6 +132,33 @@ async def rotate_refresh_token(
     return new_token, old_record.user_id
 
 
+async def classify_refresh_token_failure(
+    db: AsyncSession,
+    token: str,
+) -> str:
+    """Classify why refresh token validation failed for audit details."""
+    token_hash = hash_refresh_token(token)
+    now = datetime.now(UTC)
+
+    result = await db.execute(
+        select(RefreshToken).where(RefreshToken.token_hash == token_hash)
+    )
+    record = result.scalar_one_or_none()
+    if not record:
+        return "not_found"
+
+    if record.is_revoked:
+        return "revoked"
+
+    expires_at = record.expires_at
+    if expires_at.tzinfo is None:
+        expires_at = expires_at.replace(tzinfo=UTC)
+    if expires_at <= now:
+        return "expired"
+
+    return "unknown"
+
+
 async def revoke_refresh_token(db: AsyncSession, token: str) -> bool:
     """Revoke a specific refresh token."""
     record = await validate_refresh_token(db, token)

--- a/api/tests/test_auth_refresh.py
+++ b/api/tests/test_auth_refresh.py
@@ -2,7 +2,7 @@
 
 import time
 from datetime import UTC, datetime, timedelta
-from unittest.mock import PropertyMock, patch
+from unittest.mock import AsyncMock, PropertyMock, patch
 
 import pytest
 from httpx import AsyncClient
@@ -203,6 +203,49 @@ async def test_refresh_rejects_revoked_session_token(
     )
     assert refresh_response.status_code == 401
     assert refresh_response.json() == {"detail": "Invalid or expired refresh token"}
+
+
+@pytest.mark.asyncio
+async def test_refresh_reuse_logs_revoked_token_status(
+    client: AsyncClient, db_session: AsyncSession
+):
+    """Reusing a rotated refresh token should log token_status=revoked."""
+    user = User()
+    user.emails.append(
+        UserEmail(
+            email="refresh-reuse@example.com",
+            is_primary=True,
+        )
+    )
+    db_session.add(user)
+    await db_session.commit()
+    await db_session.refresh(user)
+
+    refresh_token = await create_refresh_token(db_session, user.id)
+    with (
+        patch("app.auth.router.AuditLogger.log_event", new=AsyncMock()) as mock_log_event,
+        patch.object(User, "email", new_callable=PropertyMock, return_value="refresh-reuse@example.com"),
+    ):
+        first_refresh = await client.post(
+            "/api/v1/auth/refresh",
+            json={"refresh_token": refresh_token},
+        )
+        assert first_refresh.status_code == 200
+
+        second_refresh = await client.post(
+            "/api/v1/auth/refresh",
+            json={"refresh_token": refresh_token},
+        )
+
+    assert second_refresh.status_code == 401
+    assert second_refresh.json() == {"detail": "Invalid or expired refresh token"}
+    assert mock_log_event.await_count == 2
+    failed_call = mock_log_event.await_args_list[1]
+    assert failed_call.args[2] is None
+    assert failed_call.args[3] == {
+        "reason": "Invalid or expired token",
+        "token_status": "revoked",
+    }
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add `classify_refresh_token_failure` to classify refresh failure as `not_found`/`revoked`/`expired`
- include `token_status` in `TOKEN_REFRESH_FAILED` audit event details
- add regression test that reuses a rotated refresh token and asserts `token_status=revoked`

## Test
- `UV_CACHE_DIR=/tmp/uv-cache uv run --with-requirements requirements.txt pytest -q tests/test_auth_refresh.py::test_refresh_reuse_logs_revoked_token_status`
- `UV_CACHE_DIR=/tmp/uv-cache uv run --with-requirements requirements.txt pytest -q tests/test_auth_refresh.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run --with-requirements requirements.txt pytest -q tests/test_users_delete_account.py tests/test_sessions_api.py` *(1 fail: localhost:6379 Connection refused in existing env dependency)*

## Issue
- closes #377
