### PR TITLE
docs: sync README and docs index feature descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,10 @@
 
 ## Features
 
-- 🔑 OAuth 2.0 authentication (Google, GitHub, Discord, X, LinkedIn, Facebook, Slack, Twitch)
+- 🔑 OAuth 2.0 authentication for 8 providers (Google, GitHub, X (Twitter), LinkedIn, Facebook, Discord, Slack, Twitch)
+- 🛡️ PKCE-enabled secure OAuth flow
+- 🔄 Refresh token rotation support
+- 📣 Webhook integration for user events
 - 🐳 Docker Compose ready - just add secrets and run
 - 🗄️ PostgreSQL with automatic migrations
 - 🔒 JWT-based session management
@@ -14,6 +17,7 @@
 - 👤 User profile with avatar support
 
 > Source of truth for provider support notation: `docs/guides/oauth/index.md`.
+> Source of truth for top-level feature descriptions: `docs/index.md`.
 
 ## Quick Start
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,6 +14,7 @@
 | ユーザーイベントを外部サービスにリアルタイム通知 | Docker Composeで簡単にデプロイ |
 
 > 対応プロバイダー表記の参照元（正）は `docs/guides/oauth/index.md` です。
+> 機能説明の参照元（正）は `docs/index.md` とし、`README.md` は本項目へ同期します。
 
 ## クイックスタート
 


### PR DESCRIPTION
## Summary
- sync top-level feature descriptions between README and docs index
- unify provider notation to match OAuth guide (including X (Twitter))
- add a one-line source-of-truth policy for feature descriptions

## Validation
- `rg -n "Source of truth|機能説明の参照元|X \(Twitter\)" README.md docs/index.md`
- `mkdocs build --strict` (not runnable in this environment: `mkdocs` command not found)

Closes #36