### PR TITLE
docs: FAQにprovider有効化順序チェックの受け入れ基準を明確化

### DIFF
--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -180,7 +180,11 @@ API 契約とレスポンス例は [ユーザーAPI: プロバイダ情報から
 - クイックスタート: [2.5 コールバックURLの検証](../getting-started.md#25-コールバックurlの検証)
 - トラブルシューティング: [401 Unauthorized / invalid_client](./troubleshooting.md#401-unauthorized--invalid_client)
 
-受け入れ時は、FAQ / installation / troubleshooting の3点同期（手順・用語・リンク先）が保たれていることを確認してください。
+受け入れ時は、次の3点を満たしていることを確認してください。
+
+1. FAQ の順序チェック項目が3つ以上あり、今回の運用順（profile固定 → secret配置 → callback一致 → 認可導線確認）を説明できる
+2. 参照リンクが [インストール](../installation.md#oauth認証情報) と [クイックスタート](../getting-started.md#25-コールバックurlの検証) を指している
+3. [FAQ](./faq.md#複数providerを有効化するときの順序チェックは) / [installation](../installation.md#oauth認証情報) / [troubleshooting](./troubleshooting.md#401-unauthorized--invalid_client) の三点同期（手順・用語・リンク先）が保たれている
 
 ### ローカルでテストするには？
 


### PR DESCRIPTION
## Summary\n- FAQ の『複数providerを有効化するときの順序チェック』節を補強\n- 受け入れ時チェックを3項目で明文化（3つ以上の順序チェック、installation/getting-started参照、三点同期）\n\n## Test\n- \docs/getting-started.md:95:- `redirect_uri_mismatch` / `invalid_client`: [トラブルシューティング: 401 Unauthorized / invalid_client](help/troubleshooting.md#401-unauthorized--invalid_client)
docs/getting-started.md:97:- profile や secret 前提の再確認: [インストール](installation.md#oauth認証情報)
docs/getting-started.md:102:- [インストールの OAuth 認証情報](installation.md#oauth認証情報) と callback 前提（URL 形式・provider 単位）が一致している
docs/getting-started.md:311:   - [トラブルシューティング: 401 Unauthorized / invalid_client](help/troubleshooting.md#401-unauthorized--invalid_client)
docs/getting-started.md:448:1. [インストール](installation.md#oauth認証情報)で OAuth シークレットの配置と profile を確認する
docs/getting-started.md:451:4. 認証フローの失敗は [state mismatch 診断フロー](help/troubleshooting.md#state-mismatch-flow)、資格情報エラーは [`401 Unauthorized` / `invalid_client`](help/troubleshooting.md#401-unauthorized--invalid_client) を確認する
docs/help/troubleshooting.md:25:| `provider` | [`401 Unauthorized` / `invalid_client`](#401-unauthorized--invalid_client) | `docker compose logs --tail=100 api \| rg -n "invalid_client\|401\|client_secret\|client_id"` |
docs/help/troubleshooting.md:348:**受け入れ時の三点同期チェック:**
docs/installation.md:595:4. `auth` / `provider` で詰まった場合は [state mismatch](help/troubleshooting.md#state-mismatch-flow) と [`401 Unauthorized` / `invalid_client`](help/troubleshooting.md#401-unauthorized--invalid_client) を順に確認する
docs/help/faq.md:79:シークレットの配置方針は [インストールガイド: OAuth認証情報](../installation.md#oauth認証情報)、
docs/help/faq.md:164:切り分け手順は [トラブルシューティング: state mismatch 診断フロー](./troubleshooting.md#state-mismatch-flow) と [トラブルシューティング: 401 Unauthorized / invalid_client](./troubleshooting.md#401-unauthorized--invalid_client) を参照してください。  
docs/help/faq.md:168:### 複数providerを有効化するときの順序チェックは？
docs/help/faq.md:179:- インストール: [OAuth認証情報](../installation.md#oauth認証情報)
docs/help/faq.md:180:- クイックスタート: [2.5 コールバックURLの検証](../getting-started.md#25-コールバックurlの検証)
docs/help/faq.md:181:- トラブルシューティング: [401 Unauthorized / invalid_client](./troubleshooting.md#401-unauthorized--invalid_client)
docs/help/faq.md:186:2. 参照リンクが [インストール](../installation.md#oauth認証情報) と [クイックスタート](../getting-started.md#25-コールバックurlの検証) を指している
docs/help/faq.md:187:3. [FAQ](./faq.md#複数providerを有効化するときの順序チェックは) / [installation](../installation.md#oauth認証情報) / [troubleshooting](./troubleshooting.md#401-unauthorized--invalid_client) の三点同期（手順・用語・リンク先）が保たれている\n\nCloses #329