### PR TITLE
docs: improve webhook quickstart onboarding flow

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -324,7 +324,7 @@ curl -i -X POST "http://localhost:8000/api/v1/auth/logout" \
 Webhookは、getting-started から以下の2クリック以内で設定手順へ到達できます。
 
 1. このページの「次のステップ」から [Webhook設定](guides/webhooks.md) を開く
-2. ガイド内の [ローカルテスト](guides/webhooks.md#ローカルテスト) に沿って設定する
+2. ガイド内の [クイック導入（5分）](guides/webhooks.md#クイック導入5分) に沿って設定する
 
 ### Webhook導入の前提条件
 

--- a/docs/guides/webhooks.md
+++ b/docs/guides/webhooks.md
@@ -15,6 +15,20 @@ YESOD Authは、ユーザーイベント発生時に外部サービスへHTTP通
 | `user.oauth_linked` | OAuthプロバイダー連携時 |
 | `user.oauth_unlinked` | OAuthプロバイダー連携解除時 |
 
+## クイック導入（5分）
+
+まず最短で動作確認したい場合は、[クイックスタートの Webhook 導線](../getting-started.md#5-webhook導入の最短導線) からこの節へ到達し、次の 3 手順だけ実行してください。
+
+1. `config/webhooks.yaml` に webhook.site の URL を設定する
+2. `docker compose --profile default up -d` で API を起動する
+3. Mock OAuth ログインを 1 回実行し、webhook.site で配信を確認する
+
+```bash
+curl "http://localhost:8000/api/v1/auth/mock/login?user=alice&provider=google"
+```
+
+詳細設定（署名検証、リトライ調整、鍵ローテーション）はこのページの各節を順に参照してください。
+
 ## セットアップ
 
 ### 1. 設定ファイルの作成


### PR DESCRIPTION
## Summary
- add a 5-minute webhook quickstart section in `docs/guides/webhooks.md`
- link `docs/getting-started.md` directly to the new quickstart section
- keep OAuth導線を維持しつつ、Webhook導入の2クリック導線を明文化

## Testing
- `rg --line-number "クイック導入（5分）|guides/webhooks.md#クイック導入5分|Webhook導入の最短導線" docs/getting-started.md docs/guides/webhooks.md`
- `mkdocs build --strict` *(failed: `mkdocs` command not found in this environment)*

Closes #43
