### PR TITLE
fix: deterministic sort order for OAuth provider registry

### DIFF
--- a/api/app/oauth_providers.py
+++ b/api/app/oauth_providers.py
@@ -2,21 +2,24 @@
 
 from types import MappingProxyType
 
-_OAUTH_PROVIDER_REGISTRY: tuple[tuple[str, tuple[str, str]], ...] = (
-    ("google", ("GOOGLE_CLIENT_ID", "GOOGLE_CLIENT_SECRET")),
-    ("discord", ("DISCORD_CLIENT_ID", "DISCORD_CLIENT_SECRET")),
-    ("github", ("GITHUB_CLIENT_ID", "GITHUB_CLIENT_SECRET")),
-    ("x", ("X_CLIENT_ID", "X_CLIENT_SECRET")),
-    ("linkedin", ("LINKEDIN_CLIENT_ID", "LINKEDIN_CLIENT_SECRET")),
-    ("facebook", ("FACEBOOK_CLIENT_ID", "FACEBOOK_CLIENT_SECRET")),
-    ("slack", ("SLACK_CLIENT_ID", "SLACK_CLIENT_SECRET")),
-    ("twitch", ("TWITCH_CLIENT_ID", "TWITCH_CLIENT_SECRET")),
+_OAUTH_PROVIDER_CREDENTIAL_MAP = MappingProxyType(
+    {
+        "google": ("GOOGLE_CLIENT_ID", "GOOGLE_CLIENT_SECRET"),
+        "discord": ("DISCORD_CLIENT_ID", "DISCORD_CLIENT_SECRET"),
+        "github": ("GITHUB_CLIENT_ID", "GITHUB_CLIENT_SECRET"),
+        "x": ("X_CLIENT_ID", "X_CLIENT_SECRET"),
+        "linkedin": ("LINKEDIN_CLIENT_ID", "LINKEDIN_CLIENT_SECRET"),
+        "facebook": ("FACEBOOK_CLIENT_ID", "FACEBOOK_CLIENT_SECRET"),
+        "slack": ("SLACK_CLIENT_ID", "SLACK_CLIENT_SECRET"),
+        "twitch": ("TWITCH_CLIENT_ID", "TWITCH_CLIENT_SECRET"),
+    }
 )
 
-OAUTH_PROVIDER_ORDER: tuple[str, ...] = tuple(
-    provider for provider, _ in _OAUTH_PROVIDER_REGISTRY
+# Keep provider initialization deterministic by sorting provider keys explicitly.
+OAUTH_PROVIDER_ORDER: tuple[str, ...] = tuple(sorted(_OAUTH_PROVIDER_CREDENTIAL_MAP))
+OAUTH_PROVIDER_CREDENTIAL_FIELDS = MappingProxyType(
+    {provider: _OAUTH_PROVIDER_CREDENTIAL_MAP[provider] for provider in OAUTH_PROVIDER_ORDER}
 )
 OAUTH_PROVIDER_CREDENTIAL_KEYS: tuple[tuple[str, str], ...] = tuple(
-    credential_keys for _, credential_keys in _OAUTH_PROVIDER_REGISTRY
+    OAUTH_PROVIDER_CREDENTIAL_FIELDS[provider] for provider in OAUTH_PROVIDER_ORDER
 )
-OAUTH_PROVIDER_CREDENTIAL_FIELDS = MappingProxyType(dict(_OAUTH_PROVIDER_REGISTRY))

--- a/api/tests/test_auth_provider_registry.py
+++ b/api/tests/test_auth_provider_registry.py
@@ -15,14 +15,14 @@ auth_router_module = importlib.import_module("app.auth.router")
 def test_provider_registry_order_is_stable() -> None:
     """Provider registry order must stay deterministic across modules."""
     assert OAUTH_PROVIDER_ORDER == (
-        "google",
         "discord",
-        "github",
-        "x",
-        "linkedin",
         "facebook",
+        "github",
+        "google",
+        "linkedin",
         "slack",
         "twitch",
+        "x",
     )
     assert tuple(OAUTH_PROVIDER_CREDENTIAL_FIELDS.keys()) == OAUTH_PROVIDER_ORDER
     assert OAUTH_PROVIDER_CREDENTIAL_KEYS == tuple(OAUTH_PROVIDER_CREDENTIAL_FIELDS.values())
@@ -34,4 +34,4 @@ def test_provider_registry_order_is_logged(caplog) -> None:
         auth_router_module._log_provider_registry_order()
 
     assert "OAuth provider registry initialized in deterministic order" in caplog.text
-    assert "google -> discord -> github -> x -> linkedin -> facebook -> slack -> twitch" in caplog.text
+    assert "discord -> facebook -> github -> google -> linkedin -> slack -> twitch -> x" in caplog.text


### PR DESCRIPTION
## Summary
- build provider credential registry from a sorted provider key list
- keep `OAUTH_PROVIDER_ORDER`, credential fields, and credential keys aligned deterministically
- update deterministic-order tests and registry-order log assertion

## Test
- `uv run --python 3.11 --with-requirements requirements.txt pytest -q tests/test_auth_provider_registry.py`
- `uv run --python 3.11 --with-requirements requirements.txt pytest -q tests/test_auth_oauth_provider_disabled.py tests/test_auth_rate_limit_provider_path.py tests/test_github_oauth.py`

Closes #326
