### PR TITLE
fix(ci): prefer dedicated token for pull request auto-merge

### DIFF
--- a/.github/workflows/pr-auto-merge.yml
+++ b/.github/workflows/pr-auto-merge.yml
@@ -22,6 +22,7 @@ jobs:
       - name: Enable auto-merge
         uses: peter-evans/enable-pull-request-automerge@v3
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # Use a dedicated token when available so workflow-changing PRs can enable auto-merge.
+          token: ${{ secrets.AUTO_MERGE_TOKEN || secrets.GITHUB_TOKEN }}
           pull-request-number: ${{ github.event.pull_request.number }}
           merge-method: squash


### PR DESCRIPTION
## Summary
- prefer `AUTO_MERGE_TOKEN` over `GITHUB_TOKEN` in the PR auto-merge workflow
- keep `GITHUB_TOKEN` as a fallback so existing behavior remains unchanged when the dedicated secret is absent

## Why
- workflow-changing PRs cannot enable auto-merge with the default GitHub App token because it lacks `workflows` permission
- using a dedicated token allows the repository to opt in without changing the normal path for other PRs

## Notes
- repository secret `AUTO_MERGE_TOKEN` still needs to be added with `Workflows`, `Contents`, and `Pull requests` write access
- this change must land on `main` before PR #516 can be retried successfully