### PR TITLE
docs: webhook署名検証失敗時の監査ログ項目を明文化

### DIFF
--- a/docs/api/webhooks.md
+++ b/docs/api/webhooks.md
@@ -170,3 +170,5 @@ POST /api/v1/admin/webhooks/reload
 4. 改善しない場合は旧鍵へ一時ロールバックし、`reload` 後に成功可否を確認して鍵不一致か実装差異かを判定する
 
 詳細なログ確認コマンドと復旧パターンは [トラブルシューティングの「署名検証に失敗する」](../help/troubleshooting.md#署名検証に失敗する) を参照してください。
+調査時に最低限確認する監査ログ項目（`event_type`, `failure_reason`, `webhook_id`, `x_webhook_event`, `request_id`）は、
+[Webhook設定ガイド: 署名検証失敗時の監査ログ項目](../guides/webhooks.md#署名検証失敗時の監査ログ項目) を参照してください。

--- a/docs/help/troubleshooting.md
+++ b/docs/help/troubleshooting.md
@@ -642,7 +642,18 @@ FAQ での方針説明は [FAQ: Adminで未翻訳キーが出たときの表示�
 | 時刻ずれや再送遅延 | 特定環境のみ断続的に失敗 | サーバー時刻同期を確認し、遅延経路を短縮 |
 | 再送イベントの重複処理 | 同じ `event_id` で副作用が複数回実行される | 受信側の冪等キーを `event_id`（必要に応じて `endpoint_id` 併用）へ統一し、`delivery id` / `attempt_count` は重複判定に使わない |
 
+**監査ログで最低限確認する項目:**
+
+| 項目 | 期待値/例 | 確認ポイント |
+| --- | --- | --- |
+| `event_type` | `webhook.signature_verification_failed` | 署名検証失敗イベントとして記録されているか |
+| `failure_reason` | `hmac_mismatch` など | 失敗分類が固定値で記録されているか |
+| `webhook_id` | `my-service` | どの送信先で失敗したか特定できるか |
+| `x_webhook_event` | `user.login` | どの通知イベントで失敗したか追跡できるか |
+| `request_id` | `req-...` | APIログと相互参照できるか |
+
 署名鍵ローテーション時の手順は [Webhook API の `reload` 説明](../api/webhooks.md#署名鍵ローテーション時の利用) を参照。
+監査ログ項目の完全版は [Webhook設定ガイド: 署名検証失敗時の監査ログ項目](../guides/webhooks.md#署名検証失敗時の監査ログ項目) を参照。
 
 ---
 


### PR DESCRIPTION
## 概要\n- troubleshooting の署名検証失敗手順に、最低限確認すべき監査ログ項目を追加\n- Webhook API ドキュメントから監査ログ項目セクションへの参照導線を追加\n\n## 検証\n-  は未導入のため実行不可（ /  共に未解決）\n\nCloses #190