### PR TITLE
fix: make admin valkey reconnect wait configurable

### DIFF
--- a/admin/config.py
+++ b/admin/config.py
@@ -12,6 +12,27 @@ def read_secret(name: str, default: str = "") -> str:
     return os.getenv(name.upper(), default)
 
 
+def read_bounded_float_env(
+    name: str,
+    *,
+    default: float,
+    minimum: float,
+    maximum: float,
+) -> float:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+
+    try:
+        value = float(raw)
+    except ValueError as exc:
+        raise ValueError(f"{name} must be a float value") from exc
+
+    if value < minimum or value > maximum:
+        raise ValueError(f"{name} must be between {minimum} and {maximum}")
+    return value
+
+
 class Settings:
     # Use sync driver (psycopg2) for Streamlit
     DATABASE_URL: str = os.getenv(
@@ -19,6 +40,12 @@ class Settings:
         "postgresql://yesod_user:yesod_password@localhost:5432/yesod"
     )
     VALKEY_URL: str = os.getenv("VALKEY_URL", "redis://localhost:6379/0")
+    VALKEY_RECONNECT_WAIT_SECONDS: float = read_bounded_float_env(
+        "VALKEY_RECONNECT_WAIT_SECONDS",
+        default=0.2,
+        minimum=0.05,
+        maximum=30.0,
+    )
     ADMIN_USER: str = os.getenv("ADMIN_USER", "admin")
     ADMIN_PASSWORD: str = read_secret("admin_password", "admin")
     

--- a/admin/tests/test_valkey_client.py
+++ b/admin/tests/test_valkey_client.py
@@ -1,0 +1,67 @@
+"""Tests for admin Valkey reconnect behavior."""
+import types
+import unittest
+from unittest.mock import AsyncMock, patch
+
+import redis.asyncio as redis
+
+import valkey_client
+
+
+class _FakeClient:
+    def __init__(self) -> None:
+        self.close = AsyncMock()
+
+
+class ValkeyClientReconnectTests(unittest.IsolatedAsyncioTestCase):
+    async def test_retries_once_with_configured_wait(self) -> None:
+        first = _FakeClient()
+        second = _FakeClient()
+        operation = AsyncMock(
+            side_effect=[redis.ConnectionError("down"), [{"ok": True}]]
+        )
+
+        settings = types.SimpleNamespace(
+            VALKEY_URL="redis://localhost:6379/0",
+            VALKEY_RECONNECT_WAIT_SECONDS=1.25,
+        )
+        with patch.object(valkey_client, "settings", settings), patch.object(
+            valkey_client.redis,
+            "from_url",
+            side_effect=[first, second],
+        ) as from_url, patch.object(valkey_client.asyncio, "sleep", new=AsyncMock()) as sleep:
+            result = await valkey_client._execute_with_single_retry(operation)
+
+        self.assertEqual(result, [{"ok": True}])
+        self.assertEqual(operation.await_count, 2)
+        self.assertEqual(from_url.call_count, 2)
+        sleep.assert_awaited_once_with(1.25)
+        first.close.assert_awaited_once()
+        second.close.assert_awaited_once()
+
+    async def test_raises_after_second_failure(self) -> None:
+        first = _FakeClient()
+        second = _FakeClient()
+        operation = AsyncMock(
+            side_effect=[redis.ConnectionError("down"), redis.TimeoutError("timeout")]
+        )
+
+        settings = types.SimpleNamespace(
+            VALKEY_URL="redis://localhost:6379/0",
+            VALKEY_RECONNECT_WAIT_SECONDS=0.5,
+        )
+        with patch.object(valkey_client, "settings", settings), patch.object(
+            valkey_client.redis,
+            "from_url",
+            side_effect=[first, second],
+        ), patch.object(valkey_client.asyncio, "sleep", new=AsyncMock()) as sleep:
+            with self.assertRaises(redis.TimeoutError):
+                await valkey_client._execute_with_single_retry(operation)
+
+        sleep.assert_awaited_once_with(0.5)
+        first.close.assert_awaited_once()
+        second.close.assert_awaited_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/admin/tests/test_valkey_reconnect_wait.py
+++ b/admin/tests/test_valkey_reconnect_wait.py
@@ -1,0 +1,51 @@
+"""Tests for VALKEY reconnect wait settings."""
+import os
+import unittest
+from unittest import mock
+
+from config import read_bounded_float_env
+
+
+class ValkeyReconnectWaitConfigTests(unittest.TestCase):
+    def test_uses_default_when_unset(self) -> None:
+        with mock.patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("VALKEY_RECONNECT_WAIT_SECONDS", None)
+            value = read_bounded_float_env(
+                "VALKEY_RECONNECT_WAIT_SECONDS",
+                default=0.2,
+                minimum=0.05,
+                maximum=30.0,
+            )
+        self.assertEqual(value, 0.2)
+
+    def test_uses_env_value_when_set(self) -> None:
+        with mock.patch.dict(
+            os.environ,
+            {"VALKEY_RECONNECT_WAIT_SECONDS": "1.5"},
+            clear=False,
+        ):
+            value = read_bounded_float_env(
+                "VALKEY_RECONNECT_WAIT_SECONDS",
+                default=0.2,
+                minimum=0.05,
+                maximum=30.0,
+            )
+        self.assertEqual(value, 1.5)
+
+    def test_raises_when_out_of_range(self) -> None:
+        with mock.patch.dict(
+            os.environ,
+            {"VALKEY_RECONNECT_WAIT_SECONDS": "0.001"},
+            clear=False,
+        ):
+            with self.assertRaises(ValueError):
+                read_bounded_float_env(
+                    "VALKEY_RECONNECT_WAIT_SECONDS",
+                    default=0.2,
+                    minimum=0.05,
+                    maximum=30.0,
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/admin/valkey_client.py
+++ b/admin/valkey_client.py
@@ -14,8 +14,7 @@ def run_async(coro):
 
 
 async def _get_oauth_states() -> list[dict]:
-    client = redis.from_url(settings.VALKEY_URL, decode_responses=True)
-    try:
+    async def _read(client) -> list[dict]:
         keys = await client.keys("oauth_state:*")
         states = []
         for key in keys:
@@ -29,13 +28,12 @@ async def _get_oauth_states() -> list[dict]:
                 "ttl_seconds": ttl,
             })
         return states
