### PR TITLE
[Bench-80][05] Add Slack OAuth secrets to docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,6 +60,8 @@ services:
       - google_client_secret
       - github_client_id
       - github_client_secret
+      - slack_client_id
+      - slack_client_secret
       - facebook_client_id
       - facebook_client_secret
       - linkedin_client_id
@@ -110,6 +112,8 @@ services:
       - google_client_secret
       - github_client_id
       - github_client_secret
+      - slack_client_id
+      - slack_client_secret
       - facebook_client_id
       - facebook_client_secret
       - linkedin_client_id
@@ -174,6 +178,10 @@ secrets:
     file: ./secrets/github_client_id.txt
   github_client_secret:
     file: ./secrets/github_client_secret.txt
+  slack_client_id:
+    file: ./secrets/slack_client_id.txt
+  slack_client_secret:
+    file: ./secrets/slack_client_secret.txt
   facebook_client_id:
     file: ./secrets/facebook_client_id.txt
   facebook_client_secret:


### PR DESCRIPTION
Summary
- add slack_client_id and slack_client_secret to api service secrets
- add the same Slack secrets to api-ci
- define Slack secret files in top-level secrets section

Testing
- python3 one-shot check for Slack secret entries in docker-compose.yml

Closes #5
