### PR TITLE
chore: normalize Bench-80 queue inventory and add snapshot tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,6 +420,27 @@ This repository includes GitHub Actions workflows for automatic PR approval and 
 This script ensures the repository keeps the labels used by Codex / codex-orch automation:
 `codex`, `codex-automation`, `codex:queue`, `codex:claimed`, `codex:blocked`, `codex:pr-opened`.
 
+### Bench-80 Queue Inventory Normalization
+
+`codex:queue` issue の title 先頭に付いている `"[Bench-80][NN]"` 番号は重複・スロット逸脱の温床になるため、在庫キーとして運用しません。
+active queue の正規化は title から番号プレフィックスを除去する方針で統一します。
+
+```bash
+# 事前確認（dry-run）
+python3 scripts/normalize_bench80_queue_titles.py --repo mashirou1234/yesod-auth
+
+# 実適用
+python3 scripts/normalize_bench80_queue_titles.py --repo mashirou1234/yesod-auth --apply
+
+# 正規化後の確認
+python3 scripts/queue_seed_snapshot.py --repo mashirou1234/yesod-auth --format markdown
+```
+
+期待値:
+- `unexpected_slots` が空
+- `duplicate_slots` が空
+- `bench_count` は `0`（番号プレフィックス廃止方針）
+
 If a pull request was opened while the auto-approve / auto-merge workflows were disabled, enabling the workflows later does not retroactively register auto-merge for that PR. In that case, reopen/synchronize the PR or enable auto-merge manually.
 
 With this setup, a PR is auto-approved and put into auto-merge waiting state on open/update, then merged automatically when required CI checks complete successfully.

