### PR TITLE
[Bench-80][75] Clarify Valkey failure classification

### DIFF
--- a/api/app/valkey.py
+++ b/api/app/valkey.py
@@ -1,25 +1,58 @@
 """Valkey (Redis-compatible) client for OAuth state management."""
 
 import json
+import logging
 
 import redis.asyncio as redis
+from redis import exceptions as redis_exceptions
 
 from app.config import get_settings
 
 settings = get_settings()
+logger = logging.getLogger(__name__)
 
 # Global connection pool
 _pool: redis.ConnectionPool | None = None
+
+
+def _raise_valkey_error(operation: str, error: Exception) -> None:
+    """Classify Valkey failures with retryability hints and raise RuntimeError."""
+    if isinstance(error, ValueError):
+        message = (
+            f"Valkey configuration error during {operation}. "
+            "retryable=no next_action=Fix VALKEY_URL/auth settings before retry."
+        )
+    elif isinstance(error, redis_exceptions.ConnectionError):
+        message = (
+            f"Valkey unavailable during {operation}. "
+            "retryable=yes next_action=Check Valkey reachability/logs, then retry."
+        )
+    elif isinstance(error, redis_exceptions.TimeoutError):
+        message = (
+            f"Valkey timeout during {operation}. "
+            "retryable=yes next_action=Check Valkey load/network and retry with backoff."
+        )
+    else:
+        message = (
+            f"Valkey operation failed during {operation}. "
+            "retryable=unknown next_action=Inspect API/Valkey logs and exception cause."
+        )
+
+    logger.error(message, exc_info=error)
+    raise RuntimeError(message) from error
 
 
 async def get_valkey() -> redis.Redis:
     """Get Valkey client with connection pooling."""
     global _pool
     if _pool is None:
-        _pool = redis.ConnectionPool.from_url(
-            settings.VALKEY_URL,
-            decode_responses=True,
-        )
+        try:
+            _pool = redis.ConnectionPool.from_url(
+                settings.VALKEY_URL,
+                decode_responses=True,
+            )
+        except Exception as error:
+            _raise_valkey_error("client initialization", error)
     return redis.Redis(connection_pool=_pool)
 
 
@@ -44,46 +77,58 @@ class OAuthStateStore:
         code_verifier: str | None = None,
     ) -> None:
         """Save OAuth state with TTL."""
-        client = await get_valkey()
-        data = {"provider": provider}
-        if code_verifier:
-            data["code_verifier"] = code_verifier
+        try:
+            client = await get_valkey()
+            data = {"provider": provider}
+            if code_verifier:
+                data["code_verifier"] = code_verifier
 
-        await client.setex(
-            f"{cls.PREFIX}{state}",
-            settings.OAUTH_STATE_TTL,
-            json.dumps(data),
-        )
+            await client.setex(
+                f"{cls.PREFIX}{state}",
+                settings.OAUTH_STATE_TTL,
+                json.dumps(data),
+            )
+        except Exception as error:
+            _raise_valkey_error("oauth_state.save", error)
 
     @classmethod
     async def save_with_data(cls, state: str, data: dict) -> None:
         """Save OAuth state with custom data."""
-        client = await get_valkey()
-        await client.setex(
-            f"{cls.PREFIX}{state}",
-            settings.OAUTH_STATE_TTL,
-            json.dumps(data),
-        )
+        try:
+            client = await get_valkey()
+            await client.setex(
+                f"{cls.PREFIX}{state}",
+                settings.OAUTH_STATE_TTL,
+                json.dumps(data),
+            )
+        except Exception as error:
+            _raise_valkey_error("oauth_state.save_with_data", error)
 
     @classmethod
     async def get_and_delete(cls, state: str) -> dict | None:
         """Get and delete OAuth state (one-time use)."""
-        client = await get_valkey()
-        key = f"{cls.PREFIX}{state}"
+        try:
+            client = await get_valkey()
+            key = f"{cls.PREFIX}{state}"
 
-        # Get and delete atomically using pipeline
-        pipe = client.pipeline()
-        pipe.get(key)
-        pipe.delete(key)
-        results = await pipe.execute()
+            # Get and delete atomically using pipeline
+            pipe = client.pipeline()
+            pipe.get(key)
+            pipe.delete(key)
+            results = await pipe.execute()
 
