### PR TITLE
ci: CIでFacebook OAuth secretsファイルを生成する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,8 @@ jobs:
           echo "ci-x-secret" > secrets/x_client_secret.txt
           echo "ci-linkedin-id" > secrets/linkedin_client_id.txt
           echo "ci-linkedin-secret" > secrets/linkedin_client_secret.txt
+          echo "ci-facebook-id" > secrets/facebook_client_id.txt
+          echo "ci-facebook-secret" > secrets/facebook_client_secret.txt
           echo "ci-jwt-secret-key" > secrets/jwt_secret.txt
           echo "ci-admin-password" > secrets/admin_password.txt
 


### PR DESCRIPTION
## Summary
- CI workflow の secrets 生成ステップに Facebook 用 `facebook_client_id.txt` / `facebook_client_secret.txt` を追加
- docker-compose(ci) が参照する Facebook secrets と整合

## Test
- docker compose --profile ci config | rg "facebook_client_(id|secret)"

Closes #10