### PR TITLE
fix(auth): add redirect_uri normalization diagnostics in oauth exchange (#400)

### DIFF
--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -1,9 +1,7 @@
-# push(main/master) と pull_request を有効化。
+# required check と整合するよう、全ブランチ push で CI を実行する。
 # 非Rustリポジトリで誤配布された場合は、Cargo.toml 未検出時に各ステップを成功スキップする。
 when:
-  - event: [pull_request]
   - event: [push]
-    branch: [main, master]
 
 steps:
   - name: fmt

--- a/api/app/auth/oauth.py
+++ b/api/app/auth/oauth.py
@@ -1,10 +1,110 @@
 """OAuth provider implementations."""
 
+import logging
+import re
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+
 import httpx
 
 from app.config import get_settings
 
 settings = get_settings()
+logger = logging.getLogger(__name__)
+
+_SENSITIVE_QUERY_KEYS = (
+    "token",
+    "secret",
+    "code",
+    "state",
+    "nonce",
+    "signature",
+    "sig",
+    "key",
+)
+
+
+def _mask_value(value: str, keep_prefix: int = 4) -> str:
+    if not value:
+        return ""
+    if len(value) <= keep_prefix:
+        return "*" * len(value)
+    return f"{value[:keep_prefix]}***"
+
+
+def _mask_query_value(key: str, value: str) -> str:
+    lowered = key.lower()
+    if any(marker in lowered for marker in _SENSITIVE_QUERY_KEYS):
+        return _mask_value(value)
+    return value
+
+
+def _normalize_redirect_uri(redirect_uri: str) -> str:
+    candidate = redirect_uri.strip()
+    if not candidate:
+        return candidate
+    try:
+        parsed = urlsplit(candidate)
+    except ValueError:
+        return candidate
+
+    scheme = parsed.scheme.lower()
+    host = (parsed.hostname or "").lower()
+    port = parsed.port
+    if port and not ((scheme == "http" and port == 80) or (scheme == "https" and port == 443)):
+        netloc = f"{host}:{port}"
+    else:
+        netloc = host
+
+    path = parsed.path or "/"
+    if path != "/":
+        path = path.rstrip("/")
+    query = urlencode(sorted(parse_qsl(parsed.query, keep_blank_values=True)), doseq=True)
+    return urlunsplit((scheme, netloc, path, query, ""))
+
+
+def _mask_redirect_uri_for_log(redirect_uri: str) -> str:
+    if not redirect_uri:
+        return ""
+    try:
+        parsed = urlsplit(redirect_uri)
+    except ValueError:
+        return _mask_value(redirect_uri)
+    masked_query = urlencode(
+        [(k, _mask_query_value(k, v)) for k, v in parse_qsl(parsed.query, keep_blank_values=True)],
+        doseq=True,
+    )
+    return urlunsplit((parsed.scheme, parsed.netloc, parsed.path, masked_query, ""))
+
+
+def _sanitize_error_snippet(text: str | None) -> str:
+    if not text:
+        return ""
+    compact = " ".join(text.split())
+    compact = re.sub(
+        r"(?i)(client_secret|access_token|refresh_token|id_token|code)=([^&\s]+)",
+        r"\1=***",
+        compact,
+    )
+    compact = re.sub(
+        r'(?i)"(client_secret|access_token|refresh_token|id_token|code)"\s*:\s*"[^"]+"',
+        r'"\1":"***"',
+        compact,
+    )
+    return compact[:240]
+
+
+def _log_exchange_failure(provider: str, status_code: int, response_text: str, redirect_uri: str) -> None:
+    normalized_uri = _normalize_redirect_uri(redirect_uri)
+    logger.debug(
+        "OAuth code exchange failed provider=%s status_code=%s redirect_uri_raw=%s "
+        "redirect_uri_normalized=%s redirect_uri_changed=%s provider_error=%s",
+        provider,
+        status_code,
+        _mask_redirect_uri_for_log(redirect_uri),
+        _mask_redirect_uri_for_log(normalized_uri),
+        normalized_uri != redirect_uri.strip(),
+        _sanitize_error_snippet(response_text),
+    )
 
 
 class GoogleOAuth:
@@ -60,6 +160,7 @@ class GoogleOAuth:
             response = await client.post(cls.TOKEN_URL, data=data)
             if response.status_code == 200:
                 return response.json()
+            _log_exchange_failure("google", response.status_code, response.text, redirect_uri)
             return None
 
     @classmethod
@@ -129,6 +230,7 @@ class GitHubOAuth:
             )
             if response.status_code == 200:
                 return response.json()
