### PR TITLE
[Bench-80][83] users soft delete 猶予期限の可観測性を強化する

### DIFF
--- a/api/app/users/router.py
+++ b/api/app/users/router.py
@@ -166,12 +166,19 @@ async def delete_account(
     # Get OAuth providers for reference
     oauth_providers = [oa.provider for oa in user.oauth_accounts]
 
+    scheduled_delete_at = datetime.now(UTC) + timedelta(days=SOFT_DELETE_GRACE_DAYS)
+    scheduled_delete_at_iso = scheduled_delete_at.isoformat().replace("+00:00", "Z")
+
     # Log account deletion before deleting
     await AuditLogger.log_event(
         db,
         AuthEventType.ACCOUNT_DELETED,
         user_id,
-        {"email": email, "oauth_providers": oauth_providers},
+        {
+            "email": email,
+            "oauth_providers": oauth_providers,
+            "scheduled_delete_at": scheduled_delete_at_iso,
+        },
         ip_address,
         device_info,
     )
@@ -186,7 +193,7 @@ async def delete_account(
         id=user_id,
         email_backup=email,
         display_name_backup=display_name,
-        purge_at=datetime.now(UTC) + timedelta(days=SOFT_DELETE_GRACE_DAYS),
+        purge_at=scheduled_delete_at,
         oauth_providers=json.dumps(oauth_providers) if oauth_providers else None,
     )
     db.add(deleted_user)
@@ -199,6 +206,7 @@ async def delete_account(
         message=f"Account scheduled for deletion. Will be permanently removed after {SOFT_DELETE_GRACE_DAYS} days.",
         deleted_user_id=user_id,
         deleted_email=email,
+        scheduled_delete_at=scheduled_delete_at,
     )
 
 

--- a/api/app/users/schemas.py
+++ b/api/app/users/schemas.py
@@ -58,6 +58,9 @@ class UserDeleteResponse(BaseModel):
     message: str = Field(..., description="Deletion confirmation message")
     deleted_user_id: uuid.UUID = Field(..., description="ID of the deleted user")
     deleted_email: str = Field(..., description="Email of the deleted user")
+    scheduled_delete_at: datetime = Field(
+        ..., description="Scheduled permanent deletion datetime (UTC)"
+    )
 
 
 class SyncFromProviderResponse(BaseModel):

--- a/api/tests/test_users_delete_account.py
+++ b/api/tests/test_users_delete_account.py
@@ -1,5 +1,7 @@
 """User account deletion endpoint tests."""
 
+from datetime import UTC, datetime
+
 import pytest
 from httpx import AsyncClient
 from sqlalchemy import select
@@ -46,11 +48,16 @@ async def test_delete_account_invalidates_related_session_tokens(
         "/api/v1/users/me",
         headers={"Authorization": f"Bearer {access_token}"},
     )
+    payload = delete_response.json()
     assert delete_response.status_code == 200
-    assert delete_response.json()["deleted_user_id"] == str(user.id)
+    assert payload["deleted_user_id"] == str(user.id)
+    assert payload["deleted_email"] == "delete-session-test@example.com"
+    scheduled_delete_at = datetime.fromisoformat(payload["scheduled_delete_at"].replace("Z", "+00:00"))
+    assert scheduled_delete_at.tzinfo == UTC
 
     deleted_user = await db_session.scalar(select(DeletedUser).where(DeletedUser.id == user.id))
     assert deleted_user is not None
+    assert deleted_user.purge_at == scheduled_delete_at.replace(tzinfo=None)
 
     refresh_record = await db_session.scalar(
         select(RefreshToken).where(RefreshToken.token_hash == hash_refresh_token(refresh_token))
@@ -63,3 +70,37 @@ async def test_delete_account_invalidates_related_session_tokens(
     )
     assert refresh_response.status_code == 401
     assert refresh_response.json() == {"detail": "Invalid or expired refresh token"}
+
+
+@pytest.mark.asyncio
+async def test_delete_account_second_request_with_same_token_returns_user_not_found(
+    client: AsyncClient, db_session: AsyncSession
+):
+    """Second delete with the same access token should fail because user is already removed."""
+    user = User()
+    db_session.add(user)
+    await db_session.flush()
+    db_session.add(
+        UserEmail(
+            user_id=user.id,
+            email="delete-user-not-found@example.com",
+            is_primary=True,
+        )
+    )
+    await db_session.commit()
+    await db_session.refresh(user)
+
+    access_token = create_access_token(str(user.id), "delete-user-not-found@example.com")
+
+    first_delete = await client.delete(
+        "/api/v1/users/me",
+        headers={"Authorization": f"Bearer {access_token}"},
+    )
+    assert first_delete.status_code == 200
+
+    second_delete = await client.delete(
+        "/api/v1/users/me",
+        headers={"Authorization": f"Bearer {access_token}"},
+    )
+    assert second_delete.status_code == 401
+    assert second_delete.json() == {"detail": "User not found"}

--- a/docs/api/users.md
+++ b/docs/api/users.md
@@ -146,6 +146,19 @@ Authorization: Bearer <access_token>
 !!! warning "注意"
     この操作は取り消せません。関連するすべてのデータが削除されます。
 
+**成功レスポンス (`200 OK`)**
+
+```json
+{
+  "message": "Account scheduled for deletion. Will be permanently removed after 30 days.",
+  "deleted_user_id": "550e8400-e29b-41d4-a716-446655440000",
+  "deleted_email": "user@example.com",
+  "scheduled_delete_at": "2026-01-31T00:00:00Z"
+}
+```
+
+`scheduled_delete_at` は UTC で、永続削除予定時刻を示します。
+
 !!! note "Webhookイベント"
     アカウント削除時に`user.deleted`イベントが発火します。
 


### PR DESCRIPTION
## 概要
- `DELETE /api/v1/users/me` のレスポンスに `scheduled_delete_at` (UTC) を追加
- `ACCOUNT_DELETED` 監査ログ詳細に `scheduled_delete_at` を追加
- soft delete レコード作成時とレスポンスで同一の予定時刻を使用するよう統一
- 再削除時（同一トークン）の異常系をテストで固定
- users API ドキュメントに削除成功レスポンス例を追記

## 変更ファイル
- `api/app/users/router.py`
- `api/app/users/schemas.py`
- `api/tests/test_users_delete_account.py`
- `docs/api/users.md`

## テスト
- `python -m pytest -q tests/test_users_delete_account.py`
- `python -m pytest -q tests/test_users_me_auth.py tests/test_users_sync_from_provider.py`

Closes #480
