### PR TITLE
docs: align OpenAPI provider description with 8-provider support

### DIFF
--- a/api/app/main.py
+++ b/api/app/main.py
@@ -59,11 +59,11 @@ app = FastAPI(
     description="""
 ## OAuth Authentication API
 
-YESOD Auth provides a complete OAuth 2.0 authentication solution with support for multiple providers.
+YESOD Auth provides a complete OAuth 2.0 authentication solution with multi-provider support.
 
 ### Features
 
-- 🔑 **OAuth 2.0** - Eight-provider authentication (Google, GitHub, Discord, X, LinkedIn, Facebook, Slack, Twitch) with PKCE support
+- 🔑 **OAuth 2.0** - Eight-provider OAuth authentication (Google, GitHub, Discord, X, LinkedIn, Facebook, Slack, Twitch) with PKCE support
 - 🔄 **Token Rotation** - Secure refresh token rotation
 - 👤 **User Management** - Profile updates, account linking
 - 📊 **Audit Logging** - Complete authentication event tracking


### PR DESCRIPTION
## Summary
- update FastAPI OpenAPI description to explicitly state multi-provider support
- keep provider list aligned with current eight supported providers
- preserve existing feature bullets (token rotation, audit logging, etc.)

## Testing
- `rg -n "Google and Discord|multi-provider|8" api/app/main.py`
- `cd api && python -m pytest tests/test_health.py -q`

Closes #14