### PR TITLE
test: FRONTEND_URL未設定時の既定挙動を固定

### DIFF
--- a/api/tests/test_config.py
+++ b/api/tests/test_config.py
@@ -129,6 +129,23 @@ def test_config_import_fails_fast_when_cors_origins_contains_empty_element():
     assert "CORS_ORIGINS contains empty element" in (result.stderr + result.stdout)
 
 
+def test_frontend_url_defaults_when_env_is_unset():
+    env = os.environ.copy()
+    env.pop("FRONTEND_URL", None)
+
+    result = subprocess.run(
+        [sys.executable, "-c", "from app.config import Settings; print(Settings.FRONTEND_URL)"],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=str(Path(__file__).resolve().parents[1]),
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert result.stdout.strip() == "http://localhost:3000"
+
+
 def test_settings_raises_when_provider_client_id_exists_but_secret_is_empty(monkeypatch):
     monkeypatch.setattr(Settings, "GITHUB_CLIENT_ID", "github-client-id")
     monkeypatch.setattr(Settings, "GITHUB_CLIENT_SECRET", "")


### PR DESCRIPTION
## 概要
- `FRONTEND_URL` 未設定時の既定値 (`http://localhost:3000`) を固定するテストを追加
- `api/tests/test_config.py` に subprocess ベースの回帰テストを追加

## 変更ファイル
- `api/tests/test_config.py`

## テスト
- 実行不可: ローカル `python3` が 3.9.6 で、`app.config` の `str | None` 注釈を解釈できず import 時に失敗
- 実行不可: `docker compose run --rm api-ci ...` / `docker run python:3.11-slim ...` はイメージ取得フェーズでハングし、この実行枠で完了せず