### PR TITLE
docs: add valkey connectivity check command for auth troubleshooting

### DIFF
--- a/docs/help/troubleshooting.md
+++ b/docs/help/troubleshooting.md
@@ -124,6 +124,9 @@ sqlalchemy.exc.OperationalError: could not connect to server
 
 1. 認証フローを最初からやり直す
 2. Valkeyが正常に動作しているか確認
+   ```bash
+   docker compose exec valkey sh -lc 'valkey-cli ping || redis-cli ping'
+   ```
 
 <a id="state-mismatch-flow"></a>
 


### PR DESCRIPTION
## Summary\n- add explicit Valkey connectivity command under `Invalid or expired state` recovery steps\n- align quick recovery path for OAuth state/session failures\n\n## Testing\n- rg -n "Valkey|redis" docs/help/troubleshooting.md\n- docker compose --profile default config --services\n\n## Issue\n- closes #212