### PR TITLE
[Bench-80][76] Mock→実OAuth導線を docs 4点で同期

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -97,7 +97,7 @@ OAuth 導入時は、実装前に「provider 管理画面の callback URL」と�
 
 ### FAQ / installation / troubleshooting 同期チェック（受け入れ基準）
 
-- [FAQ の本番OAuth切替手順](help/faq.md#mock-oauthから本番oauthへ切り替える最小確認は) にある callback 確認手順と矛盾がない
+- [FAQ の実OAuth切替手順](help/faq.md#mock-oauthから実oauthへ切り替える最小確認は) にある callback 確認手順と矛盾がない
 - [インストールの OAuth 認証情報](installation.md#oauth認証情報) と callback 前提（URL 形式・provider 単位）が一致している
 - [トラブルシューティング](help/troubleshooting.md#認証エラー) への参照導線が残っている
 
@@ -228,6 +228,11 @@ curl -fsS -o /dev/null -w '%{http_code}\n' \
 
 `invalid_client` や `redirect_uri_mismatch` が出る場合は
 [トラブルシューティング](help/troubleshooting.md) を参照してください。
+
+再開ポイント:
+- [FAQ: Mock OAuthから実OAuthへ切り替える最小確認は？](help/faq.md#mock-oauthから実oauthへ切り替える最小確認は)
+- [インストール: provider 未設定時の最短スキップ手順](installation.md#provider-未設定時の最短スキップ手順)
+- [トラブルシューティング: provider 未設定のまま認証導線を実行した](help/troubleshooting.md#provider-未設定のまま認証導線を実行した)
 
 ### セッション失効時の再ログイン手順
 

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -114,13 +114,18 @@ organization制限が必要な場合は、`read:org`スコープとコールバ�
 開発・テスト時に、実際のOAuthプロバイダーなしで認証フローをテストできる機能です。
 `MOCK_OAUTH_ENABLED=1`で有効化できます。
 
-### Mock OAuthから本番OAuthへ切り替える最小確認は？
+### Mock OAuthから実OAuthへ切り替える最小確認は？
 
-本番切替時は次の3項目だけ先に確認してください。
+実OAuth切替時は次の3項目だけ先に確認してください。
 
 1. `MOCK_OAUTH_ENABLED=0` になっていること（アプリ既定値は `0`。開発用 `default`/`ci` プロファイルでは Compose 側で `1` に上書きされるため、本番運用値を再確認）
 2. 利用するOAuthプロバイダーの `*_client_id` / `*_client_secret` が本番値で設定され、不要な開発用値が混在していないこと
 3. provider管理画面の callback URL と `GET /api/v1/auth/{provider}/callback` の実運用URLが一致していること
+
+再開ポイント:
+- [クイックスタート: Mock OAuthから実OAuthへ切り替える最小チェック](../getting-started.md#mock-oauthから実oauthへ切り替える最小チェック)
+- [インストール: provider 未設定時の最短スキップ手順](../installation.md#provider-未設定時の最短スキップ手順)
+- [トラブルシューティング: provider 未設定のまま認証導線を実行した](./troubleshooting.md#provider-未設定のまま認証導線を実行した)
 
 切り分け手順は [トラブルシューティング: state mismatch 診断フロー](./troubleshooting.md#state-mismatch-flow) と [トラブルシューティング: 401 Unauthorized / invalid_client](./troubleshooting.md#401-unauthorized--invalid_client) を参照してください。  
 前提の設定差分は [インストール: profile別の環境変数優先順位](../installation.md#profile別の環境変数優先順位) を参照してください。

--- a/docs/help/troubleshooting.md
+++ b/docs/help/troubleshooting.md
@@ -164,6 +164,7 @@ environment:
 再開ポイント:
 - [クイックスタート: provider 未設定時の最短スキップ手順](../getting-started.md#provider-未設定時の最短スキップ手順)
 - [インストール: provider 未設定時の最短スキップ手順](../installation.md#provider-未設定時の最短スキップ手順)
+- [FAQ: Mock OAuthから実OAuthへ切り替える最小確認は？](./faq.md#mock-oauthから実oauthへ切り替える最小確認は)
 
 ---
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -44,6 +44,7 @@ OAuth provider をまだ一部用意できていない場合は、次の手順�
 - 起動確認の継続: [docker compose利用時の最小確認手順](#docker-compose利用時の最小確認手順)
 - 実 OAuth の再開: [クイックスタート: Mock OAuthから実OAuthへ切り替える最小チェック](./getting-started.md#mock-oauthから実oauthへ切り替える最小チェック)
 - 失敗時: [トラブルシューティング: provider 未設定のまま認証導線を実行した](./help/troubleshooting.md#provider-未設定のまま認証導線を実行した)
+- FAQ での要点確認: [Mock OAuthから実OAuthへ切り替える最小確認は？](./help/faq.md#mock-oauthから実oauthへ切り替える最小確認は)
 
 ## Docker起動前チェック項目
 


### PR DESCRIPTION
## 概要
- FAQ の見出し/本文を「Mock OAuth→実OAuth」に統一
- getting-started / installation / troubleshooting に再開ポイント導線を同期
- 旧アンカー参照（本番OAuth見出し）を実OAuth見出しへ更新

## テスト
- rg -n "Mock OAuth|実OAuth|最短スキップ手順|再開ポイント" docs/getting-started.md docs/installation.md docs/help/faq.md docs/help/troubleshooting.md
- rg -n "mock-oauthから本番oauthへ切り替える最小確認は|本番OAuthへ切り替える最小確認" docs -S （0件確認）
- mkdocs build -q （環境に mkdocs が無く未実行）

Closes #447
