### PR TITLE
docs: 障害時の docs 参照順導線を明確化

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -391,4 +391,5 @@ API認証で問題が発生した場合は、次の順で確認してくださ�
 
 1. [インストール](installation.md#oauth認証情報)で OAuth シークレットの配置と profile を確認する
 2. [クイックスタート](getting-started.md#4-動作確認)で `/health` と `/docs` の到達性を確認する
-3. [トラブルシューティング](help/troubleshooting.md#state-mismatch-flow)で症状別の診断手順を実施する
+3. [トラブルシューティング: 障害時の参照順（最短導線）](help/troubleshooting.md#障害時の参照順最短導線) で `health -> auth -> provider -> webhook` の順に切り分ける
+4. 認証フローの失敗は [state mismatch 診断フロー](help/troubleshooting.md#state-mismatch-flow)、資格情報エラーは [`401 Unauthorized` / `invalid_client`](help/troubleshooting.md#401-unauthorized--invalid_client) を確認する

--- a/docs/help/troubleshooting.md
+++ b/docs/help/troubleshooting.md
@@ -16,6 +16,15 @@ curl -fsS http://localhost:8000/health
 docker compose logs api --since=30m | rg -n "Invalid state|callback|invalid_client|401"
 ```
 
+段階ごとの参照先ショートカット:
+
+| 段階 | まず見る場所 | 最小確認コマンド |
+| --- | --- | --- |
+| `health` | [初回起動トラブルシュート](./first-start-troubleshooting.md#症状1-health-が失敗する) | `curl -fsS http://localhost:8000/health` |
+| `auth` | [state mismatch 診断フロー](#state-mismatch-flow) | `docker compose logs api --since=30m \| rg "Invalid state\|/auth/.*/callback"` |
+| `provider` | [`401 Unauthorized` / `invalid_client`](#401-unauthorized--invalid_client) | `docker compose logs --tail=100 api \| rg -n "invalid_client\|401\|client_secret\|client_id"` |
+| `webhook` | [Webhook設定ガイド](../guides/webhooks.md#ローカルテスト) | `curl -fsS http://localhost:8000/api/v1/admin/webhooks/endpoints` |
+
 ## 起動時のエラー
 
 `secret ... not found` の即時復旧は [`インストールガイド` の secret不足時手順](../installation.md#1-docker-compose-up-で-secret-未設定エラーになる) を先に実行してください。

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -539,7 +539,8 @@ rg -n "/api/v1/auth/\\{provider\\}/callback|invalid_client|Invalid or expired st
 
 1. このセクションのシークレットが有効化した provider 分そろっていることを確認する
 2. [クイックスタート](getting-started.md#4-動作確認)で API 到達性を確認する
-3. [トラブルシューティング](help/troubleshooting.md#state-mismatch-flow)で症状別の対処を行う
+3. [トラブルシューティング: 障害時の参照順（最短導線）](help/troubleshooting.md#障害時の参照順最短導線) で `health -> auth -> provider -> webhook` の順に切り分ける
+4. `auth` / `provider` で詰まった場合は [state mismatch](help/troubleshooting.md#state-mismatch-flow) と [`401 Unauthorized` / `invalid_client`](help/troubleshooting.md#401-unauthorized--invalid_client) を順に確認する
 
 ## セルフホスト向け秘密情報配置例
 


### PR DESCRIPTION
## 概要\n-  に health/auth/provider/webhook の段階別ショートカット表を追加\n-  と  の API 認証トラブル導線を最短導線アンカーへ統一\n- state mismatch / invalid_client の参照先を明示して自己解決しやすくした\n\n## テスト\n- docs/help/troubleshooting.md:3:## 障害時の参照順（最短導線）
docs/help/troubleshooting.md:24:| `auth` | [state mismatch 診断フロー](#state-mismatch-flow) | `docker compose logs api --since=30m \| rg "Invalid state\|/auth/.*/callback"` |
docs/help/troubleshooting.md:25:| `provider` | [`401 Unauthorized` / `invalid_client`](#401-unauthorized--invalid_client) | `docker compose logs --tail=100 api \| rg -n "invalid_client\|401\|client_secret\|client_id"` |
docs/help/troubleshooting.md:120:### `401 Unauthorized` / `invalid_client`
docs/help/troubleshooting.md:190:### 管理者トークン失効で管理APIが `401 Unauthorized` になる
docs/help/troubleshooting.md:192:**症状:** 管理画面操作や `GET /api/v1/admin/*` 呼び出しが `401 Unauthorized` を返す
docs/getting-started.md:187:アクセストークン失効で `401 Unauthorized` が返る場合は、次の順序で復旧します。
docs/getting-started.md:224:   - [トラブルシューティング: state mismatch 診断フロー](help/troubleshooting.md#state-mismatch-flow)
docs/getting-started.md:226:   - [トラブルシューティング: 401 Unauthorized / invalid_client](help/troubleshooting.md#401-unauthorized--invalid_client)
docs/getting-started.md:252:未認証でログアウトAPIを呼ぶと、`401 Unauthorized` とエラーボディを確認できます。
docs/getting-started.md:262:- ステータスコード: `401 Unauthorized`
docs/getting-started.md:334:3. [トラブルシューティング: 障害時の参照順（最短導線）](help/troubleshooting.md#障害時の参照順最短導線) で `health -> auth -> provider -> webhook` の順に切り分ける
docs/getting-started.md:335:4. 認証フローの失敗は [state mismatch 診断フロー](help/troubleshooting.md#state-mismatch-flow)、資格情報エラーは [`401 Unauthorized` / `invalid_client`](help/troubleshooting.md#401-unauthorized--invalid_client) を確認する
docs/installation.md:419:3. [トラブルシューティング: 障害時の参照順（最短導線）](help/troubleshooting.md#障害時の参照順最短導線) で `health -> auth -> provider -> webhook` の順に切り分ける
docs/installation.md:420:4. `auth` / `provider` で詰まった場合は [state mismatch](help/troubleshooting.md#state-mismatch-flow) と [`401 Unauthorized` / `invalid_client`](help/troubleshooting.md#401-unauthorized--invalid_client) を順に確認する\n-  （ローカル未導入のため実行スキップ）\n\nCloses #38