### PR TITLE
Fix fallback provider key for OAuth rate-limit metrics

### DIFF
--- a/api/app/auth/rate_limit.py
+++ b/api/app/auth/rate_limit.py
@@ -25,6 +25,7 @@ SUPPORTED_OAUTH_PROVIDERS = frozenset(
         "twitch",
     }
 )
+MISSING_OAUTH_PROVIDER_KEY = "missing_provider"
 
 # Create limiter instance
 limiter = Limiter(
@@ -52,12 +53,22 @@ def extract_oauth_provider_from_path(path: str) -> str | None:
     return None
 
 
+def resolve_oauth_provider_metric_key(path: str) -> str | None:
+    """Resolve provider metric key with stable fallback for auth paths."""
+    provider = extract_oauth_provider_from_path(path)
+    if provider is not None:
+        return provider
+    if path.startswith("/api/v1/auth/"):
+        return MISSING_OAUTH_PROVIDER_KEY
+    return None
+
+
 async def oauth_rate_limit_exceeded_handler(
     request: Request,
     exc: RateLimitExceeded,
 ) -> Response:
     """Record provider-level burst rate-limit metric before returning 429."""
-    provider = extract_oauth_provider_from_path(request.url.path)
+    provider = resolve_oauth_provider_metric_key(request.url.path)
     if provider is not None:
         record_oauth_rate_limit_burst_metric(provider)
 

--- a/api/tests/test_auth_refresh.py
+++ b/api/tests/test_auth_refresh.py
@@ -12,6 +12,7 @@ from slowapi.wrappers import Limit
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.auth.rate_limit import MISSING_OAUTH_PROVIDER_KEY
 from app.auth.tokens import create_access_token, create_refresh_token, hash_refresh_token
 from app.main import app
 from app.metrics import (
@@ -209,6 +210,7 @@ async def test_refresh_rejects_revoked_session_token(
 @pytest.mark.enable_rate_limiter
 async def test_refresh_rate_limited_response_includes_retry_after_header(client: AsyncClient):
     """Rate limited refresh response should include Retry-After header."""
+    reset_oauth_rate_limit_burst_metrics()
     limiter = app.state.limiter
     limit_item = RateLimitItemPerMinute(30, 1)
     synthetic_limit = Limit(
@@ -242,6 +244,10 @@ async def test_refresh_rate_limited_response_includes_retry_after_header(client:
     assert retry_after is not None
     assert retry_after.isdigit()
     assert int(retry_after) >= 0
+    assert (
+        f'yesod_oauth_rate_limit_burst_total{{provider="{MISSING_OAUTH_PROVIDER_KEY}"}} 1'
+        in render_oauth_rate_limit_burst_metrics_lines()
+    )
 
 
 @pytest.mark.asyncio
@@ -277,4 +283,8 @@ async def test_oauth_provider_rate_limit_records_burst_metric(client: AsyncClien
     assert response.status_code == 429
     assert 'yesod_oauth_rate_limit_burst_total{provider="google"} 1' in (
         render_oauth_rate_limit_burst_metrics_lines()
+    )
+    assert (
+        f'yesod_oauth_rate_limit_burst_total{{provider="{MISSING_OAUTH_PROVIDER_KEY}"}} 1'
+        not in render_oauth_rate_limit_burst_metrics_lines()
     )

--- a/docs/api/auth.md
+++ b/docs/api/auth.md
@@ -30,6 +30,7 @@
 `GET /metrics` では OAuth 関連のレート制限を次のメトリクスで確認できます。
 
 - `yesod_oauth_rate_limit_burst_total{provider="<provider>"}`: provider 別に 429 が返った回数
+  - provider をパスから特定できない場合は `provider="missing_provider"` で集計
 - `yesod_oauth_failures_total{provider="<provider>",reason="<reason>"}`: OAuth 処理失敗回数（既存）
   - `reason="unknown_error_code"`: provider callback で未知の OAuth error code を受けた回数（provider ラベル付き）
 


### PR DESCRIPTION
## 概要
- OAuth rate-limit メトリクスの provider 解決に `missing_provider` fallback を追加
- `/api/v1/auth/*` で provider 特定不能なパス（例: `/api/v1/auth/refresh`）でも一意キーで集計
- 既存 provider 指定パスの挙動は維持

## 変更点
- `api/app/auth/rate_limit.py`
  - `MISSING_OAUTH_PROVIDER_KEY = "missing_provider"` を追加
  - `resolve_oauth_provider_metric_key` を追加して handler から利用
- `api/tests/test_auth_refresh.py`
  - refresh の 429 テストで fallback キーの記録を検証
  - provider=`google` の 429 テストで fallback 混入がないことを検証
- `docs/api/auth.md`
  - fallback キー仕様を追記

## テスト
- `cd api && .venv/bin/pytest tests -k rate_limit`
  - 2 passed, 213 deselected

## 関連
- closes #444
