### PR TITLE
docs: secrets権限不備の復旧フローを3点同期

### DIFF
--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -88,7 +88,8 @@ YESOD AuthはGoogle OAuthでPKCEを自動的に使用します。
 1. `docker compose logs --tail=100 api | rg -n "permission denied|/run/secrets"` で症状を確認する
 2. Linux: `stat -c '%n %a %U:%G' secrets/*.txt` / macOS: `stat -f '%N %Lp %Su:%Sg' secrets/*.txt` で権限と所有者を確認する
 3. `chmod 600 secrets/*.txt` と `sudo chown "$(id -un):$(id -gn)" secrets/*.txt` で復旧する
-4. `docker compose up -d --force-recreate api worker` 後に `curl -fsS http://localhost:8000/health` を確認する
+4. `docker compose up -d --force-recreate api worker` で反映する
+5. `docker compose logs --tail=100 api | rg -n "permission denied|/run/secrets"` と `curl -fsS http://localhost:8000/health` で再確認する
 
 詳細手順は [トラブルシューティング: secrets 権限不備で `Permission denied` が出る](./troubleshooting.md#secrets-permission-recovery) を参照してください。  
 受け入れ時は FAQ / installation / troubleshooting の3点で、コマンドと手順順が一致していることを確認してください。

--- a/docs/help/troubleshooting.md
+++ b/docs/help/troubleshooting.md
@@ -310,18 +310,17 @@ curl -sS -X POST -H "Authorization: Bearer ${TOKEN}" \
 
 **症状:** `docker compose up -d` 実行時に `permission denied` が出て起動できない。`/run/secrets/*` の読み込みエラーが API ログに残る。
 
-**確認手順（Linux/macOS）:**
+**確認手順（症状→確認）:**
 
-1. 対象 secret の所有者とパーミッションを確認する
+1. 症状をログで確認する
    ```bash
-   ls -l secrets/*.txt
+   docker compose logs --tail=100 api | rg -n "permission denied|/run/secrets"
    ```
-2. Linux の詳細確認
+2. 権限と所有者を確認する（Linux/macOS）
    ```bash
+   # Linux
    stat -c '%n %a %U:%G' secrets/*.txt
-   ```
-3. macOS の詳細確認
-   ```bash
+   # macOS
    stat -f '%N %Lp %Su:%Sg' secrets/*.txt
    ```
 
@@ -333,7 +332,7 @@ curl -sS -X POST -H "Authorization: Bearer ${TOKEN}" \
    ```
 2. 所有者が現在ユーザーでない場合は修正する（Linux/macOS 共通）
    ```bash
-   sudo chown \"$(id -un):$(id -gn)\" secrets/*.txt
+   sudo chown "$(id -un):$(id -gn)" secrets/*.txt
    ```
 3. API を再作成して反映する
    ```bash
@@ -341,7 +340,7 @@ curl -sS -X POST -H "Authorization: Bearer ${TOKEN}" \
    ```
 4. 再確認する
    ```bash
-   docker compose logs --tail=100 api | rg -n \"permission denied|/run/secrets|invalid_client\"
+   docker compose logs --tail=100 api | rg -n "permission denied|/run/secrets"
    curl -fsS http://localhost:8000/health
    ```
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -336,6 +336,11 @@ curl -fsS http://localhost:8000/health
    sudo chown "$(id -un):$(id -gn)" secrets/*.txt
    docker compose up -d --force-recreate api worker
    ```
+4. 再確認
+   ```bash
+   docker compose logs --tail=100 api | rg -n "permission denied|/run/secrets"
+   curl -fsS http://localhost:8000/health
+   ```
 
 詳細な切り分けは [トラブルシューティング: secrets 権限不備で `Permission denied` が出る](./help/troubleshooting.md#secrets-permission-recovery) を参照してください。
 


### PR DESCRIPTION
## 概要
- troubleshooting の権限不備手順を「症状→確認→復旧→再確認」に統一
- installation/faq の同手順を同一コマンド列へ同期
- 受け入れ条件の FAQ / installation / troubleshooting 三点同期を満たすよう整合

## テスト
- `mkdocs build --strict`（`mkdocs` コマンド未導入で未実施）
- `python3 -m mkdocs build --strict`（`No module named mkdocs` で未実施）

Closes #330
