### PR TITLE
docs: logout未認証エラーレスポンス確認手順を現行契約に同期

### DIFF
--- a/api/tests/test_auth_logout.py
+++ b/api/tests/test_auth_logout.py
@@ -14,5 +14,9 @@ async def test_logout_without_auth_returns_401(client: AsyncClient):
 
     assert response.status_code == 401
     data = response.json()
-    assert "detail" in data
-    assert isinstance(data["detail"], str)
+    assert data == {
+        "detail": {
+            "code": "missing_bearer_token",
+            "message": "Not authenticated",
+        }
+    }

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -331,7 +331,18 @@ curl -i -X POST "http://localhost:8000/api/v1/auth/logout" \
 期待値:
 
 - ステータスコード: `401 Unauthorized`
-- レスポンスボディ: `{"detail":"Not authenticated"}`
+- `WWW-Authenticate` ヘッダ: `Bearer`
+- レスポンスボディ: `{"detail":{"code":"missing_bearer_token","message":"Not authenticated"}}`
+
+値を機械的に確認したい場合は、次のコマンドで HTTP ステータスと本文を同時に検証できます。
+
+```bash
+status=$(curl -s -o /tmp/logout-unauth.json -w "%{http_code}" -X POST "http://localhost:8000/api/v1/auth/logout" \
+  -H "Content-Type: application/json" \
+  -d '{"refresh_token":"dummy"}')
+test "$status" = "401"
+jq -e '.detail.code == "missing_bearer_token" and .detail.message == "Not authenticated"' /tmp/logout-unauth.json
+```
 
 詳細な調査手順は [トラブルシューティング](help/troubleshooting.md) を参照してください。
 


### PR DESCRIPTION
## 概要
- `docs/getting-started.md` の未認証 `POST /api/v1/auth/logout` 手順を現行レスポンス契約に更新
- 期待値へ `WWW-Authenticate: Bearer` を追加
- HTTPステータスと本文を機械的に検証するコマンドを追加
- `api/tests/test_auth_logout.py` を現行エラー契約（`detail.code` / `detail.message`）に同期

## テスト
- `cd api && UV_CACHE_DIR=/tmp/uv-cache UV_PYTHON_INSTALL_DIR=/tmp/uv-python UV_TOOL_DIR=/tmp/uv-tools uv run --with-requirements requirements.txt pytest -q tests/test_auth_logout.py`

Closes #158
