### PR TITLE
[Bench-80][70] Classify missing JWT kid as invalid_token_header

### DIFF
--- a/api/app/auth/jwt.py
+++ b/api/app/auth/jwt.py
@@ -2,12 +2,14 @@
 
 import uuid
 
-from fastapi import Depends, HTTPException, status
+from fastapi import Depends, HTTPException, Request, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from jose import JWTError, jwt
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
+from app.audit import AuditLogger, AuthEventType
 from app.config import get_settings
 from app.db.session import get_db
 from app.models import User
@@ -18,6 +20,8 @@ settings = get_settings()
 security = HTTPBearer(auto_error=False)
 
 MISSING_BEARER_TOKEN_DETAIL = "Not authenticated"
+INVALID_TOKEN_HEADER_CODE = "invalid_token_header"
+INVALID_TOKEN_HEADER_MESSAGE = "Invalid token header"
 
 
 def _missing_bearer_token_exception() -> HTTPException:
@@ -29,7 +33,38 @@ def _missing_bearer_token_exception() -> HTTPException:
     )
 
 
+def _get_client_info(request: Request) -> tuple[str | None, str | None]:
+    """Extract device info and IP address from request."""
+    device_info = request.headers.get("User-Agent")
+    ip_address = request.client.host if request.client else None
+    return device_info, ip_address
+
+
+def _get_token_header_fields(token: str) -> list[str]:
+    """Return sorted JWT header field names or an empty list on parse failure."""
+    try:
+        header = jwt.get_unverified_header(token)
+    except JWTError:
+        return []
+    if not isinstance(header, dict):
+        return []
+    return sorted(str(key) for key in header.keys())
+
+
+def _token_has_kid(token: str) -> bool:
+    """Check whether JWT header contains a non-empty `kid` field."""
+    try:
+        header = jwt.get_unverified_header(token)
+    except JWTError:
+        return True
+    if not isinstance(header, dict):
+        return False
+    kid = header.get("kid")
+    return isinstance(kid, str) and bool(kid.strip())
+
+
 async def get_current_user(
+    request: Request,
     credentials: HTTPAuthorizationCredentials | None = Depends(security),
     db: AsyncSession = Depends(get_db),
 ) -> User:
@@ -44,6 +79,29 @@ async def get_current_user(
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid or expired token",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    token_header_fields = _get_token_header_fields(token)
+    if not _token_has_kid(token):
+        device_info, ip_address = _get_client_info(request)
+        await AuditLogger.log_event(
+            db,
+            AuthEventType.LOGIN_FAILED,
+            details={
+                "reason": INVALID_TOKEN_HEADER_CODE,
+                "token_header_fields": token_header_fields,
+            },
+            ip_address=ip_address,
+            user_agent=device_info,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail={
+                "code": INVALID_TOKEN_HEADER_CODE,
+                "message": INVALID_TOKEN_HEADER_MESSAGE,
+                "token_header_fields": token_header_fields,
+            },
             headers={"WWW-Authenticate": "Bearer"},
         )
 

--- a/api/app/auth/tokens.py
+++ b/api/app/auth/tokens.py
@@ -13,6 +13,7 @@ from app.config import get_settings
 from app.models import RefreshToken
 
 settings = get_settings()
+ACCESS_TOKEN_HEADER_KID = "local-hs256"
 
 
 def create_access_token(user_id: str, email: str) -> str:
@@ -24,7 +25,12 @@ def create_access_token(user_id: str, email: str) -> str:
         "exp": expire,
         "type": "access",
     }
-    return jwt.encode(payload, settings.JWT_SECRET, algorithm=settings.JWT_ALGORITHM)
+    return jwt.encode(
+        payload,
+        settings.JWT_SECRET,
+        algorithm=settings.JWT_ALGORITHM,
+        headers={"kid": ACCESS_TOKEN_HEADER_KID},
+    )
 
 
 def decode_access_token(token: str) -> dict | None:

--- a/api/tests/test_users_me_auth.py
+++ b/api/tests/test_users_me_auth.py
@@ -1,7 +1,12 @@
 """Users /me authentication contract tests."""
 
+from datetime import UTC, datetime, timedelta
+
 import pytest
 from httpx import AsyncClient
+from jose import jwt
+
+from app.config import get_settings
 
 
 @pytest.mark.asyncio
@@ -14,3 +19,33 @@ async def test_users_me_requires_valid_token(client: AsyncClient):
 
     assert response.status_code == 401
     assert response.json() == {"detail": "Invalid or expired token"}
+
+
+@pytest.mark.asyncio
+async def test_users_me_rejects_token_without_kid_header(client: AsyncClient):
+    """GET /api/v1/users/me returns invalid_token_header when JWT kid is missing."""
+    settings = get_settings()
+    token = jwt.encode(
+        {
+            "sub": "00000000-0000-0000-0000-000000000001",
+            "email": "user@example.com",
+            "exp": datetime.now(UTC) + timedelta(minutes=5),
+            "type": "access",
+        },
+        settings.JWT_SECRET,
+        algorithm=settings.JWT_ALGORITHM,
+    )
+
+    response = await client.get(
+        "/api/v1/users/me",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert response.status_code == 401
+    assert response.json() == {
+        "detail": {
+            "code": "invalid_token_header",
+            "message": "Invalid token header",
+            "token_header_fields": ["alg", "typ"],
+        }
+    }


### PR DESCRIPTION
## Summary\n- classify JWT header without  as  in \n- include  in auth audit event details for this failure\n- emit access tokens with a fixed  header and add regression API test\n\n## Test\n- ../.venv-codex/bin/python -m pytest -q tests/test_users_me_auth.py tests/test_sessions.py