### PR TITLE
docs: 管理者トークン失効時の再認証導線を help に追加

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -289,7 +289,7 @@ curl -sS -o /dev/null -w '%{http_code}\n' \
 補足:
 - 認証API詳細は `docs/api/auth.md` を参照してください。
 - セッションAPI一覧は `README.md` の `Sessions` セクションと同一です。
-- 管理API向けの同等手順は `docs/help/troubleshooting.md` の「管理者トークン失効で管理APIが `401 Unauthorized` になる」を参照してください。
+- 管理API向けの同等手順は [`docs/help/troubleshooting.md`](help/troubleshooting.md#admin-token-reauth) を参照してください。
 
 ### OAuth callback失敗時の確認順
 

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -28,6 +28,17 @@ MIT Licenseです。商用利用も可能です。
 リフレッシュトークンを使用するたびに、新しいリフレッシュトークンが発行され、
 古いトークンは無効化されます。これにより、トークン漏洩時のリスクを軽減します。
 
+### 管理者トークンが失効して管理APIで 401 が出たときの再認証手順は？
+
+次の順で復旧してください。
+
+1. 現在の `access_token` で管理API（例: `GET /api/v1/admin/webhooks/endpoints`）を呼び、`401` を確認する
+2. `refresh_token` が有効なら `POST /api/v1/auth/refresh` で再発行する
+3. `refresh_token` も失効している場合は OAuth ログインを最初からやり直す
+4. 新しい `access_token` で管理APIを再実行し、`200` を確認する
+
+コマンド付きの詳細手順は [トラブルシューティング: 管理者トークン失効で管理APIが `401 Unauthorized` になる](./troubleshooting.md#admin-token-reauth) を参照してください。
+
 ### PKCEとは？
 
 Proof Key for Code Exchangeの略で、OAuth 2.0の認可コードフローをより安全にする拡張機能です。

--- a/docs/help/troubleshooting.md
+++ b/docs/help/troubleshooting.md
@@ -516,6 +516,8 @@ curl -sS -X POST -H "Authorization: Bearer ${TOKEN}" \
 - 返却件数は指定 `limit` を超えない
 - `401` が混在する場合はトークン失効を疑い、再ログイン後に再検証する
 
+<a id="admin-token-reauth"></a>
+
 ### 管理者トークン失効で管理APIが `401 Unauthorized` になる
 
 **症状:** 管理画面操作や `GET /api/v1/admin/*` 呼び出しが `401 Unauthorized` を返す


### PR DESCRIPTION
## 概要
- FAQ に「管理者トークン失効時の再認証手順」を追加
- troubleshooting に固定アンカー `#admin-token-reauth` を追加
- getting-started からの参照を固定アンカーに更新

## テスト
- `rg -n "admin-token-reauth|管理者トークンが失効して管理APIで 401|troubleshooting.md#admin-token-reauth" docs/help/faq.md docs/help/troubleshooting.md docs/getting-started.md`
- `mkdocs build --strict`（実行不可: ローカル環境に mkdocs 未導入）

## 公開時の影響
- OAuth 導入時の 401 復旧導線が help から辿りやすくなります
- セルフホスト運用時の管理API復旧手順を FAQ と troubleshooting で一貫化できます
- OSS 利用者向けに、再認証の最短手順と詳細手順の導線が明確になります

Closes #192
