### PR TITLE
test(auth): PKCE code_verifier length boundary tests

### DIFF
--- a/api/app/auth/pkce.py
+++ b/api/app/auth/pkce.py
@@ -4,14 +4,28 @@ import base64
 import hashlib
 import secrets
 
+PKCE_CODE_VERIFIER_MIN_LENGTH = 43
+PKCE_CODE_VERIFIER_MAX_LENGTH = 128
+
 
 def generate_code_verifier() -> str:
     """Generate a cryptographically random code verifier."""
     return secrets.token_urlsafe(64)
 
 
+def validate_code_verifier(code_verifier: str) -> None:
+    """Validate PKCE code_verifier length bounds defined by RFC 7636."""
+    verifier_length = len(code_verifier)
+    if (
+        verifier_length < PKCE_CODE_VERIFIER_MIN_LENGTH
+        or verifier_length > PKCE_CODE_VERIFIER_MAX_LENGTH
+    ):
+        raise ValueError("code_verifier must be between 43 and 128 characters")
+
+
 def generate_code_challenge(code_verifier: str) -> str:
     """Generate code challenge from code verifier using S256 method."""
+    validate_code_verifier(code_verifier)
     digest = hashlib.sha256(code_verifier.encode()).digest()
     return base64.urlsafe_b64encode(digest).rstrip(b"=").decode()
 

--- a/api/tests/test_pkce.py
+++ b/api/tests/test_pkce.py
@@ -1,0 +1,40 @@
+"""Tests for PKCE helpers."""
+
+import pytest
+
+from app.auth.pkce import (
+    generate_code_challenge,
+    verify_code_challenge,
+)
+
+
+def test_generate_code_challenge_accepts_min_length_verifier():
+    verifier = "a" * 43
+
+    challenge = generate_code_challenge(verifier)
+
+    assert challenge
+    assert verify_code_challenge(verifier, challenge) is True
+
+
+def test_generate_code_challenge_accepts_max_length_verifier():
+    verifier = "a" * 128
+
+    challenge = generate_code_challenge(verifier)
+
+    assert challenge
+    assert verify_code_challenge(verifier, challenge) is True
+
+
+@pytest.mark.parametrize(
+    ("verifier", "expected_message"),
+    [
+        ("a" * 42, "code_verifier must be between 43 and 128 characters"),
+        ("a" * 129, "code_verifier must be between 43 and 128 characters"),
+    ],
+)
+def test_generate_code_challenge_rejects_out_of_range_length(
+    verifier: str, expected_message: str
+):
+    with pytest.raises(ValueError, match=expected_message):
+        generate_code_challenge(verifier)


### PR DESCRIPTION
## Summary
- add PKCE `code_verifier` length validation (43..128)
- raise fixed `ValueError` message when out of range
- add boundary pytest cases for min/max and under/over lengths

## Test
- `/Users/shiroguchi/Documents/Github/mashirou1234/yesod-auth/.venv-codex/bin/pytest -q api/tests/test_pkce.py`
- `/Users/shiroguchi/Documents/Github/mashirou1234/yesod-auth/.venv-codex/bin/pytest -q api/tests/test_*oauth*.py`

Closes #401
