### PR TITLE
docs: Twitch 追加設定の最小手順を整理

### DIFF
--- a/api/app/main.py
+++ b/api/app/main.py
@@ -59,11 +59,11 @@ app = FastAPI(
     description="""
 ## OAuth Authentication API
 
-YESOD Auth provides a complete OAuth 2.0 authentication solution with support for multiple providers.
+YESOD Auth provides a complete OAuth 2.0 authentication solution with multi-provider support.
 
 ### Features
 
-- 🔑 **OAuth 2.0** - Eight-provider authentication (Google, GitHub, Discord, X, LinkedIn, Facebook, Slack, Twitch) with PKCE support
+- 🔑 **OAuth 2.0** - Eight-provider OAuth authentication (Google, GitHub, Discord, X, LinkedIn, Facebook, Slack, Twitch) with PKCE support
 - 🔄 **Token Rotation** - Secure refresh token rotation
 - 👤 **User Management** - Profile updates, account linking
 - 📊 **Audit Logging** - Complete authentication event tracking

--- a/docs/guides/oauth/twitch.md
+++ b/docs/guides/oauth/twitch.md
@@ -25,16 +25,25 @@ echo "your-client-secret" > secrets/twitch_client_secret.txt
 
 ## 4. 追加設定の最小手順（セルフホスト向け）
 
+「起動できるがTwitchログインだけ失敗する」状態を避けるため、次の5項目を順に確認します。
+
 1. **Callback URLを実運用値へ更新**
     - ローカル: `http://localhost:8000/api/v1/auth/twitch/callback`
     - 本番: `https://<your-domain>/api/v1/auth/twitch/callback`
-2. **スコープを固定**
-    - YESOD Auth の既定は `openid user:read:email`
-    - Twitch側の設定変更時も、この2つを維持する
-3. **APIコンテナへ secrets を渡す**
-    - `docker-compose.override.yml` で `twitch_client_id` / `twitch_client_secret` を `api` と `api-ci` に追加する
-4. **実OAuthモードを有効化**
-    - `MOCK_OAUTH_ENABLED=0`（または未設定）を確認する
+2. **Client ID / Client Secret を secrets に配置**
+    - `secrets/twitch_client_id.txt`
+    - `secrets/twitch_client_secret.txt`
+3. **APIコンテナへ secrets をマウント**
+    - `docker-compose.override.yml` で `twitch_client_id` / `twitch_client_secret` を `api` と `api-ci` に追加
+4. **実OAuthモードへ切替**
+    - `MOCK_OAUTH_ENABLED=0`（または未設定）を確認
+5. **スコープを固定**
+    - YESOD Auth の既定: `openid user:read:email`
+    - Twitch側の設定変更時もこの2つを維持
+
+補足:
+- OAuth設定全体の共通方針は [OAuth設定ハブ](index.md) を参照してください。
+- 初回導入時の起動確認は [クイックスタート](../../getting-started.md) の手順と同じです。
 
 ### docker-compose.override.yml の最小例
 
@@ -59,7 +68,7 @@ secrets:
 ### 最小確認手順
 
 ```bash
-# 1) API起動確認
+# 1) API起動確認（200 + {"status":"healthy"}）
 curl -fsS http://localhost:8000/health
 
 # 2) Twitch OAuth導線確認（302想定）


### PR DESCRIPTION
## 概要
- `docs/guides/oauth/twitch.md` の「追加設定の最小手順」を5項目の順序付きチェックに再整理
- `secrets` 配置、overrideでのマウント、`MOCK_OAUTH_ENABLED` 切替、スコープ固定を明確化
- OAuthハブとクイックスタートへの参照を追加し、導線を統一

## テスト
- `rg "設定|手順" docs/guides/oauth/twitch.md`
- `docker compose --profile default config --services`

Closes #204
