### PR TITLE
Fix #201 OAuth provider disabled response contract

### DIFF
--- a/api/tests/test_auth_provider_response_codes.py
+++ b/api/tests/test_auth_provider_response_codes.py
@@ -1,0 +1,33 @@
+"""OAuth provider endpoint response code contract tests."""
+
+import importlib
+
+import pytest
+from httpx import AsyncClient
+
+auth_router_module = importlib.import_module("app.auth.router")
+
+
+@pytest.mark.asyncio
+async def test_oauth_known_provider_disabled_returns_503(client: AsyncClient, monkeypatch):
+    """Known provider with missing credentials should return 503."""
+    monkeypatch.setattr(auth_router_module.settings, "GOOGLE_CLIENT_ID", "")
+    monkeypatch.setattr(auth_router_module.settings, "GOOGLE_CLIENT_SECRET", "")
+
+    response = await client.get("/api/v1/auth/google", follow_redirects=False)
+
+    assert response.status_code == 503
+    assert response.json() == {
+        "detail": (
+            "OAuth provider 'google' is disabled. "
+            "Configure GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET."
+        )
+    }
+
+
+@pytest.mark.asyncio
+async def test_oauth_unsupported_provider_path_returns_404(client: AsyncClient):
+    """Unsupported provider path should follow FastAPI route-level 404."""
+    response = await client.get("/api/v1/auth/unknown", follow_redirects=False)
+
+    assert response.status_code == 404

--- a/docs/api/auth.md
+++ b/docs/api/auth.md
@@ -83,9 +83,14 @@ GET /api/v1/auth/google
 }
 ```
 
-### 未知 provider 入力時
+### 未対応 provider path の場合
 
-- 条件: サポート対象外の provider 名が入力された場合
+- 条件: `GET /api/v1/auth/unknown` のように未対応 path を呼び出した場合
+- 応答: `404 Not Found`（ルーティング未定義）
+
+### 未知 provider 名のバリデーション時
+
+- 条件: サポート対象外の provider 名が内部バリデーションへ渡された場合
 - 応答: `400 Bad Request`
 - 例:
 


### PR DESCRIPTION
## Summary\n- add HTTP-level contract tests for OAuth auth-start endpoints\n- specify disabled known provider as 503 and unsupported provider path as 404 in docs\n\n## Test\n- uv run pytest -q tests/test_auth_provider_response_codes.py tests/test_auth_oauth_provider_disabled.py