### PR TITLE
chore: update codex-orch distribution to v1.23

### DIFF
--- a/.codex/skills/ci-status-inspector/SKILL.md
+++ b/.codex/skills/ci-status-inspector/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: ci-status-inspector
+description: 失敗した PR check や commit pipeline の CI provider を特定し、GitHub Actions / Woodpecker / GitLab CI のどれが失敗しているかを正確に切り分ける。外部 status URL、pipeline URL、commit SHA から exact target を調べたいときに使う。
+---
+
+# ci-status-inspector
+
+`$ci-status-inspector` は、失敗した check の provider を判定し、repo 全体の最新状況ではなく「その check が指している実体」を優先して調査する。
+
+## provider 判定
+
+repo 構成よりも、check 自体のメタデータを優先する。
+
+1. まず failing target を確認する。
+   - GitHub PR: `gh pr view <pr> --json statusCheckRollup,headRefOid,url`
+   - commit status: `gh api repos/<owner>/<repo>/commits/<sha>/status`
+2. 次に provider を分類する。
+   - **GitHub Actions**: `detailsUrl` が `github.com/.../actions/runs/...`
+   - **Woodpecker**: context が `ci/woodpecker/` で始まる、または URL が `/repos/<repo-id>/pipeline/<n>/...` に一致する
+   - **GitLab CI**: URL が GitLab pipelines/jobs を指す、またはタスクが明示的に GitLab CI を対象としている
+3. repo ファイルは fallback signal としてだけ使う。
+   - `.woodpecker.yml`
+   - `.github/workflows/`
+   - `.gitlab-ci.yml`
+4. 複数 provider が混在する場合は、failing check の `detailsUrl` を最優先する。まだ曖昧なら、曖昧さと根拠を明示して止める。
+
+## exact target の優先順位
+
+次の順で selector を選ぶ。
+
+1. pipeline URL
+2. pipeline ID / number
+3. commit SHA
+4. latest pipeline
+
+障害調査で `latest` に頼るのは、他に selector がない場合だけにする。
+
+## GitHub Actions の流れ
+
+失敗 check が GitHub Actions なら、この流れを使う。
+
+- GitHub PR check の失敗調査が主目的なら、`$gh-fix-ci` が使える場合はそちらを優先する
+- それ以外は `gh pr checks <pr>` と `gh run view <run-id> --log` を使う
+- failing job 名、failing step、最小の再現ヒントだけを要約する
+- 外部 check を GitHub 上に見えているという理由だけで GitHub Actions 扱いしない
+
+## Woodpecker の流れ
+
+失敗 check が Woodpecker を指している場合は、bundled script を使う。
+
+前提:
+- `WOODPECKER_TOKEN`
+- 任意: `WOODPECKER_HOST`（既定 `https://mashirou.stream`）
+
+bundled script:
+- `scripts/get-woodpecker-pipeline-status.sh`
+
+推奨コマンド:
+
+```bash
+# 最優先: GitHub status の target_url をそのまま渡す
+scripts/get-woodpecker-pipeline-status.sh --pipeline-url <target_url>
+
+# repo id / pipeline number が分かっている場合
+scripts/get-woodpecker-pipeline-status.sh --repo-id <repo_id> --pipeline-id <pipeline_number>
+
+# commit しか分からない場合
+scripts/get-woodpecker-pipeline-status.sh --repo <owner/repo> --commit <sha>
+```
+
+解釈ルール:
+- `workflow_failures` を最優先で読み、具体的な failed workflow / plugin / command step を特定する
+- `errors` は config validation や lint 段階の reject を示すことが多い
+- `--strict` は selected pipeline が `success` でない限り exit code `3` を返すので、自動ガードに使える
+- PR 調査では、同じ commit に複数 pipeline がある場合 `push` より `pull_request` を優先する
+
+## GitLab CI の流れ
+
+失敗 URL またはタスクが明確に GitLab CI を指している場合は、この流れを使う。
+
+- 既存の GitLab 向けツール（`glab` や内部 script）があればそれを優先する
+- API が使えるなら、latest pipeline ではなく exact pipeline/job URL を直接見る
+- token や tooling が無ければ推測せず、足りない前提を明示して止める
+
+この skill は現在 Woodpecker helper script を同梱している。GitLab については workflow guidance を定義し、bundled implementation はまだ持たない。
+
+## 出力形式
+
+返答は provider を意識した短い要約に揃える。
+
+- Provider
+- 使った exact target（`pipeline-url` / `pipeline-id` / `commit` / `latest`）
+- Pipeline status
+- Failing workflow / job / plugin / step
+- Key error text
+- 今回の diff 起因か、既存 CI / infrastructure 起因かの見立て
+
+## resources
+
+### scripts/get-woodpecker-pipeline-status.sh
+
+Woodpecker API を exact selector で問い合わせる helper script。
+
+次の場面で使う。
+- GitHub status が Woodpecker URL を返している
+- Woodpecker の PR pipeline を正確に調べたい
+- latest pipeline に依存せず commit から exact pipeline を引きたい

