### PR TITLE
fix: unify missing bearer token 401 contract

### DIFF
--- a/api/app/auth/jwt.py
+++ b/api/app/auth/jwt.py
@@ -20,6 +20,7 @@ settings = get_settings()
 security = HTTPBearer(auto_error=False)
 
 MISSING_BEARER_TOKEN_DETAIL = "Not authenticated"
+MISSING_BEARER_TOKEN_CODE = "missing_bearer_token"
 INVALID_TOKEN_HEADER_CODE = "invalid_token_header"
 INVALID_TOKEN_HEADER_MESSAGE = "Invalid token header"
 
@@ -28,7 +29,10 @@ def _missing_bearer_token_exception() -> HTTPException:
     """Return a fixed auth error for missing Authorization bearer token."""
     return HTTPException(
         status_code=status.HTTP_401_UNAUTHORIZED,
-        detail=MISSING_BEARER_TOKEN_DETAIL,
+        detail={
+            "code": MISSING_BEARER_TOKEN_CODE,
+            "message": MISSING_BEARER_TOKEN_DETAIL,
+        },
         headers={"WWW-Authenticate": "Bearer"},
     )
 

--- a/api/tests/test_auth_missing_bearer_token.py
+++ b/api/tests/test_auth_missing_bearer_token.py
@@ -22,5 +22,9 @@ async def test_missing_bearer_token_returns_fixed_contract(
     response = await getattr(client, method)(path, **kwargs)
 
     assert response.status_code == 401
-    assert response.json() == {"detail": "Not authenticated"}
-
+    assert response.json() == {
+        "detail": {
+            "code": "missing_bearer_token",
+            "message": "Not authenticated",
+        }
+    }

--- a/api/tests/test_sessions.py
+++ b/api/tests/test_sessions.py
@@ -24,7 +24,12 @@ async def test_sessions_endpoints_require_authorization_header(
     response = await getattr(client, method)(path)
 
     assert response.status_code == 401
-    assert response.json()["detail"] == "Not authenticated"
+    assert response.json() == {
+        "detail": {
+            "code": "missing_bearer_token",
+            "message": "Not authenticated",
+        }
+    }
 
 
 @pytest.mark.asyncio

--- a/docs/api/auth.md
+++ b/docs/api/auth.md
@@ -172,7 +172,10 @@ Content-Type: application/json
 
 ```json
 {
-  "detail": "Not authenticated"
+  "detail": {
+    "code": "missing_bearer_token",
+    "message": "Not authenticated"
+  }
 }
 ```
 

--- a/docs/api/users.md
+++ b/docs/api/users.md
@@ -72,7 +72,10 @@ curl -sS -H "Authorization: Bearer ${TOKEN}" \
 
 ```json
 {
-  "detail": "Not authenticated"
+  "detail": {
+    "code": "missing_bearer_token",
+    "message": "Not authenticated"
+  }
 }
 ```
 


### PR DESCRIPTION
## 概要
- missing bearer token の 401 応答を固定コード付きの共通フォーマットへ統一
- 保護エンドポイント横断テストを更新し、共通契約を検証
- auth/users API ドキュメントの未認証レスポンス例を実装に同期

## 変更点
- `api/app/auth/jwt.py`
  - `missing_bearer_token` コードを追加
  - 未認証時 `detail` を `{"code":"missing_bearer_token","message":"Not authenticated"}` に統一
- `api/tests/test_auth_missing_bearer_token.py`
  - 複数 protected endpoint の 401 契約をコード付きで検証
- `api/tests/test_sessions.py`
  - セッションAPI未認証時アサーションを統一契約に更新
- `docs/api/auth.md`, `docs/api/users.md`
  - 401 レスポンス例を実装に合わせて更新

## テスト
- `/Users/shiroguchi/Documents/Github/mashirou1234/yesod-auth/.venv-codex/bin/pytest -q tests/test_auth_missing_bearer_token.py tests/test_sessions.py -k 'missing_bearer_token or require_authorization_header or with_valid_token_returns_200'`
- `/Users/shiroguchi/Documents/Github/mashirou1234/yesod-auth/.venv-codex/bin/pytest -q tests/test_users_me_auth.py`

Closes #321