-        data = results[0]
-        if data:
-            return json.loads(data)
-        return None
+            data = results[0]
+            if data:
+                return json.loads(data)
+            return None
+        except Exception as error:
+            _raise_valkey_error("oauth_state.get_and_delete", error)
 
     @classmethod
     async def exists(cls, state: str) -> bool:
         """Check if state exists."""
-        client = await get_valkey()
-        return await client.exists(f"{cls.PREFIX}{state}") > 0
+        try:
+            client = await get_valkey()
+            return await client.exists(f"{cls.PREFIX}{state}") > 0
+        except Exception as error:
+            _raise_valkey_error("oauth_state.exists", error)

--- a/api/tests/test_valkey.py
+++ b/api/tests/test_valkey.py
@@ -1,0 +1,43 @@
+"""Valkey error classification tests."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from redis import exceptions as redis_exceptions
+
+from app import valkey
+
+
+@pytest.fixture(autouse=True)
+async def _cleanup_pool():
+    """Reset global pool before/after each test to avoid cross-test leakage."""
+    await valkey.close_valkey()
+    yield
+    await valkey.close_valkey()
+
+
+@pytest.mark.asyncio
+async def test_get_valkey_classifies_configuration_error():
+    """Invalid connection settings are marked as non-retryable."""
+    with patch("app.valkey.redis.ConnectionPool.from_url", side_effect=ValueError("bad url")):
+        with pytest.raises(RuntimeError, match="configuration error") as exc_info:
+            await valkey.get_valkey()
+
+    message = str(exc_info.value)
+    assert "retryable=no" in message
+    assert "Fix VALKEY_URL/auth settings" in message
+
+
+@pytest.mark.asyncio
+async def test_save_classifies_connection_error_as_retryable():
+    """Reachability failures are marked as retryable with recovery guidance."""
+    mock_client = AsyncMock()
+    mock_client.setex.side_effect = redis_exceptions.ConnectionError("connection refused")
+
+    with patch("app.valkey.get_valkey", return_value=mock_client):
+        with pytest.raises(RuntimeError, match="Valkey unavailable") as exc_info:
+            await valkey.OAuthStateStore.save("state-1", "github")
+
+    message = str(exc_info.value)
+    assert "retryable=yes" in message
+    assert "Check Valkey reachability/logs" in message

--- a/docs/help/troubleshooting.md
+++ b/docs/help/troubleshooting.md
@@ -166,6 +166,15 @@ sqlalchemy.exc.OperationalError: could not connect to server
 | Valkey 接続不安定 | `OAuthStateStore` 参照前後で Valkey エラーが発生 | Valkey を復旧し、`docker compose ps/logs valkey` で安定化確認後に再試行 |
 | OAuth開始とcallbackの環境不一致 | `API_URL` と実アクセス先のホスト/スキームが異なる | 環境変数を一致させて再デプロイし、再度 `/api/v1/auth/{provider}` から開始 |
 
+#### Valkey 失敗分類（`api/app/valkey.py`）
+
+- `Valkey configuration error ... retryable=no`:
+  `VALKEY_URL` や認証情報の不備。再試行前に設定修正を優先する。
+- `Valkey unavailable ... retryable=yes`:
+  接続不能（例: refused / DNS 解決不可）。`docker compose ps/logs valkey` で疎通復旧後に再試行する。
+- `Valkey timeout ... retryable=yes`:
+  一時的な負荷・ネットワーク遅延。Valkey/API ログを確認し、バックオフ付きで再試行する。
+
 ---
 
 ### `Mock OAuth is disabled`


### PR DESCRIPTION
## Summary
- classify Valkey failures in `api/app/valkey.py` into configuration, unavailable, timeout, and unknown classes
- add retryability and next action hints to raised runtime errors (`retryable=... next_action=...`)
- add focused tests in `api/tests/test_valkey.py` and troubleshooting guidance update

## Testing
- `pytest -q api/tests -k valkey` ✅ (3 passed)
- `pytest -q api/tests` ⚠️ fails on baseline-unrelated test: `api/tests/test_auth_logout.py::test_logout_without_auth_returns_401`
- baseline check on `origin/main` reproduces the same failure (`1 failed`), so this PR does not introduce it

## Issue
- closes #451
