### PR TITLE
docs: oauth/facebook に長期トークン運用の導線を補強

### DIFF
--- a/api/app/main.py
+++ b/api/app/main.py
@@ -59,11 +59,11 @@ app = FastAPI(
     description="""
 ## OAuth Authentication API
 
-YESOD Auth provides a complete OAuth 2.0 authentication solution with support for multiple providers.
+YESOD Auth provides a complete OAuth 2.0 authentication solution with multi-provider support.
 
 ### Features
 
-- 🔑 **OAuth 2.0** - Eight-provider authentication (Google, GitHub, Discord, X, LinkedIn, Facebook, Slack, Twitch) with PKCE support
+- 🔑 **OAuth 2.0** - Eight-provider OAuth authentication (Google, GitHub, Discord, X, LinkedIn, Facebook, Slack, Twitch) with PKCE support
 - 🔄 **Token Rotation** - Secure refresh token rotation
 - 👤 **User Management** - Profile updates, account linking
 - 📊 **Audit Logging** - Complete authentication event tracking

--- a/docs/guides/oauth/facebook.md
+++ b/docs/guides/oauth/facebook.md
@@ -48,7 +48,8 @@ echo "your-app-secret" > secrets/facebook_client_secret.txt
   - 失効時の再認可導線（管理者通知または再ログイン誘導）
   - 監査用ログ（更新日時・失敗理由・対象ユーザー）
 - 長期トークンを保存する場合は、`secrets/` 直置きや平文コミットを避け、シークレット管理基盤を利用してください。
-- 障害時は [トラブルシューティング](../../help/troubleshooting.md) の OAuth 再ログイン手順とあわせて確認してください。
+- 監査ログの保持期間・ローテーション方針は [Deployment ガイド](../deployment.md#ログ保全設定例) で先に定義してください。
+- 障害時は [トラブルシューティング](../../help/troubleshooting.md) の「管理者トークン失効で管理APIが `401 Unauthorized` になる」節の再認証導線とあわせて確認してください。
 
 ## 技術仕様
 


### PR DESCRIPTION
## 概要
- `docs/guides/oauth/facebook.md` の長期トークン運用セクションを補強
- 監査ログ方針を deployment ガイドへ明示リンク
- 失効時の再認証導線を troubleshooting 節へ明示

## テスト
- `rg "token|expiry" docs/guides/oauth/facebook.md`
- `docker compose config -q`
- `python3 -m pytest -q` (環境に `pytest` 未導入で実行不可)

Closes #208