### PR TITLE
fix: improve oauth callback missing-state audit log

### DIFF
--- a/api/app/auth/router.py
+++ b/api/app/auth/router.py
@@ -133,6 +133,22 @@ def _invalid_state_reason(request: Request, provider: str) -> str:
     return f"Invalid state [provider={provider}] [request-id={_get_request_id(request)}]"
 
 
+def _missing_oauth_callback_params_reason(
+    request: Request, provider: str, code: str | None, state: str | None
+) -> str:
+    """Build audit reason for missing OAuth callback params."""
+    missing_params: list[str] = []
+    if not code:
+        missing_params.append("code")
+    if not state:
+        missing_params.append("state")
+    missing = ",".join(missing_params) if missing_params else "unknown"
+    return (
+        f"OAuth callback missing params [provider={provider}] [missing={missing}] "
+        f"[request-id={_get_request_id(request)}]"
+    )
+
+
 def _normalize_callback_url(url: str) -> str:
     """Normalize callback URL by dropping only trailing slash and query/fragment."""
     parsed = urlsplit(url)
@@ -472,6 +488,15 @@ async def github_callback(
         raise HTTPException(status_code=400, detail=f"OAuth callback failed: {error}")
 
     if not code or not state:
+        await AuditLogger.log_login(
+            db,
+            None,
+            "github",
+            False,
+            ip_address,
+            device_info,
+            _missing_oauth_callback_params_reason(request, "github", code, state),
+        )
         raise HTTPException(status_code=400, detail="Missing code or state")
 
     # Verify and consume state

--- a/api/tests/test_github_oauth.py
+++ b/api/tests/test_github_oauth.py
@@ -338,6 +338,27 @@ class TestGitHubOAuthCallback:
         )
 
     @pytest.mark.asyncio
+    async def test_callback_missing_state_logs_missing_field(self, client):
+        """Missing state must be logged with explicit missing field and request-id."""
+        with (
+            patch("app.auth.rate_limit.limiter._check_request_limit", return_value=None),
+            patch("app.auth.router.AuditLogger.log_login", new=AsyncMock()) as mock_log_login,
+        ):
+            response = await client.get(
+                "/api/v1/auth/github/callback?code=test-code",
+                headers={"X-Request-Id": "req-test-missing-state"},
+            )
+
+        assert response.status_code == 400
+        assert response.json() == {"detail": "Missing code or state"}
+        assert mock_log_login.await_count == 1
+        assert (
+            mock_log_login.await_args.args[6]
+            == "OAuth callback missing params [provider=github] [missing=state] "
+            "[request-id=req-test-missing-state]"
+        )
+
+    @pytest.mark.asyncio
     async def test_callback_unknown_error_code_records_metric(self, client):
         """Unknown OAuth error code should increment dedicated classification metric."""
         with (


### PR DESCRIPTION
## Summary
- GitHub OAuth callback で `code/state` 欠損時に監査ログを出す処理を追加
- 監査ログに provider・missing フィールド・request-id を含めて原因切り分けを容易化
- 欠損 `state` 受信時のログ内容を検証する API テストを追加

## Test
- `cd api && UV_CACHE_DIR=/tmp/uv-cache UV_PYTHON_INSTALL_DIR=/tmp/uv-python UV_TOOL_DIR=/tmp/uv-tools uv run --with-requirements requirements.txt pytest -q tests/test_github_oauth.py -k 'mismatched_state_logs_request_id or missing_state_logs_missing_field'`

## Impact
- OAuth導入容易化: callback失敗原因の識別が容易になり初期導入時の切り分け時間を短縮
- セルフホスト運用性: request-id と欠損項目を手がかりにログ相関がしやすくなる
- OSS運用: 既存の `Missing code or state` 契約を維持しつつ観測性のみ改善
