### PR TITLE
docs/scripts: bootstrap codex labels and add dry-run

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,6 +408,8 @@ This repository includes GitHub Actions workflows for automatic PR approval and 
 
 ```bash
 ./scripts/ensure_github_labels.sh
+# dry-run only (no write):
+./scripts/ensure_github_labels.sh --dry-run
 ```
 
 This script ensures the repository keeps the labels used by Codex / codex-orch automation:

--- a/README.md
+++ b/README.md
@@ -403,6 +403,17 @@ This repository includes GitHub Actions workflows for automatic PR approval and 
 1. Enable `Allow auto-merge` in repository settings
 2. Configure branch protection for `main`/`master` with required status checks
 3. Register your CI checks (including external CI like Woodpecker) as required checks
+4. Keep `PR Auto Approve` and `PR Auto Merge` workflows enabled in GitHub Actions
+5. Bootstrap Codex labels when setting up the repository:
+
+```bash
+./scripts/ensure_github_labels.sh
+```
+
+This script ensures the repository keeps the labels used by Codex / codex-orch automation:
+`codex`, `codex-automation`, `codex:queue`, `codex:claimed`, `codex:blocked`, `codex:pr-opened`.
+
+If a pull request was opened while the auto-approve / auto-merge workflows were disabled, enabling the workflows later does not retroactively register auto-merge for that PR. In that case, reopen/synchronize the PR or enable auto-merge manually.
 
 With this setup, a PR is auto-approved and put into auto-merge waiting state on open/update, then merged automatically when required CI checks complete successfully.
 

--- a/scripts/ensure_github_labels.sh
+++ b/scripts/ensure_github_labels.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "gh CLI is required." >&2
+  exit 1
+fi
+
+repo="${1:-${GH_REPO:-}}"
+if [[ -z "${repo}" ]]; then
+  repo="$(gh repo view --json nameWithOwner -q '.nameWithOwner' 2>/dev/null || true)"
+fi
+
+if [[ -z "${repo}" ]]; then
+  echo "Repository not found. Pass owner/repo as the first argument or set GH_REPO." >&2
+  exit 1
+fi
+
+existing_labels="$(
+  gh label list --repo "${repo}" --limit 200 --json name -q '.[].name' 2>/dev/null || true
+)"
+
+ensure_label() {
+  local name="$1"
+  local color="$2"
+  local description="$3"
+
+  if grep -Fxq "${name}" <<<"${existing_labels}"; then
+    gh label edit "${name}" \
+      --repo "${repo}" \
+      --color "${color}" \
+      --description "${description}" >/dev/null
+    echo "updated: ${name}"
+  else
+    gh label create "${name}" \
+      --repo "${repo}" \
+      --color "${color}" \
+      --description "${description}" >/dev/null
+    echo "created: ${name}"
+  fi
+}
+
+while IFS='|' read -r name color description; do
+  ensure_label "${name}" "${color}" "${description}"
+done <<'EOF'
+codex|0E8A16|managed by Codex
+codex-automation|1D76DB|created or updated by Codex automation
+codex:queue|0E8A16|managed by codex-orch
+codex:claimed|0E8A16|managed by codex-orch
+codex:blocked|0E8A16|managed by codex-orch
+codex:pr-opened|0E8A16|managed by codex-orch
+EOF

--- a/scripts/ensure_github_labels.sh
+++ b/scripts/ensure_github_labels.sh
@@ -6,7 +6,33 @@ if ! command -v gh >/dev/null 2>&1; then
   exit 1
 fi
 
-repo="${1:-${GH_REPO:-}}"
+dry_run=0
+repo=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run)
+      dry_run=1
+      shift
+      ;;
+    -*)
+      echo "Unknown option: $1" >&2
+      echo "Usage: $0 [--dry-run] [owner/repo]" >&2
+      exit 1
+      ;;
+    *)
+      if [[ -n "${repo}" ]]; then
+        echo "Too many positional arguments." >&2
+        echo "Usage: $0 [--dry-run] [owner/repo]" >&2
+        exit 1
+      fi
+      repo="$1"
+      shift
+      ;;
+  esac
+done
+
+repo="${repo:-${GH_REPO:-}}"
 if [[ -z "${repo}" ]]; then
   repo="$(gh repo view --json nameWithOwner -q '.nameWithOwner' 2>/dev/null || true)"
 fi
@@ -26,17 +52,25 @@ ensure_label() {
   local description="$3"
 
   if grep -Fxq "${name}" <<<"${existing_labels}"; then
-    gh label edit "${name}" \
-      --repo "${repo}" \
-      --color "${color}" \
-      --description "${description}" >/dev/null
-    echo "updated: ${name}"
+    if [[ "${dry_run}" -eq 1 ]]; then
+      echo "would update: ${name}"
+    else
+      gh label edit "${name}" \
+        --repo "${repo}" \
+        --color "${color}" \
+        --description "${description}" >/dev/null
+      echo "updated: ${name}"
+    fi
   else
-    gh label create "${name}" \
-      --repo "${repo}" \
-      --color "${color}" \
-      --description "${description}" >/dev/null
-    echo "created: ${name}"
+    if [[ "${dry_run}" -eq 1 ]]; then
+      echo "would create: ${name}"
+    else
+      gh label create "${name}" \
+        --repo "${repo}" \
+        --color "${color}" \
+        --description "${description}" >/dev/null
+      echo "created: ${name}"
+    fi
   fi
 }
 


### PR DESCRIPTION
## Summary
- add `scripts/ensure_github_labels.sh` to create/update codex-related labels
- add `--dry-run` option to preview label operations without write
- update `README.md` with label bootstrap usage and dry-run command

## Test
- `bash -n scripts/ensure_github_labels.sh` ✅
- `./scripts/ensure_github_labels.sh --dry-run mashirou1234/yesod-auth` ✅
- `./.venv-codex/bin/python -m pytest -q api` ⚠️ 1 failed / 203 passed
  - failure: `tests/test_users_delete_account.py::test_delete_account_invalidates_related_session_tokens`
  - reason: local Redis (`localhost:6379`) connection refused in this environment

## Dry-run output
```text
would update: codex
would update: codex-automation
would update: codex:queue
would update: codex:claimed
would update: codex:blocked
would update: codex:pr-opened
```

Closes #456
