### PR TITLE
docs: sync-from-provider の制約と 400/404 失敗例を明文化

### DIFF
--- a/docs/api/users.md
+++ b/docs/api/users.md
@@ -155,6 +155,12 @@ POST /api/v1/users/me/sync-from-provider?provider=google
 Authorization: Bearer <access_token>
 ```
 
+**前提条件**
+
+1. `provider` は `google` または `discord` のみ指定可能
+2. 指定した `provider` の OAuth 連携が、実行ユーザーに紐づいていること
+3. `provider_display_name` / `provider_avatar_url` のいずれかが保存済みであること
+
 **成功レスポンス (`200 OK`)**
 
 ```json
@@ -164,6 +170,42 @@ Authorization: Bearer <access_token>
   "updated_fields": ["display_name", "avatar_url"],
   "display_name": "Provider User",
   "avatar_url": "https://example.com/provider-user.png"
+}
+```
+
+**入力不正 (`400 Bad Request`: 未対応 provider)**
+
+```bash
+POST /api/v1/users/me/sync-from-provider?provider=github
+Authorization: Bearer <access_token>
+```
+
+```json
+{
+  "detail": "Unsupported provider"
+}
+```
+
+**未連携 (`404 Not Found`)**
+
+```bash
+POST /api/v1/users/me/sync-from-provider?provider=discord
+Authorization: Bearer <access_token>
+```
+
+```json
+{
+  "detail": "No discord account linked"
+}
+```
+
+**保存情報なし (`400 Bad Request`)**
+
+指定した provider は連携済みでも、保存済みプロフィール情報がない場合は `400` を返します。
+
+```json
+{
+  "detail": "No provider info stored for google. Try re-logging in with google."
 }
 ```
 
@@ -180,3 +222,7 @@ Authorization: Bearer <access_token>
   }
 }
 ```
+
+!!! tip "三点同期の確認導線"
+    FAQ は [sync-from-provider の 400/404 の意味](../help/faq.md#sync-from-provider-の-400404-は何を意味する)、
+    障害対応は [sync-from-provider で 400/404 が返る](../help/troubleshooting.md#sync-from-provider-errors) を参照してください。

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -105,6 +105,17 @@ organization制限が必要な場合は、`read:org`スコープとコールバ�
 
 運用メモとして、分類時は「発生時刻」「対象エンドポイント」「利用プロバイダー（mock/google/github等）」をセットで記録すると再現調査が容易です。
 
+### sync-from-provider の 400/404 は何を意味する？
+
+`POST /api/v1/users/me/sync-from-provider` の主な失敗は次の 3 種類です。
+
+1. `400 Unsupported provider`: `provider` が `google` / `discord` 以外
+2. `404 No <provider> account linked`: 指定 provider の連携がない
+3. `400 No provider info stored ...`: provider 連携はあるが保存済みプロフィール情報がない
+
+API 契約とレスポンス例は [ユーザーAPI: プロバイダ情報からプロフィール復元](../api/users.md#プロバイダ情報からプロフィール復元) を参照してください。  
+切り分け手順は [トラブルシューティング: sync-from-provider で 400/404 が返る](./troubleshooting.md#sync-from-provider-errors) を参照してください。
+
 ---
 
 ## 開発

--- a/docs/help/troubleshooting.md
+++ b/docs/help/troubleshooting.md
@@ -221,6 +221,30 @@ environment:
 
 ---
 
+<a id="sync-from-provider-errors"></a>
+
+### sync-from-provider で 400/404 が返る
+
+対象: `POST /api/v1/users/me/sync-from-provider?provider=<name>`
+
+| ステータス | 代表メッセージ | 主な原因 | 直近の対処 |
+| --- | --- | --- | --- |
+| 400 | `Unsupported provider` | `provider` が `google` / `discord` 以外 | `provider` を `google` か `discord` に修正 |
+| 404 | `No <provider> account linked` | 指定 provider の連携がない | 当該 provider で再ログインして連携を作成 |
+| 400 | `No provider info stored for <provider>...` | 連携はあるが保存済みプロフィール情報が空 | 同 provider で再ログインし、プロフィール情報を再取得 |
+
+確認コマンド例:
+
+```bash
+TOKEN="<access_token>"
+curl -sS -X POST -H "Authorization: Bearer ${TOKEN}" \
+  "http://localhost:8000/api/v1/users/me/sync-from-provider?provider=discord" | jq
+```
+
+契約の最新版は [ユーザーAPI: プロバイダ情報からプロフィール復元](../api/users.md#プロバイダ情報からプロフィール復元) を参照してください。
+
+---
+
 <a id="secrets-permission-recovery"></a>
 
 ### secrets 権限不備で `Permission denied` が出る


### PR DESCRIPTION
## 概要
- `docs/api/users.md` に `sync-from-provider` の前提条件を追加（provider 制約: `google` / `discord`）
- `sync-from-provider` の失敗例を追記（`400 Unsupported provider` / `404 No <provider> account linked` / `400 No provider info stored ...`）
- 三点同期導線として FAQ / troubleshooting へ参照を追加

## 実装整合確認
- `api/app/users/router.py` の実装制約（provider 制限、404、400 メッセージ）とドキュメント記載が一致することを確認

## テスト
- 最小再現: `cd api && UV_CACHE_DIR=/tmp/uv-cache uv run pytest -q tests/test_users_sync_from_provider.py` ✅
- 回帰: `cd api && UV_CACHE_DIR=/tmp/uv-cache uv run pytest -q` ⚠️
  - 214 passed / 1 failed
  - 失敗: `tests/test_users_delete_account.py::test_delete_account_invalidates_related_session_tokens`
  - 原因: `localhost:6379` の Valkey 未起動による環境依存失敗（今回変更との直接関係なし）

Closes #486
