### PR TITLE
test: startupでOAuth secret空文字を確実に検知する (#317)

### DIFF
--- a/api/tests/test_config.py
+++ b/api/tests/test_config.py
@@ -165,6 +165,42 @@ def test_settings_allows_when_provider_secret_is_non_empty(monkeypatch):
     assert settings.GITHUB_CLIENT_SECRET == "github-client-secret"
 
 
+def test_settings_startup_fails_when_provider_secret_env_is_empty():
+    env = os.environ.copy()
+    env["GITHUB_CLIENT_ID"] = "github-client-id"
+    env["GITHUB_CLIENT_SECRET"] = ""
+
+    result = subprocess.run(
+        [sys.executable, "-c", "from app.config import Settings; Settings()"],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=str(Path(__file__).resolve().parents[1]),
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "GITHUB_CLIENT_SECRET" in (result.stderr + result.stdout)
+
+
+def test_settings_startup_succeeds_when_provider_secret_env_is_non_empty():
+    env = os.environ.copy()
+    env["GITHUB_CLIENT_ID"] = "github-client-id"
+    env["GITHUB_CLIENT_SECRET"] = "github-client-secret"
+
+    result = subprocess.run(
+        [sys.executable, "-c", "from app.config import Settings; Settings(); print('ok')"],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=str(Path(__file__).resolve().parents[1]),
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert result.stdout.strip() == "ok"
+
+
 def _load_compose_services() -> dict:
     compose_path = Path(__file__).resolve().parents[2] / "docker-compose.yml"
     with compose_path.open() as f:


### PR DESCRIPTION
## 概要
- `Settings()` 初期化を subprocess で実行する起動時テストを追加
- `GITHUB_CLIENT_ID` が有効かつ `GITHUB_CLIENT_SECRET` が空文字のとき、起動失敗しキー名がエラーに含まれることを検証
- secret が非空のとき起動成功する回帰テストを追加

## テスト
- `cd api && uv run python -m pytest -q tests/test_config.py -k 'provider_secret'`

## 影響
- OAuth 導入時の設定不備（空文字 secret）を起動前に検知できることをテストで固定
- セルフホスト運用での初動トラブルシュートの再現性を改善
- OSS 利用者向けに設定品質の期待値を明文化（テスト）
