### PR TITLE
docs: preflight に valkey 到達確認を追加

### DIFF
--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -187,6 +187,26 @@ API 契約とレスポンス例は [ユーザーAPI: プロバイダ情報から
 2. 参照リンクが [インストール](../installation.md#oauth認証情報) と [クイックスタート](../getting-started.md#25-コールバックurlの検証) を指している
 3. [FAQ](./faq.md#複数providerを有効化するときの順序チェックは) / [installation](../installation.md#oauth認証情報) / [troubleshooting](./troubleshooting.md#401-unauthorized--invalid_client) の三点同期（手順・用語・リンク先）が保たれている
 
+### preflight で valkey 到達確認を最短で行うには？
+
+最短では、選んだ profile で `valkey` を起動して `PING` が `PONG` を返すことだけ確認します。
+
+```bash
+PROFILE=default # full / ci でも可
+docker compose --profile "$PROFILE" up -d valkey
+docker compose --profile "$PROFILE" exec valkey sh -lc 'valkey-cli ping || redis-cli ping'
+```
+
+失敗時は次の順で切り分けると早いです。
+
+1. `docker compose --profile "$PROFILE" config --services | rg -x 'valkey'`
+2. `docker compose ps valkey`
+3. `docker compose logs valkey --since=30m`
+
+参照先:
+- [インストール: Docker起動前チェック項目](../installation.md#docker起動前チェック項目)
+- [トラブルシューティング: preflight で valkey 到達確認に失敗する](./troubleshooting.md#valkey-preflight-failure)
+
 ### ローカルでテストするには？
 
 ```bash

--- a/docs/help/troubleshooting.md
+++ b/docs/help/troubleshooting.md
@@ -29,6 +29,32 @@ docker compose logs api --since=30m | rg -n "Invalid state|callback|invalid_clie
 
 `secret ... not found` の即時復旧は [`インストールガイド` の secret不足時手順](../installation.md#1-docker-compose-up-で-secret-未設定エラーになる) を先に実行してください。
 
+<a id="valkey-preflight-failure"></a>
+
+### preflight で valkey 到達確認に失敗する
+
+**症状:** `docker compose ... exec valkey ... 'valkey-cli ping || redis-cli ping'` が失敗する、または `PONG` 以外を返す。
+
+**確認手順:**
+
+1. 対象 profile で `valkey` が起動対象になっているか確認する
+   ```bash
+   docker compose --profile default config --services | rg -x 'valkey'
+   docker compose --profile full config --services | rg -x 'valkey'
+   docker compose --profile ci config --services | rg -x 'valkey'
+   ```
+2. `valkey` コンテナ状態を確認する
+   ```bash
+   docker compose ps valkey
+   docker compose logs valkey --since=30m
+   ```
+3. `PING` の再実行で復旧確認する
+   ```bash
+   docker compose exec valkey sh -lc 'valkey-cli ping || redis-cli ping'
+   ```
+
+**対処:** `valkey` が `Up` で `PING` が `PONG` になるまで、ポート競合・ボリューム破損・起動失敗ログを優先して解消します。導線は [インストール: Docker起動前チェック項目](../installation.md#docker起動前チェック項目) を基準に戻してください。
+
 ### `pg_cron`関連のエラー
 
 ```

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -102,6 +102,28 @@ lsof -nP -iTCP:8000 -iTCP:5432 -iTCP:6379 -sTCP:LISTEN
 - 管理画面確認まで行う場合: `full`
 - CI相当確認のみ: `ci`
 
+7. Valkey 到達確認（profile別）
+
+選んだ profile ごとに、`valkey` へ `PING` が通ることを先に確認します。
+
+- `default`
+  ```bash
+  docker compose --profile default up -d valkey
+  docker compose --profile default exec valkey sh -lc 'valkey-cli ping || redis-cli ping'
+  ```
+- `full`
+  ```bash
+  docker compose --profile full up -d valkey
+  docker compose --profile full exec valkey sh -lc 'valkey-cli ping || redis-cli ping'
+  ```
+- `ci`
+  ```bash
+  docker compose --profile ci up -d valkey
+  docker compose --profile ci exec valkey sh -lc 'valkey-cli ping || redis-cli ping'
+  ```
+
+期待値はすべて `PONG` です。失敗した場合は [トラブルシューティング: preflight で valkey 到達確認に失敗する](./help/troubleshooting.md#valkey-preflight-failure) を参照してください。
+
 ### 起動前チェックを1コマンドで流す（任意）
 
 ```bash
@@ -110,6 +132,8 @@ docker --version \
   && docker info > /dev/null \
   && test -r secrets/jwt_secret.txt \
   && docker compose --profile default config > /dev/null \
+  && docker compose --profile default up -d valkey \
+  && docker compose --profile default exec valkey sh -lc 'valkey-cli ping || redis-cli ping' | rg -qx 'PONG' \
   && echo "preflight: OK"
 ```
 


### PR DESCRIPTION
## 概要
- `docs/installation.md` の preflight に `valkey` 到達確認（`PING`/`PONG`）を追加
- `default` / `full` / `ci` ごとの確認コマンドを明記
- `docs/help/troubleshooting.md` に preflight 失敗時の切り分け節を追加
- `docs/help/faq.md` に最短確認 FAQ を追加し、installation/troubleshooting への導線を同期

## テスト/確認
- `docker compose --profile default config > /tmp/yesod_compose_config.out`
- `rg -n "Valkey 到達確認|valkey-preflight-failure|preflight: OK" docs/installation.md docs/help/troubleshooting.md docs/help/faq.md`

## docs 三点同期チェック
- FAQ: `preflight で valkey 到達確認を最短で行うには？` を追加
- installation: `Docker起動前チェック項目` に profile別 valkey 到達確認を追加
- troubleshooting: `preflight で valkey 到達確認に失敗する` を追加

## 公開時の影響
- 導入時に `valkey` 未到達を preflight 段階で検知できるようになり、起動後の OAuth/state 障害切り分けを短縮

Closes #338
