### PR TITLE
test: stabilize accounts schema boundary inputs (#449)

### DIFF
--- a/api/app/accounts/router.py
+++ b/api/app/accounts/router.py
@@ -15,7 +15,7 @@ from app.db.session import get_db
 from app.models import OAuthAccount, User
 from app.valkey import OAuthStateStore
 
-from .schemas import OAuthAccountResponse, UnlinkResponse
+from .schemas import OAuthAccountResponse, SUPPORTED_ACCOUNT_PROVIDERS, UnlinkResponse
 
 settings = get_settings()
 router = APIRouter(prefix="/accounts", tags=["accounts"])
@@ -42,7 +42,7 @@ async def start_link_account(
     current_user: User = Depends(get_current_user),
 ):
     """Start OAuth flow to link a new provider to existing account."""
-    if provider not in ["google", "discord"]:
+    if provider not in SUPPORTED_ACCOUNT_PROVIDERS:
         raise HTTPException(status_code=400, detail="Unsupported provider")
 
     state = secrets.token_urlsafe(32)
@@ -192,7 +192,7 @@ async def unlink_account(
     db: AsyncSession = Depends(get_db),
 ):
     """Unlink an OAuth provider from current user."""
-    if provider not in ["google", "discord"]:
+    if provider not in SUPPORTED_ACCOUNT_PROVIDERS:
         raise HTTPException(status_code=400, detail="Unsupported provider")
 
     # Count linked accounts

--- a/api/app/accounts/schemas.py
+++ b/api/app/accounts/schemas.py
@@ -2,15 +2,19 @@
 
 import uuid
 from datetime import datetime
+from typing import Literal, get_args
 
 from pydantic import BaseModel
+
+AccountProvider = Literal["google", "discord"]
+SUPPORTED_ACCOUNT_PROVIDERS = frozenset(get_args(AccountProvider))
 
 
 class OAuthAccountResponse(BaseModel):
     """OAuth account response with provider info."""
 
     id: uuid.UUID
-    provider: str
+    provider: AccountProvider
     provider_user_id: str
     provider_display_name: str | None = None
     provider_avatar_url: str | None = None
@@ -25,4 +29,4 @@ class UnlinkResponse(BaseModel):
     """Unlink response."""
 
     message: str
-    provider: str
+    provider: AccountProvider

--- a/api/tests/test_accounts.py
+++ b/api/tests/test_accounts.py
@@ -2,6 +2,10 @@
 
 import pytest
 from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth.tokens import create_access_token
+from app.models import OAuthAccount, User
 
 
 @pytest.mark.asyncio
@@ -12,3 +16,69 @@ async def test_list_accounts_requires_authentication(client: AsyncClient):
     assert response.status_code == 401
     data = response.json()
     assert "detail" in data
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("provider_input", "expected_detail"),
+    [
+        ("Google", "Unsupported provider"),
+        (" google ", "Unsupported provider"),
+    ],
+    ids=["provider_uppercase", "provider_surrounded_by_spaces"],
+)
+async def test_unlink_account_returns_400_for_provider_boundary_inputs(
+    client: AsyncClient, db_session: AsyncSession, provider_input: str, expected_detail: str
+):
+    """Unsupported provider boundary inputs should keep stable 400 contract."""
+    user = User()
+    db_session.add(user)
+    await db_session.flush()
+    db_session.add(
+        OAuthAccount(
+            user_id=user.id,
+            provider="google",
+            provider_user_id="google-user-449",
+            access_token="token-449",
+        )
+    )
+    await db_session.commit()
+
+    access_token = create_access_token(str(user.id), "accounts-boundary@example.com")
+    response = await client.delete(
+        f"/api/v1/accounts/{provider_input}",
+        headers={"Authorization": f"Bearer {access_token}"},
+    )
+
+    assert response.status_code == 400
+    data = response.json()
+    assert data["detail"] == expected_detail
+
+
+@pytest.mark.asyncio
+async def test_unlink_account_returns_400_when_last_authentication_method(
+    client: AsyncClient, db_session: AsyncSession
+):
+    """Single linked account must keep stable 400 error contract."""
+    user = User()
+    db_session.add(user)
+    await db_session.flush()
+    db_session.add(
+        OAuthAccount(
+            user_id=user.id,
+            provider="google",
+            provider_user_id="single-google-user",
+            access_token="single-token",
+        )
+    )
+    await db_session.commit()
+
+    access_token = create_access_token(str(user.id), "accounts-last-method@example.com")
+    response = await client.delete(
+        "/api/v1/accounts/google",
+        headers={"Authorization": f"Bearer {access_token}"},
+    )
+
+    assert response.status_code == 400
+    data = response.json()
+    assert data["detail"] == "Cannot unlink the last authentication method"


### PR DESCRIPTION
## Summary
- add explicit AccountProvider literal and shared provider set in accounts schemas
- reuse the shared provider set in accounts router validation
- add boundary-focused accounts tests for provider input and last-auth-method guard

## Testing
- .venv-codex/bin/pytest -q api/tests/test_accounts.py

Closes #449