### PR TITLE
docs: FAQに認証失敗の一次分類フローと初動アクションを追加

### DIFF
--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -105,14 +105,18 @@ organization制限が必要な場合は、`read:org`スコープとコールバ�
 
 ### 認証失敗時の一次分類は？
 
-まずは HTTP ステータスと代表メッセージで次の4分類に分けると切り分けが速くなります。
+まずは次の順で確認すると、OAuth 導入初期やセルフホスト運用でも誤判定を減らせます。
 
-| 一次分類 | 典型シグナル | 主な原因 | 最初に見る場所 |
-| --- | --- | --- | --- |
-| 入力不正（422） | `Field required` / `Input should be a valid string` | `refresh_token` の欠落・型不正 | [`認証API: refresh失敗時エラー分類`](../api/auth.md#refresh失敗時エラー分類) |
-| 認証失敗（401） | `Not authenticated` / `Could not validate credentials` | access/refresh token の期限切れ・失効・改ざん | [`トラブルシューティング: 認証エラー`](./troubleshooting.md#認証エラー) |
-| state不整合（400） | `Invalid or expired state` | callback 二重実行、Valkey不安定、環境不一致 | [`トラブルシューティング: state mismatch 診断フロー`](./troubleshooting.md#state-mismatch-flow) |
-| レート制限（429） | `Rate limit exceeded` / `Too Many Requests` | 短時間の連続アクセス、制限値過小 | [`トラブルシューティング: 429 Too Many Requests`](./troubleshooting.md#auth-rate-limit-429) |
+1. 失敗した API の HTTP ステータスを確定する
+2. API ログから代表メッセージ（`detail` / エラーコード）を拾う
+3. 下表で一次分類し、対応するドキュメントへ遷移する
+
+| 一次分類 | 典型シグナル | 主な原因 | 初動アクション | 最初に見る場所 |
+| --- | --- | --- | --- | --- |
+| 入力不正（422） | `Field required` / `Input should be a valid string` | `refresh_token` の欠落・型不正 | リクエスト JSON と型を修正して再送 | [`認証API: refresh失敗時エラー分類`](../api/auth.md#refresh失敗時エラー分類) |
+| 認証失敗（401） | `Not authenticated` / `Could not validate credentials` | access/refresh token の期限切れ・失効・改ざん | `/api/v1/auth/refresh` を1回試し、失敗なら再ログイン | [`トラブルシューティング: 認証エラー`](./troubleshooting.md#認証エラー) |
+| state不整合（400） | `Invalid or expired state` | callback 二重実行、Valkey不安定、環境不一致 | 同一 host/scheme で認証開始からやり直し、Valkey ログ確認 | [`トラブルシューティング: state mismatch 診断フロー`](./troubleshooting.md#state-mismatch-flow) |
+| レート制限（429） | `Rate limit exceeded` / `Too Many Requests` | 短時間の連続アクセス、制限値過小 | 連続試行を止め、制限値とアクセス集中を確認 | [`トラブルシューティング: 429 Too Many Requests`](./troubleshooting.md#auth-rate-limit-429) |
 
 運用メモとして、分類時は「発生時刻」「対象エンドポイント」「利用プロバイダー（mock/google/github等）」をセットで記録すると再現調査が容易です。
 


### PR DESCRIPTION
## 概要\n- FAQ の『認証失敗時の一次分類』を、判定順序（HTTPステータス→代表メッセージ→一次分類）つきに更新\n- 一次分類テーブルに『初動アクション』列を追加し、導入直後/セルフホスト運用での最初の対応を明確化\n- 既存の API/トラブルシューティング参照リンクは維持し、OSS 利用者が追跡しやすい導線を強化\n\n## テスト\n- # FAQ
YESOD Authは、OAuth 2.0認証を簡単に実装するためのオープンソース認証基盤です。
## 認証
### 管理者トークンが失効して管理APIで 401 が出たときの再認証手順は？
2. 未設定 provider の認証導線は呼ばず、`/health` と `/docs` の到達確認を先に完了する
導線全体は [インストール](../installation.md#provider-未設定時の最短スキップ手順) と [トラブルシューティング](./troubleshooting.md#provider-未設定のまま認証導線を実行した) で同期しています。
シークレットの配置方針は [インストールガイド: OAuth認証情報](../installation.md#oauth認証情報)、
受け入れ時は FAQ / installation / troubleshooting の3点で、コマンドと手順順が一致していることを確認してください。
認証レート制限の切り分け手順を [トラブルシューティング: 429 Too Many Requests](./troubleshooting.md#auth-rate-limit-429) にまとめています。  
### 認証失敗時の一次分類は？
| 入力不正（422） | `Field required` / `Input should be a valid string` | `refresh_token` の欠落・型不正 | リクエスト JSON と型を修正して再送 | [`認証API: refresh失敗時エラー分類`](../api/auth.md#refresh失敗時エラー分類) |
| 認証失敗（401） | `Not authenticated` / `Could not validate credentials` | access/refresh token の期限切れ・失効・改ざん | `/api/v1/auth/refresh` を1回試し、失敗なら再ログイン | [`トラブルシューティング: 認証エラー`](./troubleshooting.md#認証エラー) |
| state不整合（400） | `Invalid or expired state` | callback 二重実行、Valkey不安定、環境不一致 | 同一 host/scheme で認証開始からやり直し、Valkey ログ確認 | [`トラブルシューティング: state mismatch 診断フロー`](./troubleshooting.md#state-mismatch-flow) |
開発・テスト時に、実際のOAuthプロバイダーなしで認証フローをテストできる機能です。
- [トラブルシューティング: provider 未設定のまま認証導線を実行した](./troubleshooting.md#provider-未設定のまま認証導線を実行した)
- インストール: [OAuth認証情報](../installation.md#oauth認証情報)
受け入れ時は、FAQ / installation / troubleshooting の3点同期（手順・用語・リンク先）が保たれていることを確認してください。\n- docs/api/auth.md:62:`redirect_uri_mismatch` を最短で確認する手順は [クイックスタート](../getting-started.md#25-redirect_uri_mismatch-の最短確認5ステップ) を参照してください。失敗時の切り分けは [トラブルシューティング](../help/troubleshooting.md#認証エラー) へ接続してください。
docs/api/auth.md:155:詳細な切り分け手順は [`トラブルシューティング > 認証エラー`](../help/troubleshooting.md#認証エラー) を参照してください。
docs/api/auth.md:273:### `state mismatch` の最小診断例
docs/api/auth.md:291:詳細フローは [`トラブルシューティング: state mismatch 診断フロー`](../help/troubleshooting.md#state-mismatch-flow) を参照してください。
docs/help/faq.md:98:認証レート制限の切り分け手順を [トラブルシューティング: 429 Too Many Requests](./troubleshooting.md#auth-rate-limit-429) にまとめています。  
docs/help/faq.md:106:### 認証失敗時の一次分類は？
docs/help/faq.md:117:| 認証失敗（401） | `Not authenticated` / `Could not validate credentials` | access/refresh token の期限切れ・失効・改ざん | `/api/v1/auth/refresh` を1回試し、失敗なら再ログイン | [`トラブルシューティング: 認証エラー`](./troubleshooting.md#認証エラー) |
docs/help/faq.md:118:| state不整合（400） | `Invalid or expired state` | callback 二重実行、Valkey不安定、環境不一致 | 同一 host/scheme で認証開始からやり直し、Valkey ログ確認 | [`トラブルシューティング: state mismatch 診断フロー`](./troubleshooting.md#state-mismatch-flow) |
docs/help/faq.md:119:| レート制限（429） | `Rate limit exceeded` / `Too Many Requests` | 短時間の連続アクセス、制限値過小 | 連続試行を止め、制限値とアクセス集中を確認 | [`トラブルシューティング: 429 Too Many Requests`](./troubleshooting.md#auth-rate-limit-429) |
docs/help/faq.md:156:切り分け手順は [トラブルシューティング: state mismatch 診断フロー](./troubleshooting.md#state-mismatch-flow) と [トラブルシューティング: 401 Unauthorized / invalid_client](./troubleshooting.md#401-unauthorized--invalid_client) を参照してください。  
docs/help/troubleshooting.md:24:| `auth` | [state mismatch 診断フロー](#state-mismatch-flow) | `docker compose logs api --since=30m \| rg "Invalid state\|/auth/.*/callback"` |
docs/help/troubleshooting.md:115:## 認証エラー
docs/help/troubleshooting.md:130:#### `state mismatch` 診断フロー
docs/help/troubleshooting.md:440:### `429 Too Many Requests`（認証レート制限）\n\nCloses #210