### PR TITLE
[Bench-80][17] Classify unsupported webhook signature algorithm

### DIFF
--- a/api/app/webhooks/signer.py
+++ b/api/app/webhooks/signer.py
@@ -3,13 +3,28 @@
 import hashlib
 import hmac
 import time
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class SignatureVerificationResult:
+    """Detailed result for signature verification."""
+
+    ok: bool
+    error_code: str | None = None
+    message: str | None = None
 
 
 class WebhookSigner:
     """Signs webhook payloads for verification."""
 
     SIGNATURE_PREFIX = "sha256="
+    SIGNATURE_ALGORITHM = SIGNATURE_PREFIX.removesuffix("=")
     DEFAULT_MAX_TIMESTAMP_SKEW_SECONDS = 300
+    ERROR_TIMESTAMP_SKEW = "timestamp_skew"
+    ERROR_INVALID_SIGNATURE_FORMAT = "invalid_signature_format"
+    ERROR_UNSUPPORTED_SIGNATURE_ALGORITHM = "unsupported_signature_algorithm"
+    ERROR_HMAC_MISMATCH = "hmac_mismatch"
 
     @staticmethod
     def sign(payload: str, secret: str, timestamp: int | None = None) -> tuple[str, int]:
@@ -60,14 +75,60 @@ class WebhookSigner:
         Returns:
             True if signature is valid, False otherwise
         """
+        result = WebhookSigner.verify_with_error(
+            payload=payload,
+            secret=secret,
+            timestamp=timestamp,
+            signature=signature,
+            current_timestamp=current_timestamp,
+            max_timestamp_skew_seconds=max_timestamp_skew_seconds,
+        )
+        return result.ok
+
+    @staticmethod
+    def verify_with_error(
+        payload: str,
+        secret: str,
+        timestamp: int,
+        signature: str,
+        current_timestamp: int | None = None,
+        max_timestamp_skew_seconds: int = DEFAULT_MAX_TIMESTAMP_SKEW_SECONDS,
+    ) -> SignatureVerificationResult:
+        """Verify signature and return a normalized error classification."""
         if current_timestamp is None:
             current_timestamp = int(time.time())
 
         if abs(current_timestamp - timestamp) > max_timestamp_skew_seconds:
-            return False
+            return SignatureVerificationResult(
+                ok=False,
+                error_code=WebhookSigner.ERROR_TIMESTAMP_SKEW,
+                message="Timestamp outside allowed skew window",
+            )
+
+        if "=" not in signature:
+            return SignatureVerificationResult(
+                ok=False,
+                error_code=WebhookSigner.ERROR_INVALID_SIGNATURE_FORMAT,
+                message="Signature must be in '<algorithm>=<digest>' format",
+            )
+
+        algorithm, _ = signature.split("=", 1)
+        if algorithm != WebhookSigner.SIGNATURE_ALGORITHM:
+            return SignatureVerificationResult(
+                ok=False,
+                error_code=WebhookSigner.ERROR_UNSUPPORTED_SIGNATURE_ALGORITHM,
+                message=f"Unsupported signature algorithm: {algorithm}",
+            )
 
         expected_signature, _ = WebhookSigner.sign(payload, secret, timestamp)
-        return hmac.compare_digest(expected_signature, signature)
+        if not hmac.compare_digest(expected_signature, signature):
+            return SignatureVerificationResult(
+                ok=False,
+                error_code=WebhookSigner.ERROR_HMAC_MISMATCH,
+                message="Signature does not match payload",
+            )
+
+        return SignatureVerificationResult(ok=True)
 
     @staticmethod
     def get_headers(payload: str, secret: str, event_type: str, webhook_id: str) -> dict[str, str]:

--- a/api/tests/test_webhook_signer.py
+++ b/api/tests/test_webhook_signer.py
@@ -186,6 +186,42 @@ class TestWebhookSigner:
             is False
         )
 
+    def test_verify_with_error_classifies_unsupported_algorithm(self):
+        payload = json.dumps({"event_id": str(uuid.uuid4()), "data": {}})
+        secret = "test-secret-key"
+        timestamp = 1_700_000_000
+        signature = "sha1=deadbeef"
+
+        result = WebhookSigner.verify_with_error(
+            payload=payload,
+            secret=secret,
+            timestamp=timestamp,
+            signature=signature,
+            current_timestamp=timestamp,
+        )
+
+        assert result.ok is False
+        assert result.error_code == "unsupported_signature_algorithm"
+        assert result.message == "Unsupported signature algorithm: sha1"
+
+    def test_verify_with_error_keeps_success_path_compatible(self):
+        payload = json.dumps({"event_id": str(uuid.uuid4()), "data": {}})
+        secret = "test-secret-key"
+        timestamp = 1_700_000_000
+        signature, _ = WebhookSigner.sign(payload, secret, timestamp)
+
+        result = WebhookSigner.verify_with_error(
+            payload=payload,
+            secret=secret,
+            timestamp=timestamp,
+            signature=signature,
+            current_timestamp=timestamp,
+        )
+
+        assert result.ok is True
+        assert result.error_code is None
+        assert result.message is None
+
     def test_get_headers_includes_all_required_headers(self):
         """
         Test that get_headers returns all required HTTP headers.

--- a/docs/api/webhooks.md
+++ b/docs/api/webhooks.md
@@ -129,3 +129,19 @@ POST /api/v1/admin/webhooks/reload
 3. 1回目のみ業務処理が実行され、2回目は重複としてスキップされることを確認する
 
 詳細な設定方法は[Webhook設定ガイド](../guides/webhooks.md)を参照してください。
+
+---
+
+## 署名検証エラー分類
+
+受信側の署名検証では、以下の `failure_reason` を固定値として扱うことを推奨します。
+
+| failure_reason | 説明 |
+|------|------|
+| `missing_signature_header` | `X-Webhook-Signature` ヘッダーがない |
+| `missing_timestamp_header` | `X-Webhook-Timestamp` ヘッダーがない |
+| `timestamp_skew` | 許容時刻差を超過している |
+| `invalid_signature_format` | `algorithm=digest` 形式でない |
+| `unsupported_signature_algorithm` | 未対応の署名方式が指定された（例: `sha1`） |
+| `hmac_mismatch` | 署名がペイロードと一致しない |
+| `replay_detected` | リプレイ攻撃が疑われる |

--- a/docs/guides/webhooks.md
+++ b/docs/guides/webhooks.md
@@ -198,6 +198,7 @@ curl -X POST http://localhost:8000/api/v1/admin/webhooks/reload
 - `missing_timestamp_header`
 - `timestamp_skew`
 - `invalid_signature_format`
+- `unsupported_signature_algorithm`
 - `hmac_mismatch`
 - `replay_detected`
 


### PR DESCRIPTION
## Summary
- add `WebhookSigner.verify_with_error()` to classify signature verification failures
- add explicit `unsupported_signature_algorithm` branch and stable error message
- keep existing `verify()` compatibility and update webhook docs error taxonomy

## Testing
- ../.venv-codex/bin/pytest -q tests/test_webhook_signer.py tests/test_webhook_worker.py

Closes #408