### PR TITLE
fix(ci): CIでLinkedIn OAuth secretsを生成

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,8 @@ jobs:
           echo "ci-github-secret" > secrets/github_client_secret.txt
           echo "ci-x-id" > secrets/x_client_id.txt
           echo "ci-x-secret" > secrets/x_client_secret.txt
+          echo "ci-linkedin-id" > secrets/linkedin_client_id.txt
+          echo "ci-linkedin-secret" > secrets/linkedin_client_secret.txt
           echo "ci-jwt-secret-key" > secrets/jwt_secret.txt
           echo "ci-admin-password" > secrets/admin_password.txt
 


### PR DESCRIPTION
## 概要
- CI workflow の secrets 生成に `linkedin_client_id.txt` / `linkedin_client_secret.txt` を追加
- LinkedIn OAuth を有効化した構成でも CI の前提 secret が揃うように修正

## テスト
- `docker compose --profile ci config`

Closes #9
