### PR TITLE
fix: reject empty CORS_ORIGINS entries at startup

### DIFF
--- a/api/app/config.py
+++ b/api/app/config.py
@@ -30,9 +30,12 @@ def resolve_cors_origins(raw_value: str | None) -> tuple[list[str], bool]:
     if raw_value is None or not raw_value.strip():
         return DEFAULT_CORS_ORIGINS.split(","), True
 
-    origins = [origin.strip() for origin in raw_value.split(",") if origin.strip()]
-    if not origins:
-        return DEFAULT_CORS_ORIGINS.split(","), True
+    origins = [origin.strip() for origin in raw_value.split(",")]
+    if any(not origin for origin in origins):
+        raise ValueError(
+            "CORS_ORIGINS contains empty element. "
+            "Set non-empty comma-separated values for CORS_ORIGINS."
+        )
     return origins, False
 
 

--- a/api/tests/test_config.py
+++ b/api/tests/test_config.py
@@ -48,7 +48,7 @@ def test_resolve_cors_origins_uses_default_when_unset():
 
 
 def test_resolve_cors_origins_uses_default_when_blank():
-    origins, using_default = resolve_cors_origins(" , ")
+    origins, using_default = resolve_cors_origins("   ")
 
     assert origins == DEFAULT_CORS_ORIGINS.split(",")
     assert using_default is True
@@ -59,6 +59,11 @@ def test_resolve_cors_origins_uses_env_value_when_set():
 
     assert origins == ["https://example.com", "https://admin.example.com"]
     assert using_default is False
+
+
+def test_resolve_cors_origins_raises_when_empty_element_is_present():
+    with pytest.raises(ValueError, match="CORS_ORIGINS"):
+        resolve_cors_origins("https://example.com, ,https://admin.example.com")
 
 
 def test_settings_raises_when_provider_client_id_exists_but_secret_is_empty(monkeypatch):


### PR DESCRIPTION
## Summary
- `resolve_cors_origins` で `CORS_ORIGINS` の要素を厳密解析し、空要素（連続カンマ・末尾カンマ・空白要素）を `ValueError` として起動時に検出
- 未設定または全空白のときのみ既定値へフォールバックする挙動は維持
- `api/tests/test_config.py` に空要素エラーの単体テストを追加し、エラーメッセージにキー名 `CORS_ORIGINS` が含まれることを検証

## Test
- `api/.venv/bin/pytest -q api/tests/test_config.py`

## Impact
- OAuth 導入時/セルフホスト運用時に `CORS_ORIGINS` の誤設定を起動時に即検知でき、設定不備の持ち込みを防げます。
