### PR TITLE
docs: セッション失効時の再ログイン手順を明確化

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,7 +365,8 @@ curl "http://localhost:8000/api/v1/auth/mock/users"
 
 ### セッション失効時の再ログイン
 
-`401 Unauthorized` が返る場合は、`POST /api/v1/auth/refresh` でトークン再発行を試し、失敗時は OAuth ログインを再実行してください。運用時の手順は [`docs/getting-started.md`](docs/getting-started.md) の「セッション失効時の再ログイン手順」にまとめています。
+`401 Unauthorized` が返る場合は、`POST /api/v1/auth/refresh` でトークン再発行を試し、`401` / `422` の場合は OAuth ログインを再実行してください。  
+復旧後は `GET /api/v1/users/me` が `200` になることを確認します。詳細手順は [`docs/getting-started.md`](docs/getting-started.md#セッション失効時の再ログイン手順) を参照してください。
 
 ### Running Tests
 

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -59,11 +59,11 @@ app = FastAPI(
     description="""
 ## OAuth Authentication API
 
-YESOD Auth provides a complete OAuth 2.0 authentication solution with support for multiple providers.
+YESOD Auth provides a complete OAuth 2.0 authentication solution with multi-provider support.
 
 ### Features
 
-- 🔑 **OAuth 2.0** - Eight-provider authentication (Google, GitHub, Discord, X, LinkedIn, Facebook, Slack, Twitch) with PKCE support
+- 🔑 **OAuth 2.0** - Eight-provider OAuth authentication (Google, GitHub, Discord, X, LinkedIn, Facebook, Slack, Twitch) with PKCE support
 - 🔄 **Token Rotation** - Secure refresh token rotation
 - 👤 **User Management** - Profile updates, account linking
 - 📊 **Audit Logging** - Complete authentication event tracking

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -189,10 +189,14 @@ curl -fsS -o /dev/null -w '%{http_code}\n' \
 1. まずリフレッシュトークンで再発行を試す
 
 ```bash
-curl -X POST "http://localhost:8000/api/v1/auth/refresh" \
+curl -sS -X POST "http://localhost:8000/api/v1/auth/refresh" \
   -H "Content-Type: application/json" \
   -d '{"refresh_token":"<refresh_token>"}'
 ```
+
+判定基準:
+- `200` かつ `access_token` が返る: 新しいアクセストークンで API 呼び出しを再開
+- `401` / `422`: refresh では復旧できないため、手順2へ進む
 
 2. 再発行できない場合は OAuth ログインを再実行する
 
@@ -204,13 +208,24 @@ open "http://localhost:8000/api/v1/auth/google"
 3. 複数端末で状態がずれた場合は古いセッションを失効させる
 
 ```bash
-curl -X DELETE "http://localhost:8000/api/v1/sessions/me" \
+curl -sS -X DELETE "http://localhost:8000/api/v1/sessions/me" \
   -H "Authorization: Bearer <access_token>"
 ```
+
+4. 復旧確認を行う（最小確認）
+
+```bash
+curl -sS -o /dev/null -w '%{http_code}\n' \
+  "http://localhost:8000/api/v1/users/me" \
+  -H "Authorization: Bearer <new_access_token>"
+```
+
+`200` なら復旧完了です。`401` が継続する場合は、`Authorization` ヘッダーのトークン更新漏れを確認してください。
 
 補足:
 - 認証API詳細は `docs/api/auth.md` を参照してください。
 - セッションAPI一覧は `README.md` の `Sessions` セクションと同一です。
+- 管理API向けの同等手順は `docs/help/troubleshooting.md` の「管理者トークン失効で管理APIが `401 Unauthorized` になる」を参照してください。
 
 ### OAuth callback失敗時の確認順
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -290,26 +290,41 @@ docker compose up -d --build
 
 <a id="environment-variables"></a>
 
-### 必須（未設定時に運用影響が出る）
+### 区分付き一覧（必須 / 推奨 / 任意）
 
-| 変数/シークレット | 用途 | 未設定時の症状 | 既定値/補足 |
-|------------------|------|----------------|------------|
-| `DATABASE_URL` | PostgreSQL接続先 | API/管理画面がDB接続エラーで起動失敗、または意図しないDBへ接続 | 開発向け既定値あり。セルフホストでは明示設定推奨 |
-| `VALKEY_URL` | Valkey接続先（state/レート制御） | OAuthの`state mismatch`やセッション関連エラーが発生しやすくなる | 開発向け既定値あり。セルフホストでは明示設定推奨 |
-| `FRONTEND_URL` | OAuth完了後のリダイレクト先 | ログイン後の遷移先が不正になり、認証完了後のUXが壊れる | 既定値 `http://localhost:3000` |
-| `CORS_ORIGINS` | API許可オリジン | ブラウザから`CORS`エラーでAPI呼び出し失敗 | 既定値 `http://localhost:3000,http://localhost:5173` |
-| `jwt_secret` | JWT署名鍵 | トークン検証不整合や`401`が発生。既定値運用はセキュリティ上非推奨 | Docker Secret推奨（`secrets/jwt_secret.txt`） |
-| `<provider>_client_id` / `<provider>_client_secret` | OAuth provider資格情報 | 該当providerで`invalid_client`や認証失敗が発生 | 有効化して使うprovider分のみ必須 |
-
-### 推奨（運用品質・セキュリティ向上）
-
-| 変数名 | 説明 | デフォルト |
-|--------|------|-----------|
-| `ACCESS_TOKEN_LIFETIME_SECONDS` | アクセストークン有効期限 | `900` |
-| `REFRESH_TOKEN_LIFETIME_DAYS` | リフレッシュトークン有効期限 | `7` |
-| `SESSION_EXPIRY_HOURS` | 管理画面セッション有効期限（時間） | `24` |
+| 区分 | 変数/シークレット | 用途 | 未設定時の症状 | 既定値/補足 |
+|------|-------------------|------|----------------|------------|
+| 必須 | `DATABASE_URL` | PostgreSQL接続先 | API/管理画面がDB接続エラーで起動失敗、または意図しないDBへ接続 | 開発向け既定値あり。セルフホストでは明示設定推奨 |
+| 必須 | `VALKEY_URL` | Valkey接続先（state/レート制御） | OAuthの`state mismatch`やセッション関連エラーが発生しやすくなる | 開発向け既定値あり。セルフホストでは明示設定推奨 |
+| 必須 | `FRONTEND_URL` | OAuth完了後のリダイレクト先 | ログイン後の遷移先が不正になり、認証完了後のUXが壊れる | 既定値 `http://localhost:3000` |
+| 必須 | `CORS_ORIGINS` | API許可オリジン | ブラウザから`CORS`エラーでAPI呼び出し失敗 | 既定値 `http://localhost:3000,http://localhost:5173` |
+| 必須 | `jwt_secret` | JWT署名鍵 | トークン検証不整合や`401`が発生。既定値運用はセキュリティ上非推奨 | Docker Secret推奨（`secrets/jwt_secret.txt`） |
+| 必須 | `<provider>_client_id` / `<provider>_client_secret` | OAuth provider資格情報 | 該当providerで`invalid_client`や認証失敗が発生 | 有効化して使うprovider分のみ必須 |
+| 推奨 | `ACCESS_TOKEN_LIFETIME_SECONDS` | アクセストークン有効期限 | セキュリティポリシーに対して寿命が長すぎる/短すぎる状態になりやすい | `900` |
+| 推奨 | `REFRESH_TOKEN_LIFETIME_DAYS` | リフレッシュトークン有効期限 | 再認証頻度と失効リスクのバランスが運用要件とずれる | `7` |
+| 推奨 | `SESSION_EXPIRY_HOURS` | 管理画面セッション有効期限（時間） | 管理画面セッションが運用要件より長期化/短期化する | `24` |
+| 任意 | `MOCK_OAUTH_ENABLED` | Mock OAuth有効化（アプリ既定値は`0`。`docker compose --profile default`/`ci`ではCompose側で`1`に上書き） | 期待したログイン経路（Mock/実OAuth）と実挙動がずれる | `0` |
+| 任意 | `ADMIN_USER` | 管理者ユーザー名 | 管理画面ログイン時に想定と異なるユーザー名を参照して混乱が起きる | `admin` |
+| 任意 | `DEFAULT_LANGUAGE` | 管理画面デフォルト言語（en, ja, fr, ko, de） | 管理画面の初期表示言語が運用想定と一致しない | `en` |
 
 `CORS_ORIGINS` が未設定または空文字の場合、API起動時に警告ログを出し、開発用デフォルト値（`http://localhost:3000,http://localhost:5173`）で起動します。
+
+### 設定チェック表（記入用）
+
+| 項目 | 区分 | 設定値確認 | 未設定時症状の理解確認 |
+|------|------|------------|------------------------|
+| `DATABASE_URL` | 必須 | ☐ | ☐ |
+| `VALKEY_URL` | 必須 | ☐ | ☐ |
+| `FRONTEND_URL` | 必須 | ☐ | ☐ |
+| `CORS_ORIGINS` | 必須 | ☐ | ☐ |
+| `jwt_secret` | 必須 | ☐ | ☐ |
+| `<provider>_client_id` / `<provider>_client_secret` | 必須 | ☐ | ☐ |
+| `ACCESS_TOKEN_LIFETIME_SECONDS` | 推奨 | ☐ | - |
+| `REFRESH_TOKEN_LIFETIME_DAYS` | 推奨 | ☐ | - |
+| `SESSION_EXPIRY_HOURS` | 推奨 | ☐ | - |
+| `MOCK_OAUTH_ENABLED` | 任意 | ☐ | - |
+| `ADMIN_USER` | 任意 | ☐ | - |
+| `DEFAULT_LANGUAGE` | 任意 | ☐ | - |
 
 ### 環境変数・Secrets の優先順位
 
@@ -337,16 +352,9 @@ docker compose up -d --build
 rg -n "REFRESH_TOKEN_LIFETIME_DAYS|/api/v1/auth/refresh|再ログイン" docs/installation.md README.md
 ```
 
-### 任意（要件に応じて設定）
-
-| 変数名 | 説明 | デフォルト |
-|--------|------|-----------|
-| `MOCK_OAUTH_ENABLED` | Mock OAuth有効化（アプリ既定値は`0`。`docker compose --profile default`/`ci`ではCompose側で`1`に上書き） | `0` |
-| `ADMIN_USER` | 管理者ユーザー名 | `admin` |
-| `DEFAULT_LANGUAGE` | 管理画面デフォルト言語（en, ja, fr, ko, de） | `en` |
-
 関連ヘルプ:
 - [トラブルシューティング（認証エラー）](./help/troubleshooting.md#認証エラー)
+- [初回起動トラブルシュート](./help/first-start-troubleshooting.md)
 
 ## OAuth認証情報
 


### PR DESCRIPTION
## 概要\n- セッション失効時の復旧手順に成功/失敗の判定基準（200/401/422）を追加\n- 復旧確認として  が 200 になる確認手順を追加\n- README の再ログイン節を getting-started の手順と整合\n\n## テスト\n- docker compose --profile default config --services