### PR TITLE
docs: clarify OAuth clock skew diagnosis threshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Base URL: `http://localhost:8000/api/v1`
 運用時の注意点（refresh token のローテーション/再ログイン方針）は [docs/installation.md](docs/installation.md#リフレッシュトークン運用時の注意) を参照してください。
 認証エラーコードの運用向け一覧は [`docs/api/auth.md`](docs/api/auth.md) を参照してください。
 `invalid_grant` が断続的に発生する場合は、[clock skew 診断手順](docs/help/troubleshooting.md#oauth-clock-skew) を参照してください。
+self-host では `timedatectl status` と `date -u` / `docker compose exec -T api date -u` で時刻差を確認し、`5秒以上` ずれる場合は先に時刻同期を修正してください。
 
 ### Users
 

--- a/docs/guides/oauth/index.md
+++ b/docs/guides/oauth/index.md
@@ -92,7 +92,7 @@ OAuthプロバイダーを「有効化できているか」を、次の順序で
 5. 起動後に導線で確認する
    `GET /api/v1/auth/{provider}` で認可画面へ遷移できることを確認し、失敗時は [トラブルシューティング](../../help/troubleshooting.md) を参照します。
 6. 時刻同期を確認する（self-host）
-   OAuth認可コードは短命なため、ホスト時刻のずれで `invalid_grant` が発生します。`timedatectl status` で NTP 同期状態を確認し、ずれがある場合は [clock skew 診断](../../help/troubleshooting.md#oauth-clock-skew) を参照してください。
+   OAuth認可コードは短命なため、ホスト時刻のずれで `invalid_grant` が発生します。`timedatectl status` で NTP 同期状態を確認し、ホストと API コンテナの UTC 時刻差が `5秒以上` の場合は [clock skew 診断](../../help/troubleshooting.md#oauth-clock-skew) を参照してください。
 
 ### provider切替時の確認フロー
 

--- a/docs/help/troubleshooting.md
+++ b/docs/help/troubleshooting.md
@@ -369,6 +369,12 @@ curl -sS -X POST -H "Authorization: Bearer ${TOKEN}" \
    date -u
    docker compose exec api date -u
    ```
+   判定の目安として、ホストとコンテナのUTC時刻差が `5秒以上` なら clock skew を疑って対処に進みます。
+   ```bash
+   host_epoch="$(date -u +%s)"
+   api_epoch="$(docker compose exec -T api date -u +%s)"
+   echo $(( host_epoch - api_epoch ))
+   ```
 3. NTP同期状態を確認する（self-host 環境）
    ```bash
    timedatectl status


### PR DESCRIPTION
## Summary
- add concrete  skew threshold in troubleshooting clock-skew section
- align OAuth guide self-host check with the same threshold
- add README operational note pointing to the same commands and threshold

## Test
- rg -n "oauth-clock-skew|5秒以上|timedatectl status" README.md docs/guides/oauth/index.md docs/help/troubleshooting.md

## Issue
- closes #243