### PR TITLE
docs: add OAuth callback monitoring triage runbook

### DIFF
--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -122,6 +122,22 @@ docker compose logs --since=24h api | rg -n "/api/v1/auth/.*/callback|invalid_cl
 
 `Invalid state` の切り分け手順は `docs/help/troubleshooting.md` の `state mismatch 診断フロー` を参照してください。プロバイダー設定の前提は `docs/guides/oauth/index.md` の `セルフホスト運用チェックリスト` と合わせて確認します。
 
+### callback監視アラート時の即時トリアージ Runbook
+
+監視しきい値を超えたら、次の 3 手順を順番固定で実施します。手順を入れ替えないことで、セルフホスト環境でも再現性を維持できます。
+
+1. callback 失敗の事実を 30 分窓で再確認する
+   ```bash
+   docker compose logs api --since=30m | rg -n "/api/v1/auth/.*/callback|invalid_client|Invalid state|redirect_uri_mismatch"
+   ```
+2. 失敗タイプごとに一次切り分けを実施する
+   - `Invalid state`: [state mismatch 診断フロー](../help/troubleshooting.md#state-mismatch-flow) に移動する
+   - `redirect_uri_mismatch`: [トラブルシューティング](../help/troubleshooting.md) の `redirect_uri_mismatch` 診断へ移動する
+   - `invalid_client`: `client_id` / `client_secret` と callback URL の一致を [OAuth設定ガイドの callback チェック](./oauth/index.md#oauth-callback-checklist) で確認する
+3. 復旧後に監視基準へ戻ったことを確認する
+   - 同じコマンドを `--since=30m` で再実行し、該当エラー件数が増加しないことを確認する
+   - `curl -sS -o /dev/null -w "%{http_code}\n" https://api.your-domain.com/health` が `200` であることを確認する
+
 ## OAuthシークレットローテーション手順
 
 プロバイダー個別の管理画面差分（Google/Discord など）に依存しない、共通の切替手順です。Compose/ECS/Kubernetes いずれでも「シークレット更新」「API再起動（または再デプロイ）」「疎通確認」の順序は共通です。


### PR DESCRIPTION
## Summary
- `docs/guides/deployment.md` の OAuth callback監視セクションに、アラート発生時の即時トリアージ Runbook を追加
- 30分窓の再確認コマンド、失敗タイプ別の遷移先、復旧確認条件（再確認 + `/health`=200）を固定化
- 既存の `state mismatch` / OAuth callback チェック導線へ明示リンク

## Why this change
- セルフホスト運用で callback 失敗が「発生後調査」になりやすいため、監視しきい値超過時の初動を手順化して再現性を上げる

## Duplicate-avoidance note
- open issue #265 #263 #262 #261 は別ページ/別機能の観点が中心
- 本PRは `docs/guides/deployment.md` の監視運用初動（callback監視アラート時）に限定

## Validation
- `rg -n "callback監視アラート時の即時トリアージ Runbook|redirect_uri_mismatch|state mismatch 診断フロー" docs/guides/deployment.md`
- 追加リンク先を目視確認（`docs/help/troubleshooting.md`, `docs/guides/oauth/index.md`）

Closes #291