### PR TITLE
[Bench-80][78] sessions revoke_all の監査ログを追加

### DIFF
--- a/api/app/sessions/router.py
+++ b/api/app/sessions/router.py
@@ -121,10 +121,12 @@ async def revoke_session(
 
 @router.delete("", response_model=RevokeResponse)
 async def revoke_all_sessions(
+    request: Request,
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
     """Revoke all sessions for current user."""
+    device_info, ip_address = _get_client_info(request)
     result = await db.execute(
         select(RefreshToken).where(
             and_(
@@ -140,7 +142,21 @@ async def revoke_all_sessions(
 
     await db.commit()
 
+    revoked_count = len(sessions)
+    await AuditLogger.log_event(
+        db,
+        AuthEventType.ALL_SESSIONS_REVOKED,
+        current_user.id,
+        {
+            "audit_key": "revoked_count",
+            "revoked_count": revoked_count,
+            "user_id": str(current_user.id),
+        },
+        ip_address,
+        device_info,
+    )
+
     return RevokeResponse(
-        message=f"Revoked {len(sessions)} sessions",
-        revoked_count=len(sessions),
+        message=f"Revoked {revoked_count} sessions",
+        revoked_count=revoked_count,
     )

--- a/api/tests/test_sessions_api.py
+++ b/api/tests/test_sessions_api.py
@@ -1,15 +1,20 @@
 """Sessions API tests."""
 
 import uuid
+from importlib import import_module
+from unittest.mock import AsyncMock
 
 import pytest
 from httpx import AsyncClient
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.audit import AuthEventType
 from app.auth.tokens import create_access_token, create_refresh_token, hash_refresh_token
 from app.models.refresh_token import RefreshToken
 from app.models.user import User
+
+sessions_router_module = import_module("app.sessions.router")
 
 
 @pytest.mark.asyncio
@@ -70,3 +75,36 @@ async def test_revoke_session_is_idempotent_for_same_session_id(
         "session_id": str(session_id),
         "revoked_count": None,
     }
+
+
+@pytest.mark.asyncio
+async def test_revoke_all_sessions_logs_audit_with_revoked_count_and_user_id(
+    client: AsyncClient, db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+):
+    """DELETE /api/v1/sessions should emit one all-sessions audit event."""
+    user = User()
+    db_session.add(user)
+    await db_session.commit()
+    await db_session.refresh(user)
+
+    await create_refresh_token(db_session, user.id)
+    await create_refresh_token(db_session, user.id)
+
+    access_token = create_access_token(str(user.id), "revoke-all-audit@example.com")
+    auth_header = {"Authorization": f"Bearer {access_token}"}
+
+    mock_log_event = AsyncMock()
+    monkeypatch.setattr(sessions_router_module.AuditLogger, "log_event", mock_log_event)
+
+    response = await client.delete("/api/v1/sessions", headers=auth_header)
+
+    assert response.status_code == 200
+    assert response.json()["revoked_count"] == 2
+    mock_log_event.assert_awaited_once()
+
+    _, event_type, user_id, details, *_ = mock_log_event.await_args.args
+    assert event_type == AuthEventType.ALL_SESSIONS_REVOKED
+    assert user_id == user.id
+    assert details["audit_key"] == "revoked_count"
+    assert details["revoked_count"] == 2
+    assert details["user_id"] == str(user.id)


### PR DESCRIPTION
## 概要
- `DELETE /api/v1/sessions` (`revoke_all_sessions`) に監査ログ記録を追加
- 監査メタデータへ `revoked_count` と `user_id` を追加
- `DELETE /api/v1/sessions` の監査呼び出しを検証するAPIテストを追加

## 変更詳細
- `api/app/sessions/router.py`
  - `revoke_all_sessions` に `Request` を追加し、IP/User-Agent を取得
  - `AuditLogger.log_event` を `AuthEventType.ALL_SESSIONS_REVOKED` で記録
  - details に以下を保存
    - `audit_key: revoked_count`
    - `revoked_count`
    - `user_id`
- `api/tests/test_sessions_api.py`
  - revoke-all 実行時の監査呼び出しを `AsyncMock` で検証するテストを追加

## テスト
- `pytest -q api/tests/test_sessions_api.py`
- `pytest -q api/tests/test_sessions.py`

Closes #481
