### PR TITLE
fix: normalize OAuth provider path casing (#319)

### DIFF
--- a/api/app/auth/router.py
+++ b/api/app/auth/router.py
@@ -1269,6 +1269,32 @@ async def debug_tokens(access_token: str, refresh_token: str):
 
 
 # =============================================================================
+# Provider Alias Endpoints
+# =============================================================================
+
+
+@router.get("/{provider}")
+@limiter.limit("10/minute")
+async def oauth_provider_login_alias(request: Request, provider: str):
+    """Normalize provider path casing and redirect to canonical login endpoint."""
+    normalized_provider = _validate_supported_oauth_provider(provider)
+    target_path = f"{API_V1_PREFIX}/auth/{normalized_provider}"
+    return RedirectResponse(url=target_path, status_code=status.HTTP_307_TEMPORARY_REDIRECT)
+
+
+@router.get("/{provider}/callback")
+@limiter.limit("10/minute")
+async def oauth_provider_callback_alias(request: Request, provider: str):
+    """Normalize callback path casing and redirect to canonical callback endpoint."""
+    normalized_provider = _validate_supported_oauth_provider(provider)
+    target_path = f"{API_V1_PREFIX}/auth/{normalized_provider}/callback"
+    query = request.url.query
+    if query:
+        target_path = f"{target_path}?{query}"
+    return RedirectResponse(url=target_path, status_code=status.HTTP_307_TEMPORARY_REDIRECT)
+
+
+# =============================================================================
 # Mock OAuth Endpoints (Development Only)
 # =============================================================================
 

--- a/api/tests/test_auth_provider_response_codes.py
+++ b/api/tests/test_auth_provider_response_codes.py
@@ -26,8 +26,30 @@ async def test_oauth_known_provider_disabled_returns_503(client: AsyncClient, mo
 
 
 @pytest.mark.asyncio
-async def test_oauth_unsupported_provider_path_returns_404(client: AsyncClient):
-    """Unsupported provider path should follow FastAPI route-level 404."""
+async def test_oauth_unsupported_provider_path_returns_400(client: AsyncClient):
+    """Unsupported provider path must return explicit 400 contract."""
     response = await client.get("/api/v1/auth/unknown", follow_redirects=False)
 
-    assert response.status_code == 404
+    assert response.status_code == 400
+    assert response.json() == {"detail": "Unsupported OAuth provider 'unknown'."}
+
+
+@pytest.mark.asyncio
+async def test_oauth_provider_path_case_variant_redirects_to_canonical(client: AsyncClient):
+    """Mixed-case provider path should be normalized via redirect."""
+    response = await client.get("/api/v1/auth/GitHub", follow_redirects=False)
+
+    assert response.status_code == 307
+    assert response.headers["location"] == "/api/v1/auth/github"
+
+
+@pytest.mark.asyncio
+async def test_oauth_callback_path_case_variant_redirects_to_canonical(client: AsyncClient):
+    """Mixed-case callback path should redirect while preserving query."""
+    response = await client.get(
+        "/api/v1/auth/GitHub/callback?code=abc&state=xyz",
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 307
+    assert response.headers["location"] == "/api/v1/auth/github/callback?code=abc&state=xyz"


### PR DESCRIPTION
## Summary\n- add auth provider alias endpoints that normalize mixed-case provider path values\n- return explicit 400 contract for unknown provider paths instead of route-level 404\n- add response-code tests for alias redirects and unknown-provider error contract\n\n## Test\n- cd api && uv run --python 3.12 pytest -q tests/test_auth_provider_response_codes.py tests/test_auth_oauth_provider_disabled.py\n\nCloses #319