### PR TITLE
chore: 週次Git棚卸しノイズを ignore 対応

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ htmlcov/
 config/webhooks.yaml
 
 .codex-orch/
+.codex/skills/
 /artifacts/
 artifacts/**
 api/.hypothesis/

--- a/README.md
+++ b/README.md
@@ -380,12 +380,12 @@ pytest
 
 ### Generated Artifacts Policy
 
-`artifacts/` と `api/.hypothesis/` は再生成可能な生成物のため、Git 管理対象に含めません。
+`artifacts/` と `api/.hypothesis/`、`.codex/skills/` は再生成可能またはローカル専用のため、Git 管理対象に含めません。
 週次棚卸しやレビュー時に未追跡で残っていても、コミット対象へ含めない運用を推奨します。
 
 ```bash
 # 必須エントリの確認（出力されれば設定済み）
-rg -n '^/artifacts/$|^artifacts/\\*\\*$|^api/.hypothesis/$' .gitignore
+rg -n '^/artifacts/$|^artifacts/\\*\\*$|^api/.hypothesis/$|^\\.codex/skills/$' .gitignore
 ```
 
 ## PR Auto-Approve + Auto-Merge


### PR DESCRIPTION
## 概要
- #510 の週次棚卸しで検出されたローカルノイズ `.codex/skills/` を `.gitignore` へ追加
- README の Generated Artifacts Policy に同エントリを追記し、確認コマンドを同期

## テスト
- `git check-ignore -v .codex/skills/demo.txt`
- `api/.venv/bin/pytest -q api/tests/test_health.py`

Closes #510
