### PR TITLE
test: SESSION_COOKIE_SAMESITE 未設定時の環境名回帰を追加

### DIFF
--- a/admin/tests/test_session_cookie_samesite.py
+++ b/admin/tests/test_session_cookie_samesite.py
@@ -51,6 +51,21 @@ class SessionCookieSameSiteWarningTests(unittest.TestCase):
             "staging",
         )
 
+    def test_warns_with_production_when_environment_is_empty(self) -> None:
+        logger = Mock()
+
+        warned = warn_if_session_cookie_samesite_unset(
+            logger,
+            environment="",
+            session_cookie_samesite="",
+        )
+
+        self.assertTrue(warned)
+        logger.warning.assert_called_once_with(
+            "SESSION_COOKIE_SAMESITE is not configured for admin session cookie (environment=%s)",
+            "production",
+        )
+
     def test_warns_and_falls_back_when_samesite_is_unknown(self) -> None:
         logger = Mock()
 


### PR DESCRIPTION
## 概要
- `SESSION_COOKIE_SAMESITE` 未設定時の警告ログで、`environment` が空なら `production` が出ることを回帰テスト化
- 既存の SameSite 警告テスト群を補完し、環境差での見落としを防止

## テスト
- `cd admin && python3 -m unittest tests.test_session_cookie_samesite -v`

Closes #322