--- a/.codex/skills/ci-status-inspector/agents/openai.yaml
+++ b/.codex/skills/ci-status-inspector/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "CI Status Inspector"
+  short_description: "PR/commit の CI 状態を provider 別に調査する"
+  default_prompt: "Use $ci-status-inspector to identify the CI provider for this failing check and summarize the exact failed pipeline."
+
+policy:
+  allow_implicit_invocation: true

--- a/.codex/skills/ci-status-inspector/scripts/get-woodpecker-pipeline-status.sh
+++ b/.codex/skills/ci-status-inspector/scripts/get-woodpecker-pipeline-status.sh
@@ -1,0 +1,335 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HOST="${WOODPECKER_HOST:-https://mashirou.stream}"
+REPO_ID="${WOODPECKER_REPO_ID:-}"
+REPO_FULL_NAME="${WOODPECKER_REPO:-}"
+TOKEN="${WOODPECKER_TOKEN:-}"
+FORMAT="summary"
+USE_NETRC=1
+STRICT=0
+PIPELINE_NUMBER=""
+COMMIT_SHA=""
+PIPELINE_URL=""
+SELECTION_SOURCE="latest"
+SELECTION_NOTE=""
+
+usage() {
+  cat <<'EOF'
+Usage:
+  get-woodpecker-pipeline-status.sh [options]
+
+Options:
+  --host <url>       Woodpecker host (default: $WOODPECKER_HOST or https://mashirou.stream)
+  --repo-id <id>     Repository ID (default: $WOODPECKER_REPO_ID)
+  --repo <owner/repo>
+                     Repository full name for repo lookup (default: $WOODPECKER_REPO)
+  --pipeline-id <n>  Pipeline number shown in Woodpecker UI (/repos/<repo>/pipeline/<n>/...)
+  --pipeline-number <n>
+                     Alias of --pipeline-id
+  --pipeline-url <url>
+                     Extract host / repo-id / pipeline-id from a Woodpecker UI URL
+  --status-url <url> Alias of --pipeline-url
+  --commit <sha>     Resolve the newest exact-match pipeline for a commit
+  --token <token>    Woodpecker Personal Access Token (default: $WOODPECKER_TOKEN)
+  --json             Print raw JSON response
+  --summary          Print a compact summary (default)
+  --strict           Exit with code 3 unless the selected pipeline status is "success"
+  --no-netrc         Do not use ~/.netrc for Basic auth
+  -h, --help         Show this help
+
+Examples:
+  export WOODPECKER_TOKEN='...'
+  ./get-woodpecker-pipeline-status.sh --repo-id 1
+  ./get-woodpecker-pipeline-status.sh --repo-id 1 --json | jq
+  ./get-woodpecker-pipeline-status.sh --repo mashirou1234/MIYABI --commit <sha>
+  ./get-woodpecker-pipeline-status.sh --pipeline-url https://mashirou.stream/repos/6/pipeline/28/1
+  ./get-woodpecker-pipeline-status.sh --host https://mashirou.stream --repo-id 1 --strict
+EOF
+}
+
+die() {
+  echo "[error] $*" >&2
+  exit 1
+}
+
+require_jq() {
+  if ! command -v jq >/dev/null 2>&1; then
+    die "jq is required for this mode"
+  fi
+}
+
+api_get() {
+  local endpoint="$1"
+  local body_file="$2"
+  local http_code
+
+  http_code="$(
+    curl "${curl_args[@]}" \
+      -o "${body_file}" \
+      -w '%{http_code}' \
+      "${endpoint}"
+  )"
+
+  if [[ "${http_code}" != "200" ]]; then
+    echo "[error] API request failed: HTTP ${http_code}" >&2
+    if [[ -s "${body_file}" ]]; then
+      echo "[error] response body:" >&2
+      sed -n '1,40p' "${body_file}" >&2
+    fi
+    if [[ "${http_code}" == "401" ]]; then
+      echo "[hint] ~/.netrc の Basic 認証と WOODPECKER_TOKEN の Bearer 認証を確認してください" >&2
+    fi
+    exit 1
+  fi
+}
+
+parse_pipeline_url() {
+  local url="$1"
+
+  if [[ "${url}" =~ ^(https?://[^/]+)/repos/([0-9]+)/pipeline/([0-9]+)(/.*)?$ ]]; then
+    HOST="${BASH_REMATCH[1]}"
+    REPO_ID="${BASH_REMATCH[2]}"
+    PIPELINE_NUMBER="${BASH_REMATCH[3]}"
+    SELECTION_SOURCE="pipeline-url"
+    return 0
+  fi
+
+  die "invalid pipeline/status url: ${url}"
+}
+
+resolve_repo_id() {
+  local lookup_file encoded
+
+  [[ -n "${REPO_ID}" ]] && return 0
+  [[ -n "${REPO_FULL_NAME}" ]] || return 0
+
+  require_jq
+  lookup_file="$(mktemp)"
+  encoded="${REPO_FULL_NAME//\//%2F}"
+  api_get "${HOST}/api/repos/lookup/${encoded}" "${lookup_file}"
+  REPO_ID="$(jq -r '.id // empty' "${lookup_file}")"
+  REPO_FULL_NAME="$(jq -r '.full_name // empty' "${lookup_file}")"
+  rm -f "${lookup_file}"
+
+  [[ -n "${REPO_ID}" ]] || die "failed to resolve repo id from --repo ${REPO_FULL_NAME}"
+}
+
+select_pipeline_by_commit() {
+  local list_file selected_file exact_count selected_event selected_number
+
+  require_jq
+  list_file="$(mktemp)"
+  selected_file="$(mktemp)"
+  api_get "${HOST}/api/repos/${REPO_ID}/pipelines?commit=${COMMIT_SHA}" "${list_file}"
+
+  exact_count="$(jq -r --arg commit "${COMMIT_SHA}" '[.[] | select((.commit // "") == $commit)] | length' "${list_file}")"
+  if [[ "${exact_count}" == "0" ]]; then
+    rm -f "${list_file}" "${selected_file}"
+    die "no exact-match pipeline found for commit ${COMMIT_SHA} in repo ${REPO_ID}"
+  fi
+
+  jq --arg commit "${COMMIT_SHA}" '
+    [
+      .[]
+      | select((.commit // "") == $commit)
+    ]
+    | sort_by(
+        (if .event == "pull_request" then 0 elif .event == "push" then 1 else 2 end),
+        -(.number // 0),
+        -(.id // 0)
+      )
+    | .[0]
+  ' "${list_file}" > "${selected_file}"
+
+  selected_event="$(jq -r '.event // "unknown"' "${selected_file}")"
+  selected_number="$(jq -r '.number // "unknown"' "${selected_file}")"
+  SELECTION_SOURCE="commit"
+  SELECTION_NOTE="commit exact match ${COMMIT_SHA} (matches=${exact_count}, selected_event=${selected_event}, selected_number=${selected_number})"
+
+  api_get "${HOST}/api/repos/${REPO_ID}/pipelines/${selected_number}" "${body_file}"
+  rm -f "${list_file}" "${selected_file}"
+}
+
+print_workflow_failures() {
+  if ! command -v jq >/dev/null 2>&1; then
+    return 0
+  fi
+
+  if jq -e '
+    (
+      [.workflows[]? | select((.state // "") != "success")]
+      +
+      [.workflows[]?.children[]? | select((.state // "") != "success")]
+    ) | length > 0
+  ' "${body_file}" >/dev/null 2>&1; then
+    echo
+    echo "workflow_failures:"
+    jq -r '
+      (
+        [.workflows[]? | select((.state // "") != "success") | {
+          kind: "workflow",
+          name: (.name // "-"),
+          state: (.state // "unknown"),
+          error: (.error // ""),
+          exit_code: null
+        }]
+        +
+        [.workflows[]?.children[]? | select((.state // "") != "success") | {
+          kind: (.type // "step"),
+          name: (.name // "-"),
+          state: (.state // "unknown"),
+          error: (.error // ""),
+          exit_code: (.exit_code // null)
+        }]
+      )[]
+      | "- [\(.kind)] \(.name) state=\(.state)\(if .exit_code != null then " exit_code=\(.exit_code)" else "" end)\(if (.error | length) > 0 then " error=\(.error)" else "" end)"
+    ' "${body_file}"
+  fi
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --host)
+      HOST="${2:-}"
+      shift 2
+      ;;
+    --repo-id)
+      REPO_ID="${2:-}"
+      shift 2
+      ;;
+    --repo)
+      REPO_FULL_NAME="${2:-}"
+      shift 2
+      ;;
+    --pipeline-id|--pipeline-number)
+      PIPELINE_NUMBER="${2:-}"
+      shift 2
+      ;;
+    --pipeline-url|--status-url)
+      PIPELINE_URL="${2:-}"
+      shift 2
+      ;;
+    --commit)
+      COMMIT_SHA="${2:-}"
+      shift 2
+      ;;
+    --token)
+      TOKEN="${2:-}"
+      shift 2
+      ;;
+    --json)
+      FORMAT="json"
+      shift
+      ;;
+    --summary)
+      FORMAT="summary"
+      shift
+      ;;
+    --strict)
+      STRICT=1
+      shift
+      ;;
+    --no-netrc)
+      USE_NETRC=0
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "[error] unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+HOST="${HOST%/}"
+
+if [[ -n "${PIPELINE_URL}" ]]; then
+  parse_pipeline_url "${PIPELINE_URL}"
+fi
+
+selector_count=0
+[[ -n "${PIPELINE_NUMBER}" ]] && ((selector_count+=1))
+[[ -n "${COMMIT_SHA}" ]] && ((selector_count+=1))
+if (( selector_count > 1 )); then
+  die "--pipeline-id/--pipeline-url and --commit cannot be used together"
+fi
+
+if [[ -z "${TOKEN}" ]]; then
+  die "token is required (--token or WOODPECKER_TOKEN)"
+fi
+
+curl_args=(-sS -H "Authorization: Bearer ${TOKEN}" -H "Accept: application/json")
+if [[ ${USE_NETRC} -eq 1 ]]; then
+  curl_args+=(-n)
+fi
+
+resolve_repo_id
+
+if [[ -z "${REPO_ID}" ]]; then
+  die "repo id is required (--repo-id, --repo, --pipeline-url, or WOODPECKER_REPO_ID)"
+fi
+
+body_file="$(mktemp)"
+trap 'rm -f "${body_file}"' EXIT
+
+if [[ -n "${PIPELINE_NUMBER}" ]]; then
+  if [[ "${SELECTION_SOURCE}" == "latest" ]]; then
+    SELECTION_SOURCE="pipeline-id"
+  fi
+  api_get "${HOST}/api/repos/${REPO_ID}/pipelines/${PIPELINE_NUMBER}" "${body_file}"
+elif [[ -n "${COMMIT_SHA}" ]]; then
+  select_pipeline_by_commit
+else
+  SELECTION_SOURCE="latest"
+  api_get "${HOST}/api/repos/${REPO_ID}/pipelines/latest" "${body_file}"
+fi
+
+if [[ "${FORMAT}" == "json" ]]; then
+  cat "${body_file}"
+  exit 0
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "[warn] jq が見つからないため raw JSON を出力します" >&2
+  cat "${body_file}"
+  exit 0
+fi
+
+status="$(jq -r '.status // "unknown"' "${body_file}")"
+
+jq -r --arg repo_id "${REPO_ID}" --arg repo "${REPO_FULL_NAME}" --arg source "${SELECTION_SOURCE}" --arg note "${SELECTION_NOTE}" '
+  [
+    "source: \($source)",
+    if $repo != "" then "repo: \($repo)" else empty end,
+    "repo_id: \($repo_id)",
+    "number: \(.number)",
+    "id: \(.id)",
+    "status: \(.status)",
+    "event: \(.event)",
+    "branch: \(.branch)",
+    "commit: \(.commit)",
+    "author: \(.author)",
+    "message: \(.message // "")",
+    if $note != "" then "selected_by: \($note)" else empty end
+  ] | join("\n")
+' "${body_file}"
+
+print_workflow_failures
+
+if jq -e '.errors | length > 0' "${body_file}" >/dev/null 2>&1; then
+  echo
+  echo "errors:"
+  jq -r '
+    .errors[]
+    | "- [\(.type)] \(.message) (field=\(.data.field // "-"), file=\(.data.file // "-"), warning=\(.is_warning))"
+  ' "${body_file}"
+fi
+
+if [[ ${STRICT} -eq 1 && "${status}" != "success" ]]; then
+  exit 3
+fi


### PR DESCRIPTION
## Summary
- update the distributed codex-orch reference to `v1.23`
- sync the latest managed files generated by `bootstrap.sh`
- add the default distributed skill payload under `.codex/skills/ci-status-inspector`

## Testing
- `bash /tmp/neunzehn-central-selective-HX0Eog/repo/scripts/bootstrap.sh check --target <repo clone>`