-    finally:
-        await client.close()
+
+    return await _execute_with_single_retry(_read)
 
 
 async def _get_rate_limit_info() -> list[dict]:
-    client = redis.from_url(settings.VALKEY_URL, decode_responses=True)
-    try:
+    async def _read(client) -> list[dict]:
         keys = await client.keys("LIMITER:*")
         limits = []
         for key in keys:
@@ -47,8 +45,21 @@ async def _get_rate_limit_info() -> list[dict]:
                 "ttl_seconds": ttl,
             })
         return limits
-    finally:
-        await client.close()
+
+    return await _execute_with_single_retry(_read)
+
+
+async def _execute_with_single_retry(operation):
+    for attempt in range(2):
+        client = redis.from_url(settings.VALKEY_URL, decode_responses=True)
+        try:
+            return await operation(client)
+        except (redis.ConnectionError, redis.TimeoutError):
+            if attempt == 1:
+                raise
+            await asyncio.sleep(settings.VALKEY_RECONNECT_WAIT_SECONDS)
+        finally:
+            await client.close()
 
 
 def get_oauth_states() -> list[dict]:


### PR DESCRIPTION
## Summary
- add `VALKEY_RECONNECT_WAIT_SECONDS` with bounded validation (0.05-30.0s)
- apply reconnect wait to admin valkey reads with one retry on connection/timeouts
- add admin unit tests for config default/override/range and reconnect wait behavior

## Test
- PYTHONPATH=admin .venv-codex/bin/python -m unittest discover -s admin/tests -p 'test_*.py'

Closes #404
