### PR TITLE
docs: clarify sessions pagination limit error contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,18 @@ self-host では `timedatectl status` と `date -u` / `docker compose exec -T ap
 | DELETE | `/sessions/me/{session_id}` | Revoke specific session |
 | DELETE | `/sessions/me` | Revoke all sessions |
 
+`GET /api/v1/sessions` の `limit` は最大 `1000` です。`limit > 1000` の場合は `400 Bad Request` として次の本文を返します。
+
+```json
+{
+  "detail": {
+    "code": "SESSIONS_LIMIT_EXCEEDED",
+    "message": "limit must be less than or equal to 1000",
+    "max_limit": 1000
+  }
+}
+```
+
 ### Response Format
 
 #### Successful Login (Callback Response)

--- a/api/tests/test_sessions.py
+++ b/api/tests/test_sessions.py
@@ -132,6 +132,24 @@ async def test_sessions_list_accepts_limit_at_maximum(client: AsyncClient):
 
 
 @pytest.mark.asyncio
+async def test_sessions_list_accepts_limit_100(client: AsyncClient):
+    """Session list should keep working with common pagination boundary (limit=100)."""
+    login_response = await client.get("/api/v1/auth/mock/login")
+    assert login_response.status_code == 200
+
+    token = login_response.json()["access_token"]
+    response = await client.get(
+        "/api/v1/sessions?limit=100",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["sessions"]) <= 100
+    assert data["total"] == len(data["sessions"])
+
+
+@pytest.mark.asyncio
 async def test_sessions_openapi_limit_has_maximum(client: AsyncClient):
     """OpenAPI should expose limit maximum as 1000."""
     response = await client.get("/openapi.json")

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -335,6 +335,18 @@ curl -H "Authorization: Bearer ${TOKEN}" \
 
 `limit=1/100` の境界値を含む一覧系確認を同じトークンで行う場合は、[ユーザーAPIの検証例](api/users.md#ページング境界値limit1100の検証例) を参照してください。
 
+`GET /api/v1/sessions` で `limit > 1000` を指定した場合は、`400 Bad Request` と次のエラー契約を返します。
+
+```json
+{
+  "detail": {
+    "code": "SESSIONS_LIMIT_EXCEEDED",
+    "message": "limit must be less than or equal to 1000",
+    "max_limit": 1000
+  }
+}
+```
+
 ### エラーレスポンスの確認
 
 未認証でログアウトAPIを呼ぶと、`401 Unauthorized` とエラーボディを確認できます。


### PR DESCRIPTION
## Summary
- README に `/api/v1/sessions` の limit 超過時エラー契約（専用コード・上限値）を追記
- getting-started に同じ契約を追記し、自己ホスト環境での確認導線を明確化
- `api/tests/test_sessions.py` に `limit=100` の回帰テストを追加

## Test
- `docker compose run --rm api pytest tests/test_sessions.py -q`

Closes #323
