### PR TITLE
docs: fix /sessions validation examples to use sessions field

### DIFF
--- a/docs/api/users.md
+++ b/docs/api/users.md
@@ -22,17 +22,17 @@ TOKEN="<access_token>"
 
 # 最小件数境界
 curl -sS -H "Authorization: Bearer ${TOKEN}" \
-  "http://localhost:8000/api/v1/sessions?limit=1" | jq '.items | length'
+  "http://localhost:8000/api/v1/sessions?limit=1" | jq '.sessions | length'
 
 # 実運用でよく使う上限確認（100件）
 curl -sS -H "Authorization: Bearer ${TOKEN}" \
-  "http://localhost:8000/api/v1/sessions?limit=100" | jq '.items | length'
+  "http://localhost:8000/api/v1/sessions?limit=100" | jq '.sessions | length'
 ```
 
 確認観点:
 
 1. どちらも `200 OK` で返る
-2. `.items | length` が指定した `limit` を超えない
+2. `.sessions | length` が指定した `limit` を超えない
 3. 同一トークンで `GET /api/v1/users/me` も継続して成功する
 
 上限超過時（`limit > 1000`）は `400 Bad Request` を返し、専用エラーコードと上限値を本文に含みます。

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -391,4 +391,5 @@ API認証で問題が発生した場合は、次の順で確認してくださ�
 
 1. [インストール](installation.md#oauth認証情報)で OAuth シークレットの配置と profile を確認する
 2. [クイックスタート](getting-started.md#4-動作確認)で `/health` と `/docs` の到達性を確認する
-3. [トラブルシューティング](help/troubleshooting.md#state-mismatch-flow)で症状別の診断手順を実施する
+3. [トラブルシューティング: 障害時の参照順（最短導線）](help/troubleshooting.md#障害時の参照順最短導線) で `health -> auth -> provider -> webhook` の順に切り分ける
+4. 認証フローの失敗は [state mismatch 診断フロー](help/troubleshooting.md#state-mismatch-flow)、資格情報エラーは [`401 Unauthorized` / `invalid_client`](help/troubleshooting.md#401-unauthorized--invalid_client) を確認する

--- a/docs/help/troubleshooting.md
+++ b/docs/help/troubleshooting.md
@@ -479,9 +479,9 @@ curl -sS -X POST -H "Authorization: Bearer ${TOKEN}" \
 2. `limit=1` と `limit=100` を連続実行し、HTTPステータスと件数を比較する
    ```bash
    curl -sS -H "Authorization: Bearer <access_token>" \
-     "http://localhost:8000/api/v1/sessions?limit=1" | jq '.items | length'
+     "http://localhost:8000/api/v1/sessions?limit=1" | jq '.sessions | length'
    curl -sS -H "Authorization: Bearer <access_token>" \
-     "http://localhost:8000/api/v1/sessions?limit=100" | jq '.items | length'
+     "http://localhost:8000/api/v1/sessions?limit=100" | jq '.sessions | length'
    ```
 3. 期待値から外れる場合は API ログを確認する
    ```bash

--- a/docs/help/troubleshooting.md
+++ b/docs/help/troubleshooting.md
@@ -16,6 +16,15 @@ curl -fsS http://localhost:8000/health
 docker compose logs api --since=30m | rg -n "Invalid state|callback|invalid_client|401"
 ```
 
+段階ごとの参照先ショートカット:
+
+| 段階 | まず見る場所 | 最小確認コマンド |
+| --- | --- | --- |
+| `health` | [初回起動トラブルシュート](./first-start-troubleshooting.md#症状1-health-が失敗する) | `curl -fsS http://localhost:8000/health` |
+| `auth` | [state mismatch 診断フロー](#state-mismatch-flow) | `docker compose logs api --since=30m \| rg "Invalid state\|/auth/.*/callback"` |
+| `provider` | [`401 Unauthorized` / `invalid_client`](#401-unauthorized--invalid_client) | `docker compose logs --tail=100 api \| rg -n "invalid_client\|401\|client_secret\|client_id"` |
+| `webhook` | [Webhook設定ガイド](../guides/webhooks.md#ローカルテスト) | `curl -fsS http://localhost:8000/api/v1/admin/webhooks/endpoints` |
+
 ## 起動時のエラー
 
 `secret ... not found` の即時復旧は [`インストールガイド` の secret不足時手順](../installation.md#1-docker-compose-up-で-secret-未設定エラーになる) を先に実行してください。

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -539,7 +539,8 @@ rg -n "/api/v1/auth/\\{provider\\}/callback|invalid_client|Invalid or expired st
 
 1. このセクションのシークレットが有効化した provider 分そろっていることを確認する
 2. [クイックスタート](getting-started.md#4-動作確認)で API 到達性を確認する
-3. [トラブルシューティング](help/troubleshooting.md#state-mismatch-flow)で症状別の対処を行う
+3. [トラブルシューティング: 障害時の参照順（最短導線）](help/troubleshooting.md#障害時の参照順最短導線) で `health -> auth -> provider -> webhook` の順に切り分ける
+4. `auth` / `provider` で詰まった場合は [state mismatch](help/troubleshooting.md#state-mismatch-flow) と [`401 Unauthorized` / `invalid_client`](help/troubleshooting.md#401-unauthorized--invalid_client) を順に確認する
 
 ## セルフホスト向け秘密情報配置例
 


### PR DESCRIPTION
## 概要
- `docs/api/users.md` の `/api/v1/sessions` 検証コマンドを実レスポンス構造に合わせて `jq '.sessions | length'` へ統一
- 同観点の導線である `docs/help/troubleshooting.md` の検証コマンドも同様に修正
- 説明文の確認観点を `.items` 参照から `.sessions` 参照へ更新

## 三点同期チェック（FAQ / installation / troubleshooting）
- FAQ: 該当コマンド記述なし、差分不要
- installation: 該当コマンド記述なし、差分不要
- troubleshooting: `/sessions` 検証例が `.items` 参照だったため `.sessions` へ修正

## テスト
- `rg -n "jq '\\.items \\| length'|jq '\\.sessions \\| length'" docs/api/users.md docs/help/troubleshooting.md docs/help/faq.md docs/installation.md`
- `mkdocs build -q`（環境に `mkdocs` がないため SKIP）

## 公開時の影響
- ドキュメントのみの変更です。API 実装・挙動の変更はありません。
- 利用者が `/sessions` 検証をそのまま実行した際の誤判定（`.items` 前提）を防止できます。

Closes #483
