### PR TITLE
docs: clarify github organization restriction behavior

### DIFF
--- a/docs/api/auth.md
+++ b/docs/api/auth.md
@@ -6,7 +6,7 @@
 |---------|------|------|
 | GET | `/api/v1/auth/google` | Google OAuth開始 |
 | GET | `/api/v1/auth/google/callback` | Googleコールバック |
-| GET | `/api/v1/auth/github` | GitHub OAuth開始（organization所属の制限判定は未実装） |
+| GET | `/api/v1/auth/github` | GitHub OAuth開始（organization所属チェックなし。非所属を理由に拒否しない） |
 | GET | `/api/v1/auth/github/callback` | GitHubコールバック |
 | GET | `/api/v1/auth/discord` | Discord OAuth開始 |
 | GET | `/api/v1/auth/discord/callback` | Discordコールバック |

--- a/docs/guides/oauth/github.md
+++ b/docs/guides/oauth/github.md
@@ -51,12 +51,22 @@ curl -sSI \
 
 ## organization制限時の挙動
 
-- 現在のGitHub OAuth実装は`read:user user:email`のみを要求し、organization所属チェックは行いません。
-- そのため、organization制限を有効化したい場合は、アプリ側で追加実装が必要です。
-- 追加実装の例:
-  - 認可スコープに`read:org`を追加
-  - コールバック後にGitHub APIで所属organizationを検証
-  - 未所属ユーザーはログイン完了前に拒否
+現在の YESOD Auth は GitHub OAuth で organization 制限を実施しません。  
+つまり、`/api/v1/auth/github` と `/api/v1/auth/github/callback` は organization 所属を判定せず、認可成功後は通常どおりログイン完了します。
+
+| 観点 | 現在の挙動 |
+| --- | --- |
+| 認可スコープ | `read:user user:email` のみ要求 |
+| organization 所属チェック | 実施しない |
+| 非所属ユーザーの扱い | organization を理由に拒否しない（通常のログイン結果になる） |
+
+organization メンバー限定にしたい場合は、アプリ側で次を追加してください。
+
+1. 認可スコープに `read:org` を追加
+2. callback 後に GitHub API で所属 organization を検証
+3. 未所属ユーザーはログイン完了前に `403` などで拒否
+
+セルフホスト運用では、導入前に「許可 organization 名」「未所属時のエラー応答」「監査ログ項目」を先に決めておくと、運用時の問い合わせを減らせます。
 
 共通の callback 確認手順は [OAuth設定の共通チェックリスト](index.md#oauth-callback-checklist) を先に参照してください。
 

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -100,8 +100,16 @@ YESOD AuthはGoogle OAuthでPKCEを自動的に使用します。
 
 ### GitHubログインをorganizationメンバーだけに制限できる？
 
-現状のYESOD AuthはGitHub OAuthでorganization所属チェックを行いません。
-organization制限が必要な場合は、`read:org`スコープとコールバック後の所属検証を追加実装してください。
+現状の YESOD Auth は GitHub OAuth で organization 所属チェックを行いません。  
+そのため、organization 非所属ユーザーでも GitHub 側の認可が成功すれば通常どおりログインできます。
+
+organization 制限が必要な場合は、次を追加実装してください。
+
+1. `read:org` スコープを要求する
+2. callback 後に organization 所属を検証する
+3. 未所属ユーザーを `403` などで拒否する
+
+実装前の仕様確認は [GitHub OAuth ガイド: organization制限時の挙動](../guides/oauth/github.md#organization制限時の挙動) を参照してください。
 
 ### 認証失敗時の一次分類は？
 


### PR DESCRIPTION
## Summary\n- clarify current behavior when using GitHub OAuth without organization membership checks\n- document that non-members are not rejected by current implementation\n- sync guidance in OAuth guide, API docs, and FAQ for self-hosted operators\n\n## Test\n- rg "organization|org" docs/guides/oauth/github.md\n- cd api && uv run pytest -q tests/test_github_oauth.py\n\nRelates: #200