--- a/scripts/normalize_bench80_queue_titles.py
+++ b/scripts/normalize_bench80_queue_titles.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Normalize Bench-80 queue issue titles by removing slot prefixes."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+
+BENCH_TITLE_RE = re.compile(r"^\s*\[Bench-80\]\[(\d+)\]\s*(.+?)\s*$")
+
+
+def run_gh(args: list[str]) -> str:
+    try:
+        completed = subprocess.run(
+            ["gh", *args],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError:
+        print("gh CLI is required", file=sys.stderr)
+        raise SystemExit(1)
+    except subprocess.CalledProcessError as exc:
+        print(exc.stderr.strip() or str(exc), file=sys.stderr)
+        raise SystemExit(exc.returncode)
+    return completed.stdout
+
+
+def detect_repo(explicit: str) -> str:
+    if explicit:
+        return explicit
+    return run_gh(["repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"]).strip()
+
+
+def fetch_open_queue_issues(repo: str) -> list[dict]:
+    output = run_gh(
+        [
+            "issue",
+            "list",
+            "--repo",
+            repo,
+            "--state",
+            "open",
+            "--limit",
+            "200",
+            "--json",
+            "number,title,labels,createdAt",
+        ]
+    )
+    issues = json.loads(output)
+    queue = []
+    for issue in issues:
+        labels = {label["name"] for label in issue.get("labels", [])}
+        if "codex:queue" in labels:
+            queue.append(issue)
+    queue.sort(key=lambda i: i.get("createdAt", ""))
+    return queue
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Normalize Bench-80 queue issue titles.")
+    parser.add_argument("--repo", default="", help="owner/repo")
+    parser.add_argument("--apply", action="store_true", help="Apply title updates")
+    args = parser.parse_args()
+
+    repo = detect_repo(args.repo.strip())
+    if not repo:
+        print("Repository not found. pass --repo owner/repo.", file=sys.stderr)
+        return 1
+
+    queue_issues = fetch_open_queue_issues(repo)
+    candidates = []
+    for issue in queue_issues:
+        match = BENCH_TITLE_RE.match(issue["title"])
+        if not match:
+            continue
+        new_title = match.group(2).strip()
+        if not new_title:
+            continue
+        if new_title == issue["title"].strip():
+            continue
+        candidates.append((issue["number"], issue["title"], new_title))
+
+    mode = "APPLY" if args.apply else "DRY-RUN"
+    print(f"[{mode}] repo={repo} candidates={len(candidates)}")
+
+    updated = 0
+    for number, old_title, new_title in candidates:
+        print(f"#{number}: {old_title} -> {new_title}")
+        if not args.apply:
+            continue
+        run_gh(["issue", "edit", str(number), "--repo", repo, "--title", new_title])
+        updated += 1
+
+    if args.apply:
+        print(f"updated={updated}")
+    else:
+        print("updated=0 (dry-run)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/queue_seed_snapshot.py
+++ b/scripts/queue_seed_snapshot.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Snapshot open codex:queue inventory for Bench-80 slot health."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import Any
+
+BENCH_TITLE_RE = re.compile(r"^\s*\[Bench-80\]\[(\d+)\]\s*(.+?)\s*$")
+
+
+@dataclass
+class BenchIssue:
+    number: int
+    slot: int
+    title: str
+    url: str
+
+
+def run_gh(args: list[str]) -> str:
+    try:
+        completed = subprocess.run(
+            ["gh", *args],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError:
+        print("gh CLI is required", file=sys.stderr)
+        raise SystemExit(1)
+    except subprocess.CalledProcessError as exc:
+        print(exc.stderr.strip() or str(exc), file=sys.stderr)
+        raise SystemExit(exc.returncode)
+    return completed.stdout
+
+
+def fetch_open_queue_issues(repo: str) -> list[dict[str, Any]]:
+    output = run_gh(
+        [
+            "issue",
+            "list",
+            "--repo",
+            repo,
+            "--state",
+            "open",
+            "--limit",
+            "200",
+            "--json",
+            "number,title,url,createdAt,labels",
+        ]
+    )
+    issues = json.loads(output)
+    queue_issues = []
+    for issue in issues:
+        labels = {label["name"] for label in issue.get("labels", [])}
+        if "codex:queue" in labels:
+            queue_issues.append(issue)
+    queue_issues.sort(key=lambda x: x.get("createdAt", ""))
+    return queue_issues
+
+
+def analyze(issues: list[dict[str, Any]]) -> dict[str, Any]:
+    bench_issues: list[BenchIssue] = []
+    for issue in issues:
+        match = BENCH_TITLE_RE.match(issue["title"])
+        if not match:
+            continue
+        bench_issues.append(
+            BenchIssue(
+                number=issue["number"],
+                slot=int(match.group(1)),
+                title=issue["title"],
+                url=issue["url"],
+            )
+        )
+
+    used_slots = sorted({item.slot for item in bench_issues if 1 <= item.slot <= 20})
+    unexpected_by_slot: dict[int, list[BenchIssue]] = defaultdict(list)
+    duplicates_by_slot: dict[int, list[BenchIssue]] = defaultdict(list)
+    grouped: dict[int, list[BenchIssue]] = defaultdict(list)
+
+    for item in bench_issues:
+        grouped[item.slot].append(item)
+        if item.slot < 1 or item.slot > 20:
+            unexpected_by_slot[item.slot].append(item)
+
+    for slot, members in grouped.items():
+        if len(members) > 1:
+            duplicates_by_slot[slot].extend(members)
+
+    return {
+        "queue_count": len(issues),
+        "bench_count": len(bench_issues),
+        "used_slots": used_slots,
+        "unexpected_slots": {
+            str(slot): [item.number for item in members]
+            for slot, members in sorted(unexpected_by_slot.items())
+        },
+        "duplicate_slots": {
+            str(slot): [item.number for item in members]
+            for slot, members in sorted(duplicates_by_slot.items())
+        },
+    }
+
+
+def to_markdown(repo: str, summary: dict[str, Any]) -> str:
+    lines = [
+        f"# Queue Snapshot ({repo})",
+        "",
+        f"- queue_count: `{summary['queue_count']}`",
+        f"- bench_count: `{summary['bench_count']}`",
+        f"- used_slots: `{summary['used_slots']}`",
+    ]
+
+    unexpected = summary["unexpected_slots"]
+    if unexpected:
+        rendered = [f"[{slot}] #{' #'.join(str(n) for n in numbers)}" for slot, numbers in unexpected.items()]
+        lines.append(f"- unexpected_slots: `{rendered}`")
+    else:
+        lines.append("- unexpected_slots: `[]`")
+
+    duplicate = summary["duplicate_slots"]
+    if duplicate:
+        rendered = [f"[{slot}] #{' #'.join(str(n) for n in numbers)}" for slot, numbers in duplicate.items()]
+        lines.append(f"- duplicate_slots: `{rendered}`")
+    else:
+        lines.append("- duplicate_slots: `[]`")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Snapshot Bench-80 queue slot health.")
+    parser.add_argument("--repo", default="", help="owner/repo. Defaults to current gh repo.")
+    parser.add_argument("--format", choices=("json", "markdown"), default="json")
+    args = parser.parse_args()
+
+    repo = args.repo.strip()
+    if not repo:
+        repo = run_gh(["repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"]).strip()
+    if not repo:
+        print("Repository not found. pass --repo owner/repo.", file=sys.stderr)
+        return 1
+
+    summary = analyze(fetch_open_queue_issues(repo))
+    if args.format == "markdown":
+        print(to_markdown(repo, summary))
+    else:
+        print(json.dumps(summary, ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary\n- add \{
  "queue_count": 100,
  "bench_count": 0,
  "used_slots": [],
  "unexpected_slots": {},
  "duplicate_slots": {}
} to inspect open \ inventory and detect unexpected/duplicate Bench-80 slots\n- add \[DRY-RUN] repo=mashirou1234/yesod-auth candidates=0
updated=0 (dry-run) to remove \ prefix from active queue issue titles\n- document the normalization policy and operational commands in README\n- executed live normalization on \ open queue issues: updated 98 titles\n\n## Validation\n- \[DRY-RUN] repo=mashirou1234/yesod-auth candidates=0
updated=0 (dry-run) => candidates=0\n- \{
  "queue_count": 100,
  "bench_count": 0,
  "used_slots": [],
  "unexpected_slots": {},
  "duplicate_slots": {}
} => bench_count=0, unexpected_slots={}, duplicate_slots={}\n\nCloses #539