### PR TITLE
fix: normalize OAuth provider validation and error contract

### DIFF
--- a/api/app/auth/router.py
+++ b/api/app/auth/router.py
@@ -59,6 +59,7 @@ OAUTH_PROVIDER_CREDENTIAL_FIELDS = {
     "slack": ("SLACK_CLIENT_ID", "SLACK_CLIENT_SECRET"),
     "twitch": ("TWITCH_CLIENT_ID", "TWITCH_CLIENT_SECRET"),
 }
+SUPPORTED_OAUTH_PROVIDERS = tuple(OAUTH_PROVIDER_CREDENTIAL_FIELDS.keys())
 KNOWN_OAUTH_CALLBACK_ERROR_CODES = {
     "access_denied",
     "invalid_request",
@@ -70,6 +71,22 @@ KNOWN_OAUTH_CALLBACK_ERROR_CODES = {
     "server_error",
     "temporarily_unavailable",
 }
+
+
+def _normalize_oauth_provider(provider: str) -> str:
+    """Normalize provider input for stable validation."""
+    return provider.strip().lower()
+
+
+def _validate_supported_oauth_provider(provider: str) -> str:
+    """Return normalized provider or raise stable 400 contract."""
+    normalized_provider = _normalize_oauth_provider(provider)
+    if normalized_provider not in OAUTH_PROVIDER_CREDENTIAL_FIELDS:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Unsupported OAuth provider '{normalized_provider}'.",
+        )
+    return normalized_provider
 
 
 def _get_client_info(request: Request) -> tuple[str | None, str | None]:
@@ -153,12 +170,9 @@ async def _validate_callback_url_or_raise(
 
 def _ensure_provider_enabled(provider: str) -> None:
     """Ensure OAuth provider credentials exist before starting auth flow."""
+    provider = _validate_supported_oauth_provider(provider)
     credential_fields = OAUTH_PROVIDER_CREDENTIAL_FIELDS.get(provider)
-    if credential_fields is None:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Unsupported OAuth provider '{provider}'.",
-        )
+    assert credential_fields is not None
 
     client_id_field, client_secret_field = credential_fields
     client_id = getattr(settings, client_id_field, "")
@@ -1181,20 +1195,7 @@ async def mock_login(
             status_code=403, detail="Mock OAuth is disabled. Set MOCK_OAUTH_ENABLED=1 to enable."
         )
 
-    if provider not in [
-        "google",
-        "discord",
-        "github",
-        "x",
-        "linkedin",
-        "facebook",
-        "slack",
-        "twitch",
-    ]:
-        raise HTTPException(
-            status_code=400,
-            detail="Provider must be 'google', 'discord', 'github', 'x', 'linkedin', 'facebook', 'slack', or 'twitch'",
-        )
+    provider = _validate_supported_oauth_provider(provider)
 
     device_info, ip_address = _get_client_info(request)
     mock_user = get_mock_user(user)

--- a/api/tests/test_auth_oauth_provider_disabled.py
+++ b/api/tests/test_auth_oauth_provider_disabled.py
@@ -42,3 +42,12 @@ def test_oauth_unknown_provider_raises_400():
 
     assert exc_info.value.status_code == 400
     assert exc_info.value.detail == "Unsupported OAuth provider 'unknown'."
+
+
+def test_oauth_unknown_provider_normalizes_case_before_400():
+    """Unknown mixed-case provider input should keep stable detail."""
+    with pytest.raises(auth_router_module.HTTPException) as exc_info:
+        auth_router_module._ensure_provider_enabled("UnKnown")
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail == "Unsupported OAuth provider 'unknown'."

--- a/api/tests/test_mock_oauth.py
+++ b/api/tests/test_mock_oauth.py
@@ -43,6 +43,15 @@ async def test_mock_login_invalid_provider(client: AsyncClient):
     """Test mock login with invalid provider."""
     response = await client.get("/api/v1/auth/mock/login?provider=invalid")
     assert response.status_code == 400
+    assert response.json() == {"detail": "Unsupported OAuth provider 'invalid'."}
+
+
+@pytest.mark.asyncio
+async def test_mock_login_provider_is_case_insensitive(client: AsyncClient):
+    """Mixed-case provider should be normalized and accepted."""
+    response = await client.get("/api/v1/auth/mock/login?provider=GitHub")
+    assert response.status_code == 200
+    assert response.json()["provider"] == "github"
 
 
 @pytest.mark.asyncio

--- a/docs/api/auth.md
+++ b/docs/api/auth.md
@@ -303,6 +303,15 @@ GET /api/v1/auth/mock/login?user=alice&provider=google
 
 **利用可能なプロバイダー:** `google`, `github`, `discord`, `x`, `linkedin`, `facebook`, `slack`, `twitch`
 
+- `provider` は小文字正規化して判定（例: `GitHub` は `github` と同義）
+- サポート外 provider は `400 Bad Request` と固定文言を返却
+
+```json
+{
+  "detail": "Unsupported OAuth provider 'unknown'."
+}
+```
+
 ### ユーザー一覧
 
 ```bash


### PR DESCRIPTION
## Summary\n- normalize provider input with lowercase/trim before validation\n- return stable 400 detail for unsupported providers\n- add tests for mixed-case and invalid provider inputs\n- sync Mock OAuth behavior note in docs\n\n## Test\n- UV_CACHE_DIR=/tmp/uv-cache-yesod-auth uv run pytest tests/test_mock_oauth.py tests/test_auth_oauth_provider_disabled.py -q\n- UV_CACHE_DIR=/tmp/uv-cache-yesod-auth uv run pytest tests -k provider -q\n\nCloses #445