### PR TITLE
docs: auth の logout/refresh 入力不正例を追記

### DIFF
--- a/docs/api/auth.md
+++ b/docs/api/auth.md
@@ -142,6 +142,23 @@ Content-Type: application/json
 }
 ```
 
+**入力不正時の代表レスポンス（型不一致）:**
+
+```json
+{
+  "detail": [
+    {
+      "type": "string_type",
+      "loc": ["body", "refresh_token"],
+      "msg": "Input should be a valid string",
+      "input": 12345
+    }
+  ]
+}
+```
+
+使い分け: `401` は未認証・無効トークン、`400` 系（本 API では主に `422`）は JSON 入力不正を示します。
+
 !!! info "トークンローテーション"
     リフレッシュ時に新しいリフレッシュトークンが発行されます。
     古いリフレッシュトークンは無効化されます。
@@ -185,6 +202,23 @@ Content-Type: application/json
 ```
 
 ステータスコード: `401 Unauthorized`
+
+**入力不正時の代表レスポンス（`refresh_token` 欠落）:**
+
+```json
+{
+  "detail": [
+    {
+      "type": "missing",
+      "loc": ["body", "refresh_token"],
+      "msg": "Field required",
+      "input": {}
+    }
+  ]
+}
+```
+
+使い分け: `401` は未認証・無効トークン、`400` 系（本 API では主に `422`）は JSON 入力不正を示します。
 
 ## エラーコード早見表（refresh/logout）
 


### PR DESCRIPTION
## 概要\n- docs/api/auth.md の refresh 節に型不一致時(422)の代表レスポンス例を追加\n- logout 節に refresh_token 欠落時(422)の代表レスポンス例を追加\n- 401(未認証) と 400系(主に422:入力不正) の使い分けを各節で明記\n\n## テスト\n- docs/api/auth.md の該当節で入力不正例が追加されていることを目視確認\n- docs/help/troubleshooting.md の refresh/401/422 導線と矛盾しないことを目視確認\n\nCloses #262