### PR TITLE
fix(compose): add Facebook OAuth secrets for api and api-ci

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,6 +60,8 @@ services:
       - google_client_secret
       - github_client_id
       - github_client_secret
+      - facebook_client_id
+      - facebook_client_secret
       - linkedin_client_id
       - linkedin_client_secret
       - discord_client_id
@@ -108,6 +110,8 @@ services:
       - google_client_secret
       - github_client_id
       - github_client_secret
+      - facebook_client_id
+      - facebook_client_secret
       - linkedin_client_id
       - linkedin_client_secret
       - discord_client_id
@@ -170,6 +174,10 @@ secrets:
     file: ./secrets/github_client_id.txt
   github_client_secret:
     file: ./secrets/github_client_secret.txt
+  facebook_client_id:
+    file: ./secrets/facebook_client_id.txt
+  facebook_client_secret:
+    file: ./secrets/facebook_client_secret.txt
   linkedin_client_id:
     file: ./secrets/linkedin_client_id.txt
   linkedin_client_secret:


### PR DESCRIPTION
## Summary\n- add `facebook_client_id` and `facebook_client_secret` to `api.secrets`\n- add the same two secrets to `api-ci.secrets`\n- define both secrets in root `secrets:` map\n\n## Test\n- `docker compose --profile default config | rg facebook_client_`\n- `docker compose --profile ci config | rg facebook_client_`\n\n## Impact\n- OAuth 導入時に Facebook を Compose だけで有効化しやすくなります\n- セルフホスト環境で secret 配線の手戻りを減らします\n- OSS 利用者向けに docker-compose の provider 間整合性が向上します