### PR TITLE
fix: validate webhook retry_backoff_ms at startup

### DIFF
--- a/api/app/webhooks/config.py
+++ b/api/app/webhooks/config.py
@@ -90,6 +90,7 @@ class WebhookConfigLoader:
                 logger.warning("Skipping invalid endpoint: %s", e)
 
         settings_data = raw_config.get("settings", {})
+        cls._validate_settings(settings_data)
         settings = WebhookSettings(
             max_retries=settings_data.get("max_retries", 5),
             retry_base_delay_seconds=settings_data.get("retry_base_delay_seconds", 2),
@@ -109,6 +110,16 @@ class WebhookConfigLoader:
             CONFIG_PATH,
         )
         return cls._config
+
+    @classmethod
+    def _validate_settings(cls, settings_data: dict[str, Any]) -> None:
+        """Validate webhook settings before applying them."""
+        retry_backoff_ms = settings_data.get("retry_backoff_ms")
+        if retry_backoff_ms is None:
+            return
+
+        if not isinstance(retry_backoff_ms, int) or retry_backoff_ms <= 0:
+            raise ValueError("settings.retry_backoff_ms must be a positive integer")
 
     @classmethod
     def reload(cls) -> WebhookConfig:

--- a/api/tests/test_webhook_config.py
+++ b/api/tests/test_webhook_config.py
@@ -6,6 +6,7 @@ import logging
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
 import yaml
 from hypothesis import given, settings
 from hypothesis import strategies as st
@@ -401,3 +402,32 @@ class TestWebhookConfigValidation:
         finally:
             default_path.unlink()
             override_path.unlink()
+
+    @pytest.mark.parametrize("invalid_backoff_ms", [0, -1])
+    def test_retry_backoff_ms_non_positive_raises_startup_error(self, invalid_backoff_ms: int):
+        """retry_backoff_ms が 0 以下なら起動時に設定エラーとする。"""
+        config = {
+            "endpoints": [
+                {
+                    "id": "test-endpoint",
+                    "url": "https://example.com/webhook",
+                    "secret": "secret",
+                    "events": ["user.created"],
+                }
+            ],
+            "settings": {
+                "retry_backoff_ms": invalid_backoff_ms,
+            },
+        }
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            yaml.dump(config, f)
+            config_path = Path(f.name)
+
+        try:
+            with patch.object(config_module, "CONFIG_PATH", config_path):
+                WebhookConfigLoader._config = None
+                with pytest.raises(ValueError, match="settings\\.retry_backoff_ms"):
+                    WebhookConfigLoader.load()
+        finally:
+            config_path.unlink()


### PR DESCRIPTION
## Summary\n- validate \ in webhook config loading\n- raise startup/reload error for non-positive values (0 and negatives)\n- add regression tests for invalid values and diagnostic message\n\n## Test\n- \============================= test session starts ==============================
platform darwin -- Python 3.14.3, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/shiroguchi/Documents/Github/mashirou1234/yesod-auth/api
configfile: pytest.ini (WARNING: ignoring pytest config in pyproject.toml!)
plugins: anyio-4.12.1, respx-0.22.0, hypothesis-6.151.9, asyncio-1.3.0
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=function, asyncio_default_test_loop_scope=function
collected 12 items / 9 deselected / 3 selected

api/tests/test_webhook_config.py ...                                     [100%]

======================= 3 passed, 9 deselected in 0.18s ========================\n\n## Public impact\n- Misconfigured webhook retry backoff now fails fast with explicit setting name in the error message, improving self-hosted operator diagnostics.