### PR TITLE
docs(help): clarify full profile admin_password requirement

### DIFF
--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -49,6 +49,17 @@ YESOD AuthはGoogle OAuthでPKCEを自動的に使用します。
 必須なのは`jwt_secret`と、実際に有効化して使うOAuthプロバイダーの`*_client_id`/`*_client_secret`だけです。
 たとえばGoogleのみ使う最小構成ならGoogle分だけ、複数プロバイダー運用なら有効化した各プロバイダー分を追加してください。
 
+加えて `--profile full` で `admin` を使う場合は、`secrets/admin_password.txt` も必須です（空ファイル不可）。
+
+```bash
+ls -l secrets/admin_password.txt
+test -s secrets/admin_password.txt && echo "admin_password: OK" || (echo "admin_password が未作成または空です" >&2; exit 1)
+```
+
+導線同期:
+- インストール: [管理画面付き](../installation.md#管理画面付き)
+- トラブルシューティング: [full profile で admin ログインできない（admin_password 未設定/空）](./troubleshooting.md#full-profile-admin-password-missing)
+
 ### provider 未設定のまま初回導入を進めてもよい？
 
 可能です。次の順で進めると最短で起動確認できます。

--- a/docs/help/troubleshooting.md
+++ b/docs/help/troubleshooting.md
@@ -29,6 +29,32 @@ docker compose logs api --since=30m | rg -n "Invalid state|callback|invalid_clie
 
 `secret ... not found` の即時復旧は [`インストールガイド` の secret不足時手順](../installation.md#1-docker-compose-up-で-secret-未設定エラーになる) を先に実行してください。
 
+<a id="full-profile-admin-password-missing"></a>
+
+### full profile で admin ログインできない（admin_password 未設定/空）
+
+**症状:** `--profile full` 起動後に `admin` へログインできない、または `admin` サービス起動に失敗する。
+
+**確認手順:**
+
+1. `secrets/admin_password.txt` の存在と非空を確認する
+   ```bash
+   ls -l secrets/admin_password.txt
+   test -s secrets/admin_password.txt && echo "admin_password: OK" || (echo "admin_password が未作成または空です" >&2; exit 1)
+   ```
+2. `full` プロファイルでサービス一覧を確認する
+   ```bash
+   docker compose --profile full config --services
+   ```
+3. 必要に応じて再起動する
+   ```bash
+   docker compose --profile full up -d
+   ```
+
+**参照:**
+- FAQ: [どのsecretを必須で用意すべき？](./faq.md#どのsecretを必須で用意すべき)
+- Installation: [管理画面付き](../installation.md#管理画面付き)
+
 <a id="valkey-preflight-failure"></a>
 
 ### preflight で valkey 到達確認に失敗する

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -157,6 +157,8 @@ ls -l secrets/admin_password.txt
 test -s secrets/admin_password.txt && echo "admin_password: OK" || (echo "admin_password が未作成または空です" >&2; exit 1)
 ```
 
+FAQ で同じ確認観点を参照: [どのsecretを必須で用意すべき？](./help/faq.md#どのsecretを必須で用意すべき)
+
 2. 管理画面向け環境変数の確認観点
 
 - `ADMIN_USER`: 管理者ログイン名。既定値は `admin`（`docker-compose.yml` で設定）


### PR DESCRIPTION
## 概要
- FAQ に `--profile full` 利用時の `secrets/admin_password.txt` 必須条件（非空チェック付き）を追記
- installation の「管理画面付き」節へ FAQ 相互リンクを追加
- troubleshooting に `admin_password` 未設定/空ファイル時の切り分け節を追加

## 変更理由
- OAuth 導入を進める利用者が、full profile 時の管理画面ログイン前提を FAQ から即時確認できるようにするため
- セルフホスト運用で起こりやすい `admin_password` 未設定/空ファイル起因の失敗を、FAQ/installation/troubleshooting の三点で同じ導線に統一するため
- OSS 利用者向けに、最小確認コマンドと復旧手順をドキュメントで自己完結させるため

## 検証
- `rg -n "どのsecretを必須で用意すべき|full profile で admin ログインできない|admin_password: OK|管理画面付き" docs/help/faq.md docs/installation.md docs/help/troubleshooting.md`
- 3 ファイル間のリンク整合（FAQ -> installation/troubleshooting, installation -> FAQ, troubleshooting -> FAQ/installation）を確認

## 公開時の影響
- ドキュメントのみ変更（実装・API・挙動変更なし）
- full profile 運用手順の誤解を減らし、導入時の自己解決率を向上

Closes #340
