### PR TITLE
[Bench-80][82] admin valkey key列挙をSCAN化

### DIFF
--- a/admin/tests/test_valkey_client.py
+++ b/admin/tests/test_valkey_client.py
@@ -1,7 +1,7 @@
-"""Tests for admin Valkey reconnect behavior."""
+"""Tests for admin valkey_client behavior."""
 import types
 import unittest
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import redis.asyncio as redis
 
@@ -11,6 +11,20 @@ import valkey_client
 class _FakeClient:
     def __init__(self) -> None:
         self.close = AsyncMock()
+
+
+class _AsyncIterator:
+    def __init__(self, values):
+        self._iterator = iter(values)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        try:
+            return next(self._iterator)
+        except StopIteration as exc:
+            raise StopAsyncIteration from exc
 
 
 class ValkeyClientReconnectTests(unittest.IsolatedAsyncioTestCase):
@@ -61,6 +75,95 @@ class ValkeyClientReconnectTests(unittest.IsolatedAsyncioTestCase):
         sleep.assert_awaited_once_with(0.5)
         first.close.assert_awaited_once()
         second.close.assert_awaited_once()
+
+
+class ValkeyClientScanTests(unittest.TestCase):
+    def _make_client(self, keys, ttl_map, value_map):
+        client = Mock()
+        client.scan_iter = Mock(return_value=_AsyncIterator(keys))
+        client.ttl = AsyncMock()
+        client.ttl.side_effect = lambda key: ttl_map[key]
+        client.get = AsyncMock()
+        client.get.side_effect = lambda key: value_map[key]
+        client.keys = AsyncMock()
+        client.close = AsyncMock()
+        return client
+
+    @patch("valkey_client.redis.from_url")
+    def test_get_oauth_states_uses_scan_iter_and_preserves_shape(
+        self, mock_from_url
+    ) -> None:
+        client = self._make_client(
+            keys=["oauth_state:abcdefghijklmnopqrstuvwxyz", "oauth_state:state-2"],
+            ttl_map={
+                "oauth_state:abcdefghijklmnopqrstuvwxyz": 120,
+                "oauth_state:state-2": 60,
+            },
+            value_map={
+                "oauth_state:abcdefghijklmnopqrstuvwxyz": '{"provider":"github","code_verifier":"x"}',
+                "oauth_state:state-2": '{"provider":"discord"}',
+            },
+        )
+        mock_from_url.return_value = client
+
+        states = valkey_client.get_oauth_states()
+
+        self.assertEqual(
+            states,
+            [
+                {
+                    "state": "abcdefghijklmnop...",
+                    "provider": "github",
+                    "has_pkce": True,
+                    "ttl_seconds": 120,
+                },
+                {
+                    "state": "state-2...",
+                    "provider": "discord",
+                    "has_pkce": False,
+                    "ttl_seconds": 60,
+                },
+            ],
+        )
+        client.scan_iter.assert_called_once_with(match="oauth_state:*")
+        client.keys.assert_not_called()
+        client.close.assert_awaited_once()
+
+    @patch("valkey_client.redis.from_url")
+    def test_get_rate_limit_info_handles_empty_scan_result(self, mock_from_url) -> None:
+        client = self._make_client(keys=[], ttl_map={}, value_map={})
+        mock_from_url.return_value = client
+
+        limits = valkey_client.get_rate_limit_info()
+
+        self.assertEqual(limits, [])
+        client.scan_iter.assert_called_once_with(match="LIMITER:*")
+        client.keys.assert_not_called()
+        client.close.assert_awaited_once()
+
+    @patch("valkey_client.redis.from_url")
+    def test_get_rate_limit_info_handles_multiple_scan_results(
+        self, mock_from_url
+    ) -> None:
+        client = self._make_client(
+            keys=["LIMITER:1", "LIMITER:2"],
+            ttl_map={"LIMITER:1": 30, "LIMITER:2": 15},
+            value_map={"LIMITER:1": "3", "LIMITER:2": "7"},
+        )
+        mock_from_url.return_value = client
+
+        limits = valkey_client.get_rate_limit_info()
+
+        self.assertEqual(
+            limits,
+            [
+                {"key": "LIMITER:1", "count": "3", "ttl_seconds": 30},
+                {"key": "LIMITER:2", "count": "7", "ttl_seconds": 15},
+            ],
+        )
+        client.scan_iter.assert_called_once_with(match="LIMITER:*")
+        client.keys.assert_not_called()
+        client.close.assert_awaited_once()
 
 
 if __name__ == "__main__":

--- a/admin/valkey_client.py
+++ b/admin/valkey_client.py
@@ -15,7 +15,7 @@ def run_async(coro):
 
 async def _get_oauth_states() -> list[dict]:
     async def _read(client) -> list[dict]:
-        keys = await client.keys("oauth_state:*")
+        keys = [key async for key in client.scan_iter(match="oauth_state:*")]
         states = []
         for key in keys:
             ttl = await client.ttl(key)
@@ -34,7 +34,7 @@ async def _get_oauth_states() -> list[dict]:
 
 async def _get_rate_limit_info() -> list[dict]:
     async def _read(client) -> list[dict]:
-        keys = await client.keys("LIMITER:*")
+        keys = [key async for key in client.scan_iter(match="LIMITER:*")]
         limits = []
         for key in keys:
             ttl = await client.ttl(key)


### PR DESCRIPTION
## 概要
- `admin/valkey_client.py` の `keys()` 呼び出しを `scan_iter()` ベースに置換
- OAuth state / rate limiter の返却スキーマを維持
- `admin/tests/test_valkey_client.py` を追加し、0件/複数件の SCAN 経路と KEYS 未使用を検証

## テスト
- `cd admin && UV_CACHE_DIR=/tmp/uv-cache uv run --with pytest --with redis -m pytest -q tests/test_valkey_client.py tests/test_i18n.py`