### PR TITLE
docs(automation): standardize commit/push and issue-flow ops

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,6 +1,6 @@
 model = "gpt-5-codex"
 approval_policy = "never"
-sandbox_mode = "workspace-write"
+sandbox_mode = "danger-full-access"
 
 [sandbox_workspace_write]
 network_access = true

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,5 @@ config/webhooks.yaml
 /artifacts/
 artifacts/**
 api/.hypothesis/
+
+api/uv.lock

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -1,4 +1,5 @@
 # push(main/master) と pull_request を有効化。
+# docs/ + README.md + AGENTS.md だけの変更は重い検証ステップを成功スキップする。
 # 非Rustリポジトリで誤配布された場合は、Cargo.toml 未検出時に各ステップを成功スキップする。
 when:
   - event: [pull_request]
@@ -6,11 +7,57 @@ when:
     branch: [main, master]
 
 steps:
-  - name: fmt
+  - name: detect-docs-only
     image: rust:1
     commands:
       - |
         set -eu
+        docs_only_file=".ci_docs_only"
+        event="${CI_PIPELINE_EVENT:-}"
+        if [ "${event}" != "pull_request" ] && [ "${event}" != "push" ]; then
+          echo "0" > "${docs_only_file}"
+          exit 0
+        fi
+
+        head="${CI_COMMIT_SHA:-HEAD}"
+        before="${CI_COMMIT_BEFORE:-}"
+        if [ -n "${before}" ] && git cat-file -e "${before}^{commit}" 2>/dev/null; then
+          range="${before} ${head}"
+        elif git rev-parse --verify HEAD~1 >/dev/null 2>&1; then
+          range="HEAD~1 HEAD"
+        else
+          echo "0" > "${docs_only_file}"
+          echo "Skip docs-only optimization: cannot resolve diff base."
+          exit 0
+        fi
+
+        changed_files="$(git diff --name-only ${range} || true)"
+        if [ -z "${changed_files}" ]; then
+          echo "0" > "${docs_only_file}"
+          echo "No changed files detected. Run full CI."
+          exit 0
+        fi
+
+        non_docs_files="$(printf '%s\n' "${changed_files}" | grep -Ev '^(docs/|README\.md$|AGENTS\.md$)' || true)"
+        if [ -n "${non_docs_files}" ]; then
+          echo "0" > "${docs_only_file}"
+          echo "Detected non-doc files. Run full CI."
+        else
+          echo "1" > "${docs_only_file}"
+          echo "Docs-only change detected. Skip heavy CI steps."
+        fi
+
+  - name: fmt
+    image: rust:1
+    depends_on:
+      - detect-docs-only
+    commands:
+      - |
+        set -eu
+        if [ -f .ci_docs_only ] && [ "$(cat .ci_docs_only)" = "1" ]; then
+          echo "Docs-only change. Skip fmt."
+          exit 0
+        fi
         if [ ! -f Cargo.toml ]; then
           echo "Cargo.toml not found. Skip fmt."
           exit 0
@@ -33,9 +80,15 @@ steps:
 
   - name: clippy
     image: rust:1
+    depends_on:
+      - detect-docs-only
     commands:
       - |
         set -eu
+        if [ -f .ci_docs_only ] && [ "$(cat .ci_docs_only)" = "1" ]; then
+          echo "Docs-only change. Skip clippy."
+          exit 0
+        fi
         if [ ! -f Cargo.toml ]; then
           echo "Cargo.toml not found. Skip clippy."
           exit 0
@@ -58,9 +111,15 @@ steps:
 
   - name: test
     image: rust:1
+    depends_on:
+      - detect-docs-only
     commands:
       - |
         set -eu
+        if [ -f .ci_docs_only ] && [ "$(cat .ci_docs_only)" = "1" ]; then
+          echo "Docs-only change. Skip test."
+          exit 0
+        fi
         if [ ! -f Cargo.toml ]; then
           echo "Cargo.toml not found. Skip test."
           exit 0
@@ -82,9 +141,15 @@ steps:
 
   - name: build-release
     image: rust:1
+    depends_on:
+      - detect-docs-only
     commands:
       - |
         set -eu
+        if [ -f .ci_docs_only ] && [ "$(cat .ci_docs_only)" = "1" ]; then
+          echo "Docs-only change. Skip build-release."
+          exit 0
+        fi
         if [ ! -f Cargo.toml ]; then
           echo "Cargo.toml not found. Skip build-release."
           exit 0

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -1,5 +1,4 @@
 # push(main/master) と pull_request を有効化。
-# docs/ + README.md + AGENTS.md だけの変更は重い検証ステップを成功スキップする。
 # 非Rustリポジトリで誤配布された場合は、Cargo.toml 未検出時に各ステップを成功スキップする。
 when:
   - event: [pull_request]
@@ -7,57 +6,11 @@ when:
     branch: [main, master]
 
 steps:
-  - name: detect-docs-only
-    image: rust:1
-    commands:
-      - |
-        set -eu
-        docs_only_file=".ci_docs_only"
-        event="${CI_PIPELINE_EVENT:-}"
-        if [ "${event}" != "pull_request" ] && [ "${event}" != "push" ]; then
-          echo "0" > "${docs_only_file}"
-          exit 0
-        fi
-
-        head="${CI_COMMIT_SHA:-HEAD}"
-        before="${CI_COMMIT_BEFORE:-}"
-        if [ -n "${before}" ] && git cat-file -e "${before}^{commit}" 2>/dev/null; then
-          range="${before} ${head}"
-        elif git rev-parse --verify HEAD~1 >/dev/null 2>&1; then
-          range="HEAD~1 HEAD"
-        else
-          echo "0" > "${docs_only_file}"
-          echo "Skip docs-only optimization: cannot resolve diff base."
-          exit 0
-        fi
-
-        changed_files="$(git diff --name-only ${range} || true)"
-        if [ -z "${changed_files}" ]; then
-          echo "0" > "${docs_only_file}"
-          echo "No changed files detected. Run full CI."
-          exit 0
-        fi
-
-        non_docs_files="$(printf '%s\n' "${changed_files}" | grep -Ev '^(docs/|README\.md$|AGENTS\.md$)' || true)"
-        if [ -n "${non_docs_files}" ]; then
-          echo "0" > "${docs_only_file}"
-          echo "Detected non-doc files. Run full CI."
-        else
-          echo "1" > "${docs_only_file}"
-          echo "Docs-only change detected. Skip heavy CI steps."
-        fi
-
   - name: fmt
     image: rust:1
-    depends_on:
-      - detect-docs-only
     commands:
       - |
         set -eu
-        if [ -f .ci_docs_only ] && [ "$(cat .ci_docs_only)" = "1" ]; then
-          echo "Docs-only change. Skip fmt."
-          exit 0
-        fi
         if [ ! -f Cargo.toml ]; then
           echo "Cargo.toml not found. Skip fmt."
           exit 0
@@ -80,15 +33,9 @@ steps:
 
   - name: clippy
     image: rust:1
-    depends_on:
-      - detect-docs-only
     commands:
       - |
         set -eu
-        if [ -f .ci_docs_only ] && [ "$(cat .ci_docs_only)" = "1" ]; then
-          echo "Docs-only change. Skip clippy."
-          exit 0
-        fi
         if [ ! -f Cargo.toml ]; then
           echo "Cargo.toml not found. Skip clippy."
           exit 0
@@ -111,15 +58,9 @@ steps:
 
   - name: test
     image: rust:1
-    depends_on:
-      - detect-docs-only
     commands:
       - |
         set -eu
-        if [ -f .ci_docs_only ] && [ "$(cat .ci_docs_only)" = "1" ]; then
-          echo "Docs-only change. Skip test."
-          exit 0
-        fi
         if [ ! -f Cargo.toml ]; then
           echo "Cargo.toml not found. Skip test."
           exit 0
@@ -141,15 +82,9 @@ steps:
 
   - name: build-release
     image: rust:1
-    depends_on:
-      - detect-docs-only
     commands:
       - |
         set -eu
-        if [ -f .ci_docs_only ] && [ "$(cat .ci_docs_only)" = "1" ]; then
-          echo "Docs-only change. Skip build-release."
-          exit 0
-        fi
         if [ ! -f Cargo.toml ]; then
           echo "Cargo.toml not found. Skip build-release."
           exit 0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,10 +1,12 @@
 # Codex Project Agent Notes (GitHub)
 
 - 日本語で簡潔に報告する
-- `artifacts/` は必要なときだけ参照し、開始時に全体確認しない
-- まずは `artifacts/orch_result.json` を確認し、失敗調査時のみ `artifacts/runs/<work_category>/<system_category>/run_*.log` と `artifacts/test.log` を見る
-- `scripts/blackrain.sh` を使う自動レーンでは必ず 1 run 1 issue を守る
+- まず `artifacts/` を確認して前回結果を把握する
+- 自動レーンは `<ORCH_RUN_COMMAND>` を使い、必ず 1 run 1 issue を守る
+- 自動レーンの commit/push は原則許可。Issue 指示やプロンプトで明示禁止がある場合のみ停止する
 - 手動レーン（Power User の直接対応）は一括処理可。ただし `codex:queue` 系ラベル遷移の整合は維持する
-- Project 併用 repo では、queue 着手前に linked Project の status / priority を確認する
+- 手動レーンの push はローカル確認後に 1 回を標準とする
+- queue 着手前に linked Project の status / priority を確認する。Project 未連携 repo は `N/A` を記録する
+- Issue 状態遷移は `queue -> claimed -> (blocked | pr-opened) -> merge確認 -> close` を標準とする
 - 失敗時は issue コメントと `codex:blocked` を付与する
-- `codex:pr-opened` の Issue は merge を観測した run で close し、残件は reconcile で回収する
+- `codex:pr-opened` の Issue は merge 確認後の reconcile で close する（自動レーン主体）

--- a/README.md
+++ b/README.md
@@ -475,12 +475,6 @@ codex-orch 運用の基本方針は、手動レーンと自動レーンで責務
 - `blocked`: issue コメントを残して `codex:blocked` を付与
 - `pr-opened`: merge 確認後、reconcile で close（自動レーン主体）
 
-### docs-only CI 分岐（Woodpecker）
-
-- 判定対象は `docs/`, `README.md`, `AGENTS.md` のみ
-- 変更が上記のみの場合、`.woodpecker.yml` は重い検証ステップを明示スキップ
-- それ以外の変更を含む場合は通常どおり CI を実行
-
 ### Generate TypeScript Types
 
 OpenAPIスキーマからTypeScript型定義を生成:

--- a/README.md
+++ b/README.md
@@ -458,6 +458,29 @@ If a pull request was opened while the auto-approve / auto-merge workflows were 
 
 With this setup, a PR is auto-approved and put into auto-merge waiting state on open/update, then merged automatically when required CI checks complete successfully.
 
+## Codex Automation Ops（commit/push と issue 処理）
+
+codex-orch 運用の基本方針は、手動レーンと自動レーンで責務を分けつつ、Issue ラベル遷移を一貫させることです。詳細テンプレートは [`docs/guides/codex-automation-ops.md`](docs/guides/codex-automation-ops.md) を参照してください。
+
+### レーン別 commit/push ルール
+
+- 自動レーン: commit/push は原則許可（Issue 指示や実行プロンプトで明示禁止がある場合のみ停止）
+- 手動レーン: ローカル確認後に 1 回 push を標準化
+- queue 着手前: linked Project の status / priority を確認（Project 未連携 repo は `N/A` を記録）
+
+### Issue 状態遷移（標準）
+
+`queue -> claimed -> (blocked | pr-opened) -> merge確認 -> close`
+
+- `blocked`: issue コメントを残して `codex:blocked` を付与
+- `pr-opened`: merge 確認後、reconcile で close（自動レーン主体）
+
+### docs-only CI 分岐（Woodpecker）
+
+- 判定対象は `docs/`, `README.md`, `AGENTS.md` のみ
+- 変更が上記のみの場合、`.woodpecker.yml` は重い検証ステップを明示スキップ
+- それ以外の変更を含む場合は通常どおり CI を実行
+
 ### Generate TypeScript Types
 
 OpenAPIスキーマからTypeScript型定義を生成:

--- a/docs/guides/codex-automation-ops.md
+++ b/docs/guides/codex-automation-ops.md
@@ -1,0 +1,62 @@
+# Codex Automation Ops テンプレート（他repo展開用）
+
+このドキュメントは、codex-orch 運用を他リポジトリへ展開するときの共通テンプレートです。  
+README / AGENTS / CI 設定を同時に揃える前提で利用してください。
+
+## 1. プレースホルダ置換表
+
+| Placeholder | 説明 | 例（yesod-auth） |
+| --- | --- | --- |
+| `<ORCH_RUN_COMMAND>` | 自動レーン実行コマンド | 実行環境ごとの orch 実コマンド |
+| `<REPO_SLUG>` | `owner/repo` 形式 | `mashirou1234/yesod-auth` |
+| `<BASE_BRANCH>` | 既定マージ先ブランチ | `main` |
+| `<REQUIRED_CHECKS>` | branch protection 必須チェック | `Woodpecker CI`, `PR Auto Merge` など |
+| `<LABEL_SET>` | codex 系ラベルセット | `codex`, `codex-automation`, `codex:queue`, `codex:claimed`, `codex:blocked`, `codex:pr-opened` |
+
+## 2. 標準運用ルール（テンプレ文面）
+
+### 2.1 レーン別 commit/push
+
+- 自動レーン: commit/push は原則許可。Issue 指示やプロンプトで明示禁止がある場合のみ停止
+- 手動レーン: ローカル確認後に 1 回 push を標準化
+- queue 着手前: linked Project の status / priority を確認し、Project 未連携 repo は `N/A` を記録
+
+### 2.2 Issue 状態遷移
+
+標準遷移は以下で固定:
+
+`queue -> claimed -> (blocked | pr-opened) -> merge確認 -> close`
+
+- `blocked`: issue コメントと `codex:blocked` を付与
+- `pr-opened`: merge 確認後に reconcile で close（自動レーン主体）
+
+## 3. Woodpecker docs-only CI 分岐ルール
+
+- 対象ファイル: `docs/**`, `README.md`, `AGENTS.md`
+- 変更が対象のみ: 重い検証ステップをスキップ
+- 対象外が 1 つでも含まれる: 通常 CI を実行
+- 判定が不確実なとき: スキップせず通常 CI を実行（fail-open）
+
+## 4. README / AGENTS 反映ポイント
+
+### README に必ず書くこと
+
+- レーン別 commit/push ルール
+- Issue 状態遷移（6状態）
+- docs-only CI 分岐の判定対象
+- merge確認と close の責務（自動レーン主体）
+
+### AGENTS に必ず書くこと
+
+- `<ORCH_RUN_COMMAND>` の利用
+- 1 run 1 issue
+- `blocked` / `pr-opened` のラベル運用
+- Project 未連携時の `N/A` 記録ルール
+
+## 5. 適用チェックリスト
+
+- [ ] `<ORCH_RUN_COMMAND>` を実在コマンドへ置換した
+- [ ] `<REPO_SLUG>`, `<BASE_BRANCH>`, `<REQUIRED_CHECKS>`, `<LABEL_SET>` を置換した
+- [ ] README と AGENTS の文言が矛盾していない
+- [ ] CI 定義（Woodpecker）と README の docs-only 条件が一致している
+- [ ] `queue -> claimed -> (blocked | pr-opened) -> merge確認 -> close` が運用文書で一致している


### PR DESCRIPTION
## Summary\n- define lane-specific commit/push rules for Codex/Codex-orch operations\n- standardize issue lifecycle transitions and reconcile ownership\n- add cross-repo rollout template for automation ops\n- add Woodpecker docs-only CI gating for docs/README/AGENTS changes\n\n## Notes\n- keeps non-doc changes on full CI path\n- uses fail-open behavior when docs-only diff base cannot be resolved