### PR TITLE
[Bench-80][19] CORS_ORIGINS 空要素の起動時エラー回帰テストを追加

### DIFF
--- a/api/tests/test_config.py
+++ b/api/tests/test_config.py
@@ -1,5 +1,8 @@
 """Tests for configuration helpers."""
 
+import os
+import subprocess
+import sys
 from pathlib import Path
 from unittest.mock import mock_open, patch
 
@@ -95,6 +98,23 @@ def test_parse_bool_env_raises_clear_error_on_invalid_value(monkeypatch):
 def test_resolve_cors_origins_raises_when_empty_element_is_present():
     with pytest.raises(ValueError, match="CORS_ORIGINS"):
         resolve_cors_origins("https://example.com, ,https://admin.example.com")
+
+
+def test_config_import_fails_fast_when_cors_origins_contains_empty_element():
+    env = os.environ.copy()
+    env["CORS_ORIGINS"] = "https://example.com, ,https://admin.example.com"
+
+    result = subprocess.run(
+        [sys.executable, "-c", "import app.config"],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=str(Path(__file__).resolve().parents[1]),
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "CORS_ORIGINS contains empty element" in (result.stderr + result.stdout)
 
 
 def test_settings_raises_when_provider_client_id_exists_but_secret_is_empty(monkeypatch):


### PR DESCRIPTION
## 概要
- `CORS_ORIGINS` に空要素が含まれる場合、`app.config` import（起動時）で失敗することを回帰テスト化
- 既存の `resolve_cors_origins` 単体テストに加え、実際の初期化経路を別プロセスで検証

## 変更内容
- `api/tests/test_config.py`
  - `test_config_import_fails_fast_when_cors_origins_contains_empty_element` を追加

## テスト
- `UV_CACHE_DIR=/tmp/uv-cache uv run --python 3.11 --with-requirements requirements.txt pytest -q tests/test_config.py` ✅
- `UV_CACHE_DIR=/tmp/uv-cache uv run --python 3.11 --with-requirements requirements.txt pytest -q` ⚠️
  - 246 passed / 1 failed
  - 失敗: `tests/test_users_delete_account.py::test_delete_account_invalidates_related_session_tokens`
  - 理由: ローカルで `localhost:6379` (Valkey/Redis) 未起動による `ConnectionRefusedError`

## Issue
- Closes #405