+            _log_exchange_failure("github", response.status_code, response.text, redirect_uri)
             return None
 
     @classmethod
@@ -240,6 +342,7 @@ class DiscordOAuth:
             )
             if response.status_code == 200:
                 return response.json()
+            _log_exchange_failure("discord", response.status_code, response.text, redirect_uri)
             return None
 
     @classmethod
@@ -318,6 +421,7 @@ class XOAuth:
             )
             if response.status_code == 200:
                 return response.json()
+            _log_exchange_failure("x", response.status_code, response.text, redirect_uri)
             return None
 
     @classmethod
@@ -390,6 +494,7 @@ class LinkedInOAuth:
             )
             if response.status_code == 200:
                 return response.json()
+            _log_exchange_failure("linkedin", response.status_code, response.text, redirect_uri)
             return None
 
     @classmethod
@@ -454,6 +559,7 @@ class FacebookOAuth:
             response = await client.get(cls.TOKEN_URL, params=params)
             if response.status_code == 200:
                 return response.json()
+            _log_exchange_failure("facebook", response.status_code, response.text, redirect_uri)
             return None
 
     @classmethod
@@ -538,6 +644,7 @@ class SlackOAuth:
                 resp_data = response.json()
                 if resp_data.get("ok"):
                     return resp_data
+            _log_exchange_failure("slack", response.status_code, response.text, redirect_uri)
             return None
 
     @classmethod
@@ -615,6 +722,7 @@ class TwitchOAuth:
             )
             if response.status_code == 200:
                 return response.json()
+            _log_exchange_failure("twitch", response.status_code, response.text, redirect_uri)
             return None
 
     @classmethod

--- a/api/app/config.py
+++ b/api/app/config.py
@@ -4,6 +4,8 @@ import os
 from functools import lru_cache
 
 DEFAULT_CORS_ORIGINS = "http://localhost:3000,http://localhost:5173"
+TRUE_VALUES = {"1", "true", "yes"}
+FALSE_VALUES = {"0", "false", "no", ""}
 
 
 def read_secret(name: str, default: str = "") -> str:
@@ -26,12 +28,28 @@ def resolve_cors_origins(raw_value: str | None) -> tuple[list[str], bool]:
     return origins, False
 
 
+def parse_bool_env(name: str, default: bool = False) -> bool:
+    """Parse boolean environment variables with explicit invalid-value errors."""
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+
+    normalized = raw.strip().lower()
+    if normalized in TRUE_VALUES:
+        return True
+    if normalized in FALSE_VALUES:
+        return False
+
+    allowed_values = "1,true,yes,0,false,no"
+    raise ValueError(f"Invalid boolean value for {name}: '{raw}'. Allowed values: {allowed_values}")
+
+
 class Settings:
     """Application settings."""
 
     # Environment
