### PR TITLE
fix: SESSION_EXPIRY_HOURS 不正値を既定値へフォールバック

### DIFF
--- a/admin/config.py
+++ b/admin/config.py
@@ -1,6 +1,9 @@
 """Admin configuration."""
+import logging
 import os
 from typing import Protocol
+
+logger = logging.getLogger(__name__)
 
 
 def read_secret(name: str, default: str = "") -> str:
@@ -33,6 +36,30 @@ def read_bounded_float_env(
     return value
 
 
+def read_session_expiry_hours_env(
+    name: str = "SESSION_EXPIRY_HOURS",
+    *,
+    default: int = 24,
+) -> int:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+
+    try:
+        value = int(raw)
+        if value <= 0:
+            raise ValueError("must be positive")
+    except ValueError:
+        logger.warning(
+            "%s is invalid (%r); using default value %d",
+            name,
+            raw,
+            default,
+        )
+        return default
+    return value
+
+
 class Settings:
     # Use sync driver (psycopg2) for Streamlit
     DATABASE_URL: str = os.getenv(
@@ -53,7 +80,7 @@ class Settings:
     ENVIRONMENT: str = os.getenv("ENVIRONMENT", "")
     
     # Session persistence (hours)
-    SESSION_EXPIRY_HOURS: int = int(os.getenv("SESSION_EXPIRY_HOURS", "24"))
+    SESSION_EXPIRY_HOURS: int = read_session_expiry_hours_env()
     # SameSite(None) is only valid when Secure=true.
     SESSION_COOKIE_SECURE: bool = os.getenv("SESSION_COOKIE_SECURE", "false").lower() in (
         "1",

--- a/admin/tests/test_session_expiry_hours.py
+++ b/admin/tests/test_session_expiry_hours.py
@@ -1,0 +1,59 @@
+"""Tests for SESSION_EXPIRY_HOURS parsing and fallback behavior."""
+import os
+import unittest
+from unittest import mock
+
+from config import read_session_expiry_hours_env
+
+
+class SessionExpiryHoursConfigTests(unittest.TestCase):
+    def test_uses_default_when_unset(self) -> None:
+        with mock.patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("SESSION_EXPIRY_HOURS", None)
+            value = read_session_expiry_hours_env()
+        self.assertEqual(value, 24)
+
+    def test_uses_env_value_when_valid_positive_integer(self) -> None:
+        with mock.patch.dict(
+            os.environ,
+            {"SESSION_EXPIRY_HOURS": "12"},
+            clear=False,
+        ):
+            value = read_session_expiry_hours_env()
+        self.assertEqual(value, 12)
+
+    def test_falls_back_to_default_and_warns_when_invalid_text(self) -> None:
+        with mock.patch.dict(
+            os.environ,
+            {"SESSION_EXPIRY_HOURS": "abc"},
+            clear=False,
+        ):
+            with self.assertLogs("config", level="WARNING") as captured:
+                value = read_session_expiry_hours_env()
+        self.assertEqual(value, 24)
+        self.assertTrue(
+            any(
+                "SESSION_EXPIRY_HOURS is invalid ('abc'); using default value 24" in message
+                for message in captured.output
+            )
+        )
+
+    def test_falls_back_to_default_and_warns_when_non_positive(self) -> None:
+        with mock.patch.dict(
+            os.environ,
+            {"SESSION_EXPIRY_HOURS": "0"},
+            clear=False,
+        ):
+            with self.assertLogs("config", level="WARNING") as captured:
+                value = read_session_expiry_hours_env()
+        self.assertEqual(value, 24)
+        self.assertTrue(
+            any(
+                "SESSION_EXPIRY_HOURS is invalid ('0'); using default value 24" in message
+                for message in captured.output
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/help/troubleshooting.md
+++ b/docs/help/troubleshooting.md
@@ -33,6 +33,32 @@ ERROR: extension "pg_cron" is not available
 
 ---
 
+### `SESSION_EXPIRY_HOURS` が不正値
+
+**症状:** 管理画面のセッション期限設定が反映されず、起動ログに警告が出る。
+
+警告メッセージ:
+
+```
+SESSION_EXPIRY_HOURS is invalid ('<value>'); using default value 24
+```
+
+**原因:** `SESSION_EXPIRY_HOURS` に整数以外、または 0 以下の値が設定されている。
+
+**解決策:**
+
+1. `SESSION_EXPIRY_HOURS` を 1 以上の整数に修正する
+2. 管理画面コンテナを再作成して反映する
+   ```bash
+   docker compose up -d --force-recreate admin
+   ```
+3. 反映確認
+   ```bash
+   docker compose logs admin --since=10m | rg -n "SESSION_EXPIRY_HOURS is invalid"
+   ```
+
+---
+
 ### データベース接続エラー
 
 ```


### PR DESCRIPTION
## 概要
- admin/config.py に SESSION_EXPIRY_HOURS の安全な読み取り関数を追加
- 不正値（非整数/0以下）で既定値24へフォールバックし、警告ログを統一
- docs/help/troubleshooting.md に障害切り分け手順を追記

## テスト
- PYTHONPATH=admin ./.venv-codex/bin/pytest -q admin/tests/test_session_expiry_hours.py admin/tests/test_session_cookie_samesite.py
- PYTHONPATH=admin ./.venv-codex/bin/pytest -q admin/tests

Refs #409