### PR TITLE
Webhook署名検証失敗時に hash algo をエラーへ明示

### DIFF
--- a/api/app/webhooks/signer.py
+++ b/api/app/webhooks/signer.py
@@ -35,8 +35,19 @@ class InvalidWebhookSignatureError(WebhookSignatureError):
 
     error_code = "invalid_signature"
 
-    def __init__(self):
-        super().__init__("Webhook signature verification failed")
+    def __init__(
+        self,
+        *,
+        verify_error_code: str | None = None,
+        signature_algorithm: str | None = None,
+    ):
+        details: list[str] = []
+        if verify_error_code:
+            details.append(f"error_code={verify_error_code}")
+        if signature_algorithm:
+            details.append(f"signature_algorithm={signature_algorithm}")
+        detail_text = " ".join(details) if details else "error_code=invalid_signature"
+        super().__init__(f"Webhook signature verification failed {detail_text}")
 
 
 class WebhookSigner:
@@ -49,6 +60,14 @@ class WebhookSigner:
     ERROR_INVALID_SIGNATURE_FORMAT = "invalid_signature_format"
     ERROR_UNSUPPORTED_SIGNATURE_ALGORITHM = "unsupported_signature_algorithm"
     ERROR_HMAC_MISMATCH = "hmac_mismatch"
+
+    @staticmethod
+    def signature_algorithm(signature: str) -> str | None:
+        """Extract signature algorithm from '<algorithm>=<digest>' format."""
+        if "=" not in signature:
+            return None
+        algorithm, _ = signature.split("=", 1)
+        return algorithm.strip() or None
 
     @staticmethod
     def sign(payload: str, secret: str, timestamp: int | None = None) -> tuple[str, int]:
@@ -170,8 +189,17 @@ class WebhookSigner:
         """
         if signature is None or not signature.strip():
             raise MissingWebhookSignatureError()
-        if not WebhookSigner.verify(payload, secret, timestamp, signature):
-            raise InvalidWebhookSignatureError()
+        result = WebhookSigner.verify_with_error(
+            payload=payload,
+            secret=secret,
+            timestamp=timestamp,
+            signature=signature,
+        )
+        if not result.ok:
+            raise InvalidWebhookSignatureError(
+                verify_error_code=result.error_code,
+                signature_algorithm=WebhookSigner.signature_algorithm(signature),
+            )
 
     @staticmethod
     def get_headers(payload: str, secret: str, event_type: str, webhook_id: str) -> dict[str, str]:

--- a/api/tests/test_webhook_signer.py
+++ b/api/tests/test_webhook_signer.py
@@ -1,6 +1,7 @@
 """Property-based tests for WebhookSigner."""
 
 import json
+import time
 import uuid
 
 import pytest
@@ -257,8 +258,23 @@ class TestWebhookSigner:
     def test_verify_or_raise_reports_invalid_signature_separately(self):
         """Invalid signature should stay distinct from missing-header error."""
         payload = json.dumps({"event_id": str(uuid.uuid4()), "data": {}})
+        timestamp = int(time.time())
 
         with pytest.raises(InvalidWebhookSignatureError) as exc_info:
-            WebhookSigner.verify_or_raise(payload, "test-secret-key", 1705297800, "sha256=deadbeef")
+            WebhookSigner.verify_or_raise(payload, "test-secret-key", timestamp, "sha256=deadbeef")
 
         assert exc_info.value.error_code == "invalid_signature"
+        assert "error_code=hmac_mismatch" in str(exc_info.value)
+        assert "signature_algorithm=sha256" in str(exc_info.value)
+
+    def test_verify_or_raise_reports_algorithm_in_error_message(self):
+        """Unsupported algorithm failures should include algorithm label for triage."""
+        payload = json.dumps({"event_id": str(uuid.uuid4()), "data": {}})
+        timestamp = int(time.time())
+
+        with pytest.raises(InvalidWebhookSignatureError) as exc_info:
+            WebhookSigner.verify_or_raise(payload, "test-secret-key", timestamp, "sha1=deadbeef")
+
+        assert exc_info.value.error_code == "invalid_signature"
+        assert "error_code=unsupported_signature_algorithm" in str(exc_info.value)
+        assert "signature_algorithm=sha1" in str(exc_info.value)

--- a/docs/api/webhooks.md
+++ b/docs/api/webhooks.md
@@ -155,6 +155,11 @@ POST /api/v1/admin/webhooks/reload
 | `missing_signature_header` | `X-Webhook-Signature` ヘッダが欠落または空 |
 | `invalid_signature` | 署名検証に失敗した |
 
+`invalid_signature` 例外メッセージは、調査ログの構造を一定にするため次の key-value 形式を含みます。
+
+- `error_code=<failure_reason>`（例: `hmac_mismatch`, `unsupported_signature_algorithm`）
+- `signature_algorithm=<algorithm>`（例: `sha256`, `sha1`）
+
 ### 署名検証失敗時の最小調査フロー
 
 `invalid_signature` または `hmac_mismatch` が連続する場合は、次の順で切り分けると最短で原因に到達できます。


### PR DESCRIPTION
## 概要
- `WebhookSigner.verify_or_raise()` を `verify_with_error()` ベースへ変更
- `InvalidWebhookSignatureError` のメッセージに固定 key-value を付与
  - `error_code=<failure_reason>`
  - `signature_algorithm=<algorithm>`
- 異常系テストを追加して `hmac_mismatch` / `unsupported_signature_algorithm` の表示を検証
- API ドキュメントにエラー文字列フォーマットを追記

## テスト
- `cd api && uv run --python 3.11 --with-requirements requirements.txt --with pytest --with hypothesis pytest -q tests/test_webhook_signer.py`

## 影響
- OAuth 導入容易化: Webhook 署名不一致時の切り分けが早くなり、導入時の初期障害対応を短縮
- セルフホスト運用性: 監視ログから署名アルゴリズム差異を直接判定可能
- OSS ドキュメント: `docs/api/webhooks.md` に triage 観点を明文化

Refs #320
