### PR TITLE
test: delete-account test で rate limiter の外部依存を排除

### DIFF
--- a/api/tests/test_users_delete_account.py
+++ b/api/tests/test_users_delete_account.py
@@ -6,7 +6,19 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth.tokens import create_access_token, create_refresh_token, hash_refresh_token
+from app.main import app
 from app.models import DeletedUser, RefreshToken, User, UserEmail
+
+
+@pytest.fixture(autouse=True)
+def disable_rate_limiter():
+    """Avoid external Redis dependency in account deletion tests."""
+    original_enabled = app.state.limiter.enabled
+    app.state.limiter.enabled = False
+    try:
+        yield
+    finally:
+        app.state.limiter.enabled = original_enabled
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 概要
- Issue #511 の blocked 要因だった Redis 接続失敗をテスト側で解消
- `test_users_delete_account` 実行時に rate limiter を無効化し、外部 Redis 不要で再現可能化

## テスト
- `cd api && .venv/bin/python -m pytest -q tests/test_auth_logout.py::test_logout_without_auth_returns_401 tests/test_users_delete_account.py::test_delete_account_invalidates_related_session_tokens`

Closes #511