### PR TITLE
Fix webhook retry backoff validation and diagnostics

### DIFF
--- a/api/app/webhooks/config.py
+++ b/api/app/webhooks/config.py
@@ -114,12 +114,49 @@ class WebhookConfigLoader:
     @classmethod
     def _validate_settings(cls, settings_data: dict[str, Any]) -> None:
         """Validate webhook settings before applying them."""
+        cls._validate_non_negative_int_setting(settings_data, "retry_base_delay_seconds")
+        cls._validate_non_negative_int_setting(settings_data, "retry_max_delay_seconds")
+
+        retry_base_delay_seconds = settings_data.get("retry_base_delay_seconds", 2)
+        retry_max_delay_seconds = settings_data.get("retry_max_delay_seconds", 60)
+        if retry_max_delay_seconds < retry_base_delay_seconds:
+            raise ValueError(
+                "settings.retry_max_delay_seconds must be greater than or equal to "
+                "settings.retry_base_delay_seconds"
+            )
+
         retry_backoff_ms = settings_data.get("retry_backoff_ms")
         if retry_backoff_ms is None:
             return
 
-        if not isinstance(retry_backoff_ms, int) or retry_backoff_ms <= 0:
-            raise ValueError("settings.retry_backoff_ms must be a positive integer")
+        if isinstance(retry_backoff_ms, int):
+            if retry_backoff_ms < 0:
+                raise ValueError("settings.retry_backoff_ms must be a non-negative integer")
+            return
+
+        if not isinstance(retry_backoff_ms, list) or not retry_backoff_ms:
+            raise ValueError("settings.retry_backoff_ms must be a non-empty array of integers")
+
+        prev_value = -1
+        for idx, value in enumerate(retry_backoff_ms):
+            if not isinstance(value, int) or value < 0:
+                raise ValueError(
+                    f"settings.retry_backoff_ms[{idx}] must be a non-negative integer"
+                )
+            if idx > 0 and value < prev_value:
+                raise ValueError(
+                    f"settings.retry_backoff_ms[{idx}] must be greater than or equal to "
+                    f"settings.retry_backoff_ms[{idx - 1}]"
+                )
+            prev_value = value
+
+    @staticmethod
+    def _validate_non_negative_int_setting(settings_data: dict[str, Any], key: str) -> None:
+        value = settings_data.get(key)
+        if value is None:
+            return
+        if not isinstance(value, int) or value < 0:
+            raise ValueError(f"settings.{key} must be a non-negative integer")
 
     @classmethod
     def reload(cls) -> WebhookConfig:

--- a/api/tests/test_webhook_config.py
+++ b/api/tests/test_webhook_config.py
@@ -403,9 +403,9 @@ class TestWebhookConfigValidation:
             default_path.unlink()
             override_path.unlink()
 
