### PR TITLE
test(admin): fix SameSite fallback boundary coverage (fix #448)

### DIFF
--- a/admin/config.py
+++ b/admin/config.py
@@ -6,6 +6,9 @@ from typing import Protocol
 logger = logging.getLogger(__name__)
 
 
+SUPPORTED_SESSION_COOKIE_SAMESITE = {"lax", "strict", "none"}
+
+
 def read_secret(name: str, default: str = "") -> str:
     """Read secret from Docker secrets or environment variable."""
     secret_path = f"/run/secrets/{name}"
@@ -60,6 +63,13 @@ def read_session_expiry_hours_env(
     return value
 
 
+def normalize_session_cookie_samesite(value: str) -> str:
+    normalized = value.strip().lower()
+    if normalized in SUPPORTED_SESSION_COOKIE_SAMESITE:
+        return normalized
+    return ""
+
+
 class Settings:
     # Use sync driver (psycopg2) for Streamlit
     DATABASE_URL: str = os.getenv(
@@ -88,8 +98,10 @@ class Settings:
         "yes",
         "on",
     )
-    # Empty means "use framework default" and emit a warning for visibility.
-    SESSION_COOKIE_SAMESITE: str = os.getenv("SESSION_COOKIE_SAMESITE", "").strip()
+    # Empty/unknown means "use framework default" and emit a warning for visibility.
+    SESSION_COOKIE_SAMESITE: str = normalize_session_cookie_samesite(
+        os.getenv("SESSION_COOKIE_SAMESITE", "")
+    )
 
     # Default language (en, ja, fr, ko, de)
     DEFAULT_LANGUAGE: str = os.getenv("DEFAULT_LANGUAGE", "en")
@@ -110,7 +122,16 @@ def warn_if_session_cookie_samesite_unset(
     session_cookie_secure: bool = True,
 ) -> bool:
     env_name = environment.strip() or "production"
-    samesite = session_cookie_samesite.strip().lower()
+    raw_samesite = session_cookie_samesite.strip()
+    samesite = normalize_session_cookie_samesite(raw_samesite)
+
+    if raw_samesite and not samesite:
+        logger.warning(
+            "SESSION_COOKIE_SAMESITE=%r is unsupported; falling back to framework default (environment=%s)",
+            raw_samesite,
+            env_name,
+        )
+        return True
 
     if not samesite:
         logger.warning(

--- a/admin/tests/test_session_cookie_samesite.py
+++ b/admin/tests/test_session_cookie_samesite.py
@@ -21,17 +21,19 @@ class SessionCookieSameSiteWarningTests(unittest.TestCase):
             "staging",
         )
 
-    def test_does_not_warn_when_samesite_is_set(self) -> None:
-        logger = Mock()
+    def test_does_not_warn_for_supported_samesite_values(self) -> None:
+        for value in ("lax", "Strict", "NONE"):
+            with self.subTest(value=value):
+                logger = Mock()
 
-        warned = warn_if_session_cookie_samesite_unset(
-            logger,
-            environment="staging",
-            session_cookie_samesite="lax",
-        )
+                warned = warn_if_session_cookie_samesite_unset(
+                    logger,
+                    environment="staging",
+                    session_cookie_samesite=value,
+                )
 
-        self.assertFalse(warned)
-        logger.warning.assert_not_called()
+                self.assertFalse(warned)
+                logger.warning.assert_not_called()
 
     def test_warns_when_samesite_none_and_secure_is_false(self) -> None:
         logger = Mock()
@@ -46,6 +48,22 @@ class SessionCookieSameSiteWarningTests(unittest.TestCase):
         self.assertTrue(warned)
         logger.warning.assert_called_once_with(
             "SESSION_COOKIE_SAMESITE=None requires SESSION_COOKIE_SECURE=true for admin session cookie (environment=%s)",
+            "staging",
+        )
+
+    def test_warns_and_falls_back_when_samesite_is_unknown(self) -> None:
+        logger = Mock()
+
+        warned = warn_if_session_cookie_samesite_unset(
+            logger,
+            environment="staging",
+            session_cookie_samesite="cross-site",
+        )
+
+        self.assertTrue(warned)
+        logger.warning.assert_called_once_with(
+            "SESSION_COOKIE_SAMESITE=%r is unsupported; falling back to framework default (environment=%s)",
+            "cross-site",
             "staging",
         )
 

--- a/docs/help/troubleshooting.md
+++ b/docs/help/troubleshooting.md
@@ -59,6 +59,30 @@ SESSION_EXPIRY_HOURS is invalid ('<value>'); using default value 24
 
 ---
 
+### `SESSION_COOKIE_SAMESITE` が空文字/未知値
+
+**症状:** admin 起動時に `SESSION_COOKIE_SAMESITE` の警告が出る。
+
+警告メッセージ例:
+
+```
+SESSION_COOKIE_SAMESITE is not configured for admin session cookie (environment=<env>)
+SESSION_COOKIE_SAMESITE='<value>' is unsupported; falling back to framework default (environment=<env>)
+```
+
+**原因:** `SESSION_COOKIE_SAMESITE` が未設定（空文字）、または `Lax`/`Strict`/`None` 以外の値。
+
+**解決策:**
+
+1. `SESSION_COOKIE_SAMESITE` を `Lax` / `Strict` / `None` のいずれかに修正する
+2. `None` を使う場合は `SESSION_COOKIE_SECURE=true` を同時に設定する
+3. admin を再作成して反映する
+   ```bash
+   docker compose up -d --force-recreate admin
+   ```
+
+---
+
 ### データベース接続エラー
 
 ```


### PR DESCRIPTION
## 概要
- `SESSION_COOKIE_SAMESITE` の許容値を `lax/strict/none` に正規化するヘルパーを追加
- 空文字・未知値は framework default にフォールバックする仕様を `admin/config.py` に明記
- 境界入力（空文字/未知値）と正常値（Lax/Strict/None）の回帰テストを追加
- troubleshooting に SameSite 境界入力の復旧手順を追記

## テスト
- `PYTHONPATH=admin .venv-codex/bin/pytest -q admin/tests/test_session_cookie_samesite.py`
- `PYTHONPATH=admin .venv-codex/bin/pytest -q admin/tests -k session_cookie`

## 公開時の影響
- admin セッションの SameSite 設定ミスを起動時警告で早期検知可能
- セルフホスト運用でブラウザ差異起因の不整合調査が容易化
- OSS 利用者向けに許容値とフォールバック挙動がドキュメントで追跡可能
