### PR TITLE
docs: installation に Secrets優先読込の確認コマンドを追加

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -453,6 +453,23 @@ docker compose up -d --build
 | `MOCK_OAUTH_ENABLED`（`default`/`ci`プロファイル） | Compose の service `environment` での指定（`1`）→ アプリ既定値（`0`） | `docker-compose.yml` と `api/app/config.py` |
 
 `read_secret()` の優先順は `api/tests/test_config.py` でテストされています（secret file 優先、次に環境変数、最後に既定値）。
+OAuth 導入時の判定フローは [OAuth設定ガイド: 有効化判定フロー](./guides/oauth/index.md#有効化判定フロー最初に確認) も参照してください。
+
+確認コマンド例（Secrets 優先読込）:
+
+```bash
+docker compose --profile default run --rm -e JWT_SECRET=env-fallback api python - <<'PY'
+from pathlib import Path
+from app.config import read_secret
+
+secret_file = Path("/run/secrets/jwt_secret").read_text().strip()
+resolved = read_secret("jwt_secret", "default")
+if resolved == secret_file:
+    print("OK: /run/secrets/jwt_secret が環境変数より優先されます")
+else:
+    raise SystemExit(f"NG: resolved={resolved!r} (secret_file と不一致)")
+PY
+```
 
 ### profile別の環境変数優先順位
 


### PR DESCRIPTION
## 概要\n- installation の『環境変数・Secrets の優先順位』節に、Secrets 優先読込を確認する実行コマンド例を追加\n- OAuth 導入時に参照しやすいよう、OAuth設定ガイドの有効化判定フローへのリンクを追加\n\n## 変更ファイル\n- docs/installation.md\n\n## テスト\n- rg で追記文言と位置を確認\n- git diff --name-only で想定外ファイル変更がないことを確認\n\n## 公開時の影響\n- ドキュメントのみの変更で、アプリ実行挙動への影響はありません\n- セルフホスト環境で Secrets 優先の確認手順が明確になり、OAuth 導入時の判断コストを下げます