### PR TITLE
[Bench-80][81] enqueue失敗ログに診断キーを追加

### DIFF
--- a/api/app/webhooks/emitter.py
+++ b/api/app/webhooks/emitter.py
@@ -65,7 +65,12 @@ class WebhookEmitter:
                 len(endpoints),
             )
         except Exception as e:
-            logger.error("Failed to queue webhook event: %s", e)
+            logger.error(
+                "Failed to queue webhook event (event_type=%s queue_key=%s): %s",
+                event_type,
+                WEBHOOK_QUEUE_KEY,
+                e,
+            )
             return None
 
         return event

--- a/api/tests/test_webhook_emitter.py
+++ b/api/tests/test_webhook_emitter.py
@@ -1,6 +1,7 @@
 """Tests for WebhookEmitter."""
 
 import asyncio
+import logging
 import time
 import uuid
 from unittest.mock import AsyncMock, patch
@@ -146,22 +147,25 @@ class TestWebhookEmitter:
             assert elapsed < 1.0  # Should be much faster than 1 second
 
     @pytest.mark.asyncio
-    async def test_emit_handles_valkey_error(self, mock_valkey, sample_config):
+    async def test_emit_handles_valkey_error(self, mock_valkey, sample_config, caplog):
         """Test that emit() handles Valkey errors gracefully."""
         mock_valkey.rpush = AsyncMock(side_effect=Exception("Connection failed"))
 
-        with (
-            patch("app.webhooks.emitter._is_testing", return_value=False),
-            patch("app.webhooks.emitter.get_valkey", return_value=mock_valkey),
-            patch(
-                "app.webhooks.config.WebhookConfigLoader.get_endpoints_for_event",
-                return_value=sample_config.endpoints,
-            ),
-        ):
-            event = await WebhookEmitter.emit(
-                "user.created",
-                {"user_id": str(uuid.uuid4())},
-            )
+        with caplog.at_level(logging.ERROR, logger="app.webhooks.emitter"):
+            with (
+                patch("app.webhooks.emitter._is_testing", return_value=False),
+                patch("app.webhooks.emitter.get_valkey", return_value=mock_valkey),
+                patch(
+                    "app.webhooks.config.WebhookConfigLoader.get_endpoints_for_event",
+                    return_value=sample_config.endpoints,
+                ),
+            ):
+                event = await WebhookEmitter.emit(
+                    "user.created",
+                    {"user_id": str(uuid.uuid4())},
+                )
 
-            # Should return None on error, not raise
-            assert event is None
+        # Should return None on error, not raise
+        assert event is None
+        assert "event_type=user.created" in caplog.text
+        assert "queue_key=webhook:events" in caplog.text


### PR DESCRIPTION
## 概要
- `WebhookEmitter.emit` の enqueue 失敗ログに `event_type` と `WEBHOOK_QUEUE_KEY` を追加
- 既存の戻り値契約（失敗時 `None`）は維持
- 失敗ログ内容を検証するテストを追加

## 変更ファイル
- `api/app/webhooks/emitter.py`
- `api/tests/test_webhook_emitter.py`

## テスト
- `/Users/shiroguchi/Documents/Github/mashirou1234/yesod-auth/.venv-codex/bin/pytest -q api/tests/test_webhook_emitter.py`
- `/Users/shiroguchi/Documents/Github/mashirou1234/yesod-auth/.venv-codex/bin/pytest -q api/tests/test_webhook_integration.py`

Closes #484
