### PR TITLE
fix(admin): improve unknown locale fallback diagnostics (closes #379)

### DIFF
--- a/admin/i18n.py
+++ b/admin/i18n.py
@@ -1,5 +1,6 @@
 """Internationalization (i18n) support for admin dashboard."""
 import json
+import logging
 import os
 from pathlib import Path
 from typing import Any
@@ -17,6 +18,7 @@ DEFAULT_LANGUAGE = "en"
 
 # Cache for loaded translations
 _translations_cache: dict[str, dict] = {}
+logger = logging.getLogger(__name__)
 
 
 def _resolve_language(lang: str) -> str:
@@ -24,6 +26,12 @@ def _resolve_language(lang: str) -> str:
     normalized = (lang or "").strip().lower()
     if normalized in SUPPORTED_LANGUAGES:
         return normalized
+    if normalized:
+        logger.warning(
+            "Unsupported locale '%s' requested. Falling back to '%s'.",
+            normalized,
+            DEFAULT_LANGUAGE,
+        )
     return DEFAULT_LANGUAGE
 
 

--- a/admin/tests/test_i18n.py
+++ b/admin/tests/test_i18n.py
@@ -11,6 +11,13 @@ class I18nFallbackTests(unittest.TestCase):
     def test_path_traversal_like_locale_falls_back_to_default_language(self) -> None:
         self.assertEqual(get_text("nav.overview", "../../secrets"), "📊 Overview")
 
+    def test_unknown_locale_emits_warning_log(self) -> None:
+        with self.assertLogs("i18n", level="WARNING") as captured:
+            self.assertEqual(get_text("nav.overview", "zz"), "📊 Overview")
+        self.assertTrue(
+            any("Unsupported locale 'zz' requested." in message for message in captured.output)
+        )
+
     def test_known_locale_is_not_affected(self) -> None:
         self.assertEqual(get_text("nav.overview", "ja"), "📊 概要")
         self.assertEqual(Translator("ja").lang, "ja")


### PR DESCRIPTION
## Summary
- add warning log when unsupported locale is requested and falls back to default
- keep existing locale fallback behavior and API compatibility
- add regression test to lock warning message for unknown locale fallback

## Testing
- `cd admin && PYTHONPATH=. python3 -m unittest -v tests.test_i18n`
- `cd admin && PYTHONPATH=. python3 -m unittest discover -v tests`

## Notes
- `pytest` is not available in this runner (`python3 -m pytest` failed with `No module named pytest`)
