### PR TITLE
fix(users): standardize sync-from-provider conflict contract

### DIFF
--- a/api/app/users/router.py
+++ b/api/app/users/router.py
@@ -22,6 +22,11 @@ router = APIRouter(prefix="/users", tags=["users"])
 
 # Soft delete grace period (days)
 SOFT_DELETE_GRACE_DAYS = 30
+SYNC_FROM_PROVIDER_CONFLICT_CODE = "SYNC_FROM_PROVIDER_CONFLICT"
+SYNC_FROM_PROVIDER_CONFLICT_MESSAGE = (
+    "Local profile already has different values. "
+    "Clear conflicting fields before syncing from provider."
+)
 
 
 def _get_client_info(request: Request) -> tuple[str | None, str | None]:
@@ -243,6 +248,30 @@ async def sync_profile_from_provider(
         profile = UserProfile(user_id=user.id)
         db.add(profile)
         user.profile = profile
+
+    conflicts = []
+    if (
+        oauth_account.provider_display_name
+        and user.profile.display_name
+        and user.profile.display_name != oauth_account.provider_display_name
+    ):
+        conflicts.append("display_name")
+    if (
+        oauth_account.provider_avatar_url
+        and user.profile.avatar_url
+        and user.profile.avatar_url != oauth_account.provider_avatar_url
+    ):
+        conflicts.append("avatar_url")
+
+    if conflicts:
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "code": SYNC_FROM_PROVIDER_CONFLICT_CODE,
+                "message": SYNC_FROM_PROVIDER_CONFLICT_MESSAGE,
+                "conflicting_fields": conflicts,
+            },
+        )
 
     # Sync from provider
     updated_fields = []

--- a/api/tests/test_users_sync_from_provider.py
+++ b/api/tests/test_users_sync_from_provider.py
@@ -1,0 +1,89 @@
+"""Users sync-from-provider contract tests."""
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth.tokens import create_access_token
+from app.models import OAuthAccount, User, UserProfile
+
+
+@pytest.mark.asyncio
+async def test_sync_from_provider_returns_conflict_contract_for_mismatched_profile(
+    client: AsyncClient, db_session: AsyncSession
+):
+    """POST /api/v1/users/me/sync-from-provider returns fixed 409 contract on conflict."""
+    user = User()
+    db_session.add(user)
+    await db_session.flush()
+    db_session.add(
+        UserProfile(
+            user_id=user.id,
+            display_name="Local Name",
+            avatar_url="https://example.com/local.png",
+        )
+    )
+    db_session.add(
+        OAuthAccount(
+            user_id=user.id,
+            provider="google",
+            provider_user_id="google-user-1",
+            provider_display_name="Provider Name",
+            provider_avatar_url="https://example.com/provider.png",
+        )
+    )
+    await db_session.commit()
+
+    access_token = create_access_token(str(user.id), "sync-conflict@example.com")
+    response = await client.post(
+        "/api/v1/users/me/sync-from-provider?provider=google",
+        headers={"Authorization": f"Bearer {access_token}"},
+    )
+
+    assert response.status_code == 409
+    assert response.json() == {
+        "detail": {
+            "code": "SYNC_FROM_PROVIDER_CONFLICT",
+            "message": (
+                "Local profile already has different values. "
+                "Clear conflicting fields before syncing from provider."
+            ),
+            "conflicting_fields": ["display_name", "avatar_url"],
+        }
+    }
+
+
+@pytest.mark.asyncio
+async def test_sync_from_provider_keeps_success_response_contract(
+    client: AsyncClient, db_session: AsyncSession
+):
+    """POST /api/v1/users/me/sync-from-provider keeps success response unchanged."""
+    user = User()
+    db_session.add(user)
+    await db_session.flush()
+    db_session.add(UserProfile(user_id=user.id))
+    db_session.add(
+        OAuthAccount(
+            user_id=user.id,
+            provider="google",
+            provider_user_id="google-user-2",
+            provider_display_name="Provider User",
+            provider_avatar_url="https://example.com/provider-user.png",
+        )
+    )
+    await db_session.commit()
+
+    access_token = create_access_token(str(user.id), "sync-success@example.com")
+    response = await client.post(
+        "/api/v1/users/me/sync-from-provider?provider=google",
+        headers={"Authorization": f"Bearer {access_token}"},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "message": "Profile synced from google",
+        "provider": "google",
+        "updated_fields": ["display_name", "avatar_url"],
+        "display_name": "Provider User",
+        "avatar_url": "https://example.com/provider-user.png",
+    }

--- a/docs/api/users.md
+++ b/docs/api/users.md
@@ -7,6 +7,7 @@
 | GET | `/api/v1/users/me` | 現在のユーザー情報 |
 | PATCH | `/api/v1/users/me` | プロフィール更新 |
 | DELETE | `/api/v1/users/me` | アカウント削除 |
+| POST | `/api/v1/users/me/sync-from-provider?provider=<name>` | OAuth プロバイダ情報からプロフィール復元 |
 
 ---
 
@@ -144,3 +145,38 @@ Authorization: Bearer <access_token>
 
 !!! note "Webhookイベント"
     アカウント削除時に`user.deleted`イベントが発火します。
+
+---
+
+## プロバイダ情報からプロフィール復元
+
+```bash
+POST /api/v1/users/me/sync-from-provider?provider=google
+Authorization: Bearer <access_token>
+```
+
+**成功レスポンス (`200 OK`)**
+
+```json
+{
+  "message": "Profile synced from google",
+  "provider": "google",
+  "updated_fields": ["display_name", "avatar_url"],
+  "display_name": "Provider User",
+  "avatar_url": "https://example.com/provider-user.png"
+}
+```
+
+**競合レスポンス (`409 Conflict`)**
+
+ローカルのプロフィール値とプロバイダ保持値が衝突する場合は、`detail.code` と `detail.message` を固定した契約で返します。
+
+```json
+{
+  "detail": {
+    "code": "SYNC_FROM_PROVIDER_CONFLICT",
+    "message": "Local profile already has different values. Clear conflicting fields before syncing from provider.",
+    "conflicting_fields": ["display_name", "avatar_url"]
+  }
+}
+```


### PR DESCRIPTION
## Summary
- standardize /api/v1/users/me/sync-from-provider conflict response as 409 with fixed detail.code and detail.message
- add contract tests for conflict and success responses
- update Users API docs with sync endpoint and conflict contract

## Testing
- ../.venv-codex/bin/pytest -q tests/test_users_sync_from_provider.py tests/test_users_me_auth.py tests/test_users_delete_account.py
  - note: existing tests fail in this environment because Redis localhost:6379 is not running; new sync tests pass