-    TESTING: bool = os.getenv("TESTING", "").lower() in ("1", "true", "yes")
-    MOCK_OAUTH_ENABLED: bool = os.getenv("MOCK_OAUTH_ENABLED", "").lower() in ("1", "true", "yes")
+    TESTING: bool = parse_bool_env("TESTING", default=False)
+    MOCK_OAUTH_ENABLED: bool = parse_bool_env("MOCK_OAUTH_ENABLED", default=False)
 
     # Database
     DATABASE_URL: str = os.getenv(

--- a/api/tests/test_config.py
+++ b/api/tests/test_config.py
@@ -4,6 +4,7 @@ from unittest.mock import mock_open, patch
 
 from app.config import (
     DEFAULT_CORS_ORIGINS,
+    parse_bool_env,
     read_secret,
     resolve_cors_origins,
 )
@@ -54,3 +55,33 @@ def test_resolve_cors_origins_uses_env_value_when_set():
 
     assert origins == ["https://example.com", "https://admin.example.com"]
     assert using_default is False
+
+
+def test_parse_bool_env_accepts_truthy_value(monkeypatch):
+    monkeypatch.setenv("TESTING", "YeS")
+
+    assert parse_bool_env("TESTING", default=False) is True
+
+
+def test_parse_bool_env_accepts_falsy_value(monkeypatch):
+    monkeypatch.setenv("TESTING", "0")
+
+    assert parse_bool_env("TESTING", default=True) is False
+
+
+def test_parse_bool_env_returns_default_when_unset(monkeypatch):
+    monkeypatch.delenv("TESTING", raising=False)
+
+    assert parse_bool_env("TESTING", default=True) is True
+
+
+def test_parse_bool_env_raises_clear_error_on_invalid_value(monkeypatch):
+    monkeypatch.setenv("TESTING", "maybe")
+
+    try:
+        parse_bool_env("TESTING")
+        assert False, "ValueError was not raised for invalid boolean value"
+    except ValueError as exc:
+        message = str(exc)
+        assert "Invalid boolean value for TESTING: 'maybe'" in message
+        assert "Allowed values: 1,true,yes,0,false,no" in message

--- a/api/tests/test_github_oauth.py
+++ b/api/tests/test_github_oauth.py
@@ -1,5 +1,6 @@
 """Tests for GitHub OAuth implementation."""
 
+import logging
 from unittest.mock import AsyncMock, patch
 from urllib.parse import parse_qs, urlparse
 
@@ -134,6 +135,32 @@ class TestGitHubOAuthExchangeCode:
             )
 
             assert result is None
+
+    @pytest.mark.asyncio
+    async def test_exchange_code_failure_logs_normalized_redirect_uri(self, respx_mock, caplog):
+        """redirect_uri 不一致調査向けに正規化前後の診断ログを残す。"""
+        respx_mock.post("https://github.com/login/oauth/access_token").mock(
+            return_value=httpx.Response(
+                400,
+                text='{"error":"redirect_uri_mismatch","code":"secret-code"}',
+            )
+        )
+
+        with patch("app.auth.oauth.settings") as mock_settings:
+            mock_settings.GITHUB_CLIENT_ID = "test-client-id"
+            mock_settings.GITHUB_CLIENT_SECRET = "test-client-secret"
+            with caplog.at_level(logging.DEBUG, logger="app.auth.oauth"):
+                result = await GitHubOAuth.exchange_code(
+                    code="invalid-code",
+                    redirect_uri="HTTPS://EXAMPLE.COM:443/api/v1/auth/github/callback/?code=abcdef123456",
+                )
+
+        assert result is None
+        logs = "\n".join(caplog.messages)
+        assert "redirect_uri_raw=https://EXAMPLE.COM:443/api/v1/auth/github/callback/?code=abcd%2A%2A%2A" in logs
+        assert "redirect_uri_normalized=https://example.com/api/v1/auth/github/callback?code=abcd%2A%2A%2A" in logs
+        assert "redirect_uri_changed=True" in logs
+        assert '"code":"***"' in logs
 
 
 class TestGitHubOAuthUserInfo:

--- a/docs/guides/oauth/github.md
+++ b/docs/guides/oauth/github.md
@@ -36,6 +36,8 @@ echo "your-client-secret" > secrets/github_client_secret.txt
   - コールバック後にGitHub APIで所属organizationを検証
   - 未所属ユーザーはログイン完了前に拒否
 
+共通の callback 確認手順は [OAuth設定の共通チェックリスト](index.md#oauth-callback-checklist) を先に参照してください。
+
 ## 共通チェック観点の適用例
 
 - [x] Callback URL

--- a/docs/guides/oauth/google.md
+++ b/docs/guides/oauth/google.md
@@ -55,6 +55,8 @@ docker compose logs api --since=30m | rg -n "auth/google|callback|redirect_uri|m
 
 `Invalid or expired state` が同時に発生する場合は、[トラブルシューティング](../../help/troubleshooting.md#state-mismatch-flow) の診断フローも併せて確認してください。
 
+共通の callback 確認手順は [OAuth設定の共通チェックリスト](index.md#oauth-callback-checklist) を先に参照してください。
+
 ## 共通チェック観点の適用例
 
 - [x] Callback URL

--- a/docs/guides/oauth/index.md
+++ b/docs/guides/oauth/index.md
@@ -62,3 +62,19 @@ secrets/
 
 !!! tip "PKCE"
     PKCEに対応しているプロバイダーでは、YESOD Authが自動的にPKCEを使用してセキュリティを強化します。
+
+## provider追加時チェックリスト
+
+新しいOAuth providerを追加・有効化するときは、次の順で確認してください。
+
+1. `docs/guides/oauth/index.md` の対応プロバイダー表に行を追加する（PKCE/OpenID Connect/備考を含む）。
+2. `docs/guides/oauth/<provider>.md` を作成または更新し、以下を明記する。
+   - Provider管理画面での設定手順
+   - Redirect URI（`/api/v1/auth/<provider>/callback`）
+   - 必要スコープ
+   - クライアントID/シークレットの配置方法
+3. `secrets/<provider>_client_id.txt` と `secrets/<provider>_client_secret.txt` の命名で統一する。
+4. `docs/installation.md` と `docs/help/faq.md` の「有効化したprovider分だけsecretを用意する」方針と矛盾がないか確認する。
+5. セルフホスト公開前に、本番ドメインのRedirect URIへ更新し、ローカル値（`localhost`）が残っていないか確認する。
+
+上記を満たすと、導入時の設定漏れを抑えつつ、OSSとして再利用しやすい説明構成を維持できます。

--- a/docs/guides/oauth/index.md
+++ b/docs/guides/oauth/index.md
@@ -123,6 +123,19 @@ secrets/
 !!! tip "PKCE"
     PKCEに対応しているプロバイダーでは、YESOD Authが自動的にPKCEを使用してセキュリティを強化します。
 
+## Callback確認の共通チェックリスト {#oauth-callback-checklist}
+
+プロバイダー個別ページに入る前に、まずこの共通チェックで callback 周りの設定漏れを切り分けます。
+
+1. Callback URL を完全一致で登録する
+   `http/https`、ホスト、ポート、パス、末尾 `/` を含めて一致しているか確認する。
+2. 認可開始エンドポイントから必ず検証する
+   `GET /api/v1/auth/{provider}` から開始し、直接 callback URL を叩かない。
+3. 失敗時は API ログで callback 関連語を確認する
+   `redirect_uri` / `callback` / `state` を起点に直近ログを確認する。
+4. FAQ / installation / troubleshooting の三点同期チェック
+   共通説明の整合は [インストール](../../installation.md#oauth-credentials) / [FAQ](../../help/faq.md) / [トラブルシューティング](../../help/troubleshooting.md) の3ページで確認する。
+
 ## provider追加時チェックリスト
 
 新しいOAuth providerを追加・有効化するときは、次の順で確認してください。

--- a/docs/help/first-start-troubleshooting.md
+++ b/docs/help/first-start-troubleshooting.md
@@ -8,16 +8,44 @@
    ```bash
    docker compose --profile default ps
    ```
-2. ヘルスチェック
-   ```bash
-   curl -fsS http://localhost:8000/health
-   ```
-3. APIドキュメント
-   ブラウザで `http://localhost:8000/docs` を開く
-4. 必須 secrets
+2. 必須 secrets
    ```bash
    ls -1 secrets/{google_client_id,google_client_secret,discord_client_id,discord_client_secret,jwt_secret}.txt
    ```
+
+## 1. 初回3点確認順（固定）
+
+初回起動失敗時は、必ず次の順番で確認してください。
+
+1. `/health`
+   ```bash
+   curl -fsS http://localhost:8000/health
+   ```
+2. `/docs`
+   ```bash
+   curl -fsS -o /dev/null -w '%{http_code}\n' http://localhost:8000/docs
+   ```
+3. `/metrics`
+   ```bash
+   curl -fsS -o /dev/null -w '%{http_code}\n' http://localhost:8000/metrics
+   ```
+
+## 2. 結果別の次アクション（次に読む文書）
+
+| 確認結果 | 次アクション | 次に読む文書 |
+| --- | --- | --- |
+| `/health` が失敗 | コンテナ状態と依存サービス（db/valkey）ログを確認 | [トラブルシューティング: 認証エラー](troubleshooting.md#認証エラー) |
+| `/health` は成功、`/docs` が失敗 | API 起動オプションと公開ポート設定を確認 | [インストール](../installation.md) |
+| `/docs` は成功、`/metrics` が失敗 | メトリクス収集設定と API ルータ有効化を確認 | [トラブルシューティング](troubleshooting.md) |
+| 3点すべて成功、OAuth 開始で失敗 | provider 設定と callback URL を確認 | [クイックスタート](../getting-started.md#oauth-callback失敗時の確認順) |
+
+## 3. 文書同期チェック（受け入れ基準）
+
+このページを更新したら、以下 3 点が矛盾しないことを確認します。
+
+1. [FAQ](faq.md)
+2. [インストール](../installation.md)
+3. [トラブルシューティング](troubleshooting.md)
 
 ## 症状1: `/health` が失敗する
 

--- a/docs/help/troubleshooting.md
+++ b/docs/help/troubleshooting.md
@@ -139,6 +139,30 @@ environment:
 
 ---
 
+### `redirect_uri_mismatch`（正規化差分の診断）
+
+**症状:** OAuth callback が `400` で失敗し、provider 側の `redirect_uri_mismatch` が疑われる
+
+**確認手順:**
+
+1. API ログで code exchange 失敗ログを抽出
+   ```bash
+   docker compose logs api --since=30m | rg -n "OAuth code exchange failed|redirect_uri_mismatch"
+   ```
+2. 次のログ項目を比較
+   - `redirect_uri_raw`: 実際に送信した URI（機密値はマスク）
+   - `redirect_uri_normalized`: スキーム/ホスト小文字化、既定ポート除去、query 整列後の URI（機密値はマスク）
+   - `redirect_uri_changed`: 正規化前後で差分があったか
+3. provider 側設定の callback URI と `redirect_uri_normalized` を突き合わせる
+
+| 観測シグナル | 主な原因 | 対処 |
+| --- | --- | --- |
+| `redirect_uri_changed=True` かつ provider 設定と不一致 | スキーム/ポート/末尾スラッシュ差異 | provider 設定と `API_URL` を一致させる |
+| `provider_error` に `redirect_uri_mismatch` を含む | callback URL の登録漏れ | provider 側に callback URI を追加 |
+| `provider_error` が `invalid_client` へ遷移 | credentials 不整合 | `client_id` / `client_secret` を再確認 |
+
+---
+
 <a id="auth-rate-limit-429"></a>
 
 ### `429 Too Many Requests`（認証レート制限）

--- a/docs/index.md
+++ b/docs/index.md
@@ -59,6 +59,23 @@ APIドキュメントは http://localhost:8000/docs で確認できます。
 
 OAuth provider を追加する場合は、先に[事前チェックリスト](installation.md#oauth-provider追加時の事前チェック)を実施してください。
 
+## 学習順ガイド（導入→API→運用）
+
+「まず動かす」「API仕様を確認する」「運用手順を固める」の順に進めると、オンボーディングと本番準備を並行しやすくなります。
+
+1. 導入
+   - [インストール](installation.md)
+   - [クイックスタート](getting-started.md)
+   - [OAuth設定ガイド](guides/oauth/index.md)
+2. API
+   - [認証API](api/auth.md)
+   - [ユーザーAPI](api/users.md)
+   - [Webhook API](api/webhooks.md)
+3. 運用
+   - [デプロイガイド](guides/deployment.md)
+   - [トラブルシューティング](help/troubleshooting.md)
+   - [FAQ](help/faq.md)
+
 ## アーキテクチャ
 
 ```


### PR DESCRIPTION
## Summary
- add shared OAuth exchange-failure diagnostics in `api/app/auth/oauth.py`
- log masked `redirect_uri_raw` and `redirect_uri_normalized` with `redirect_uri_changed`
- document `redirect_uri_mismatch` troubleshooting flow in docs
- add test coverage for normalized/masked redirect URI logging on GitHub exchange failure

## Test
- `api/.venv/bin/pytest -q api/tests/test_github_oauth.py`

Closes #400
