### PR TITLE
Fix #324 OAuth callback trailing-slash normalization logging

### DIFF
--- a/api/app/auth/router.py
+++ b/api/app/auth/router.py
@@ -186,10 +186,12 @@ async def _validate_callback_url_or_raise(
     if normalized_expected == normalized_actual:
         if expected_callback_url != actual_callback_url:
             logger.info(
-                "OAuth callback URL normalized for provider=%s expected=%s actual=%s",
+                "OAuth callback URL normalized for provider=%s expected=%s actual=%s normalized_expected=%s normalized_actual=%s",
                 provider,
                 expected_callback_url,
                 actual_callback_url,
+                normalized_expected,
+                normalized_actual,
             )
         return
 

--- a/api/tests/test_auth_callback_url_normalization.py
+++ b/api/tests/test_auth_callback_url_normalization.py
@@ -1,6 +1,7 @@
 """OAuth callback URL normalization tests."""
 
 import importlib
+import logging
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
@@ -19,8 +20,9 @@ def test_normalize_callback_url_trims_only_trailing_slash():
 
 
 @pytest.mark.asyncio
-async def test_validate_callback_url_allows_trailing_slash_difference():
+async def test_validate_callback_url_allows_trailing_slash_difference(caplog):
     """Trailing slash difference must be accepted."""
+    caplog.set_level(logging.INFO, logger=auth_router_module.logger.name)
     request = SimpleNamespace(
         url=SimpleNamespace(
             replace=lambda **kwargs: "https://api.example.com/api/v1/auth/google/callback/"
@@ -41,6 +43,13 @@ async def test_validate_callback_url_allows_trailing_slash_difference():
 
     mock_metric.assert_not_called()
     mock_log_login.assert_not_called()
+    assert (
+        "OAuth callback URL normalized for provider=google "
+        "expected=https://api.example.com/api/v1/auth/google/callback "
+        "actual=https://api.example.com/api/v1/auth/google/callback/ "
+        "normalized_expected=https://api.example.com/api/v1/auth/google/callback "
+        "normalized_actual=https://api.example.com/api/v1/auth/google/callback"
+    ) in caplog.text
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary\n- keep callback URL trailing-slash normalization behavior as-is and strengthen accepted-difference logging\n- include normalized expected/actual URL values in the info log when trailing-slash-only differences are accepted\n- add a regression assertion that the normalization log is emitted\n\n## Test\n- cd api && uv run --python 3.11 --with-requirements requirements.txt pytest -q tests/test_auth_callback_url_normalization.py\n\n## Impact\n- OAuth 導入時の callback URL 差分（末尾スラッシュ）を許容したケースでも、監査しやすい差分ログが残る\n