### PR TITLE
chore(codex-orch): update distributed orch templates and skills

### DIFF
--- a/.codex/skills/ci-status-inspector/scripts/get-woodpecker-pipeline-status.sh
+++ b/.codex/skills/ci-status-inspector/scripts/get-woodpecker-pipeline-status.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+# shellcheck source=../../../scripts/secret_env.sh
+source "${ROOT_DIR}/scripts/secret_env.sh"
+orch_load_standard_secret_envs "${ROOT_DIR}"
+
 HOST="${WOODPECKER_HOST:-https://mashirou.stream}"
 REPO_ID="${WOODPECKER_REPO_ID:-}"
 REPO_FULL_NAME="${WOODPECKER_REPO:-}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,9 +1,10 @@
 # Codex Project Agent Notes (GitHub)
 
 - 日本語で簡潔に報告する
-- まず `artifacts/` を確認して前回結果を把握する
-- `scripts/orch.sh` を使う自動レーンでは必ず 1 run 1 issue を守る
+- `artifacts/` は必要なときだけ参照し、開始時に全体確認しない
+- まずは `artifacts/orch_result.json` を確認し、失敗調査時のみ `artifacts/runs/<work_category>/<system_category>/run_*.log` と `artifacts/test.log` を見る
+- `scripts/blackrain.sh` を使う自動レーンでは必ず 1 run 1 issue を守る
 - 手動レーン（Power User の直接対応）は一括処理可。ただし `codex:queue` 系ラベル遷移の整合は維持する
 - Project 併用 repo では、queue 着手前に linked Project の status / priority を確認する
 - 失敗時は issue コメントと `codex:blocked` を付与する
-- `codex:pr-opened` の Issue は merge 確認後の reconcile で close する
+- `codex:pr-opened` の Issue は merge を観測した run で close し、残件は reconcile で回収する


### PR DESCRIPTION
## Summary
- Neunzehn (f76ed15dcc348b3c6aca34efa4c015c871fe827f) の配布内容を bootstrap update で反映
- codex-orch 管理ファイルと配布 Skill を最新版に同期

## Applied Command
`bash scripts/bootstrap.sh update --target <repo> --scm github --runner auto --orch-repo mashirou1234/Neunzehn --orch-ref f76ed15dcc348b3c6aca34efa4c015c871fe827f --skills auto --force`