-    @pytest.mark.parametrize("invalid_backoff_ms", [0, -1])
-    def test_retry_backoff_ms_non_positive_raises_startup_error(self, invalid_backoff_ms: int):
-        """retry_backoff_ms が 0 以下なら起動時に設定エラーとする。"""
+    @pytest.mark.parametrize("invalid_backoff_ms", [-1])
+    def test_retry_backoff_ms_negative_raises_startup_error(self, invalid_backoff_ms: int):
+        """retry_backoff_ms が負値なら起動時に設定エラーとする。"""
         config = {
             "endpoints": [
                 {
@@ -428,6 +428,103 @@ class TestWebhookConfigValidation:
             with patch.object(config_module, "CONFIG_PATH", config_path):
                 WebhookConfigLoader._config = None
                 with pytest.raises(ValueError, match="settings\\.retry_backoff_ms"):
+                    WebhookConfigLoader.load()
+        finally:
+            config_path.unlink()
+
+    @pytest.mark.parametrize(
+        ("retry_backoff_ms", "error_key"),
+        [
+            ([], "settings.retry_backoff_ms"),
+            ([100, -1, 300], "settings.retry_backoff_ms\\[1\\]"),
+            ([300, 100, 500], "settings.retry_backoff_ms\\[1\\]"),
+        ],
+    )
+    def test_retry_backoff_ms_list_invalid_cases_raise_startup_error(
+        self,
+        retry_backoff_ms: list[int],
+        error_key: str,
+    ):
+        """retry_backoff_ms 配列が非負・単調増加でなければ起動時に設定エラーとする。"""
+        config = {
+            "endpoints": [
+                {
+                    "id": "test-endpoint",
+                    "url": "https://example.com/webhook",
+                    "secret": "secret",
+                    "events": ["user.created"],
+                }
+            ],
+            "settings": {
+                "retry_backoff_ms": retry_backoff_ms,
+            },
+        }
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            yaml.dump(config, f)
+            config_path = Path(f.name)
+
+        try:
+            with patch.object(config_module, "CONFIG_PATH", config_path):
+                WebhookConfigLoader._config = None
+                with pytest.raises(ValueError, match=error_key):
+                    WebhookConfigLoader.load()
+        finally:
+            config_path.unlink()
+
+    def test_retry_backoff_ms_list_non_decreasing_is_accepted(self):
+        """retry_backoff_ms 配列が非負かつ単調増加なら設定を受理する。"""
+        config = {
+            "endpoints": [
+                {
+                    "id": "test-endpoint",
+                    "url": "https://example.com/webhook",
+                    "secret": "secret",
+                    "events": ["user.created"],
+                }
+            ],
+            "settings": {
+                "retry_backoff_ms": [100, 100, 300, 500],
+            },
+        }
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            yaml.dump(config, f)
+            config_path = Path(f.name)
+
+        try:
+            with patch.object(config_module, "CONFIG_PATH", config_path):
+                WebhookConfigLoader._config = None
+                loaded = WebhookConfigLoader.load()
+            assert loaded.settings.retry_base_delay_seconds == 2
+        finally:
+            config_path.unlink()
+
+    def test_retry_delay_bounds_invalid_order_raises_startup_error(self):
+        """retry_max_delay_seconds が retry_base_delay_seconds 未満なら設定エラーにする。"""
+        config = {
+            "endpoints": [
+                {
+                    "id": "test-endpoint",
+                    "url": "https://example.com/webhook",
+                    "secret": "secret",
+                    "events": ["user.created"],
+                }
+            ],
+            "settings": {
+                "retry_base_delay_seconds": 10,
+                "retry_max_delay_seconds": 5,
+            },
+        }
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            yaml.dump(config, f)
+            config_path = Path(f.name)
+
+        try:
+            with patch.object(config_module, "CONFIG_PATH", config_path):
+                WebhookConfigLoader._config = None
+                with pytest.raises(ValueError, match="settings\\.retry_max_delay_seconds"):
                     WebhookConfigLoader.load()
         finally:
             config_path.unlink()

--- a/docs/guides/webhooks.md
+++ b/docs/guides/webhooks.md
@@ -36,6 +36,8 @@ settings:
   max_retries: 5
   retry_base_delay_seconds: 2
   retry_max_delay_seconds: 60
+  # 任意: 再送バックオフを明示する場合は非負・単調増加（ms）
+  retry_backoff_ms: [500, 1000, 2000]
   delivery_timeout_seconds: 30
 ```
 

--- a/docs/help/troubleshooting.md
+++ b/docs/help/troubleshooting.md
@@ -456,6 +456,11 @@ FAQ での方針説明は [FAQ: Adminで未翻訳キーが出たときの表示�
      - "user_created"  # 間違い
    ```
 
+4. 起動時に `settings.retry_*` エラーが出る場合は設定値の関係を確認
+   - `settings.retry_base_delay_seconds` と `settings.retry_max_delay_seconds` は非負整数
+   - `settings.retry_max_delay_seconds >= settings.retry_base_delay_seconds`
+   - `settings.retry_backoff_ms` を配列で指定する場合は「非負・単調増加（ms）」にする
+
 ---
 
 ### 署名検証に失敗する


### PR DESCRIPTION
## Summary
- validate webhook retry delay settings with non-negative and monotonic constraints
- improve startup error messages with precise settings keys/indexes
- add config tests and update webhook docs/troubleshooting guidance

## Test
- .venv-codex/bin/pytest -q api/tests/test_webhook_config.py
- .venv-codex/bin/pytest -q api/tests -k webhook

Closes #446