### PR TITLE
docs: callback URL mismatch 診断フローを troubleshooting に追加

### DIFF
--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -163,6 +163,7 @@ API 契約とレスポンス例は [ユーザーAPI: プロバイダ情報から
 - [トラブルシューティング: provider 未設定のまま認証導線を実行した](./troubleshooting.md#provider-未設定のまま認証導線を実行した)
 
 切り分け手順は [トラブルシューティング: state mismatch 診断フロー](./troubleshooting.md#state-mismatch-flow) と [トラブルシューティング: 401 Unauthorized / invalid_client](./troubleshooting.md#401-unauthorized--invalid_client) を参照してください。  
+callback URL 不一致が疑われる場合は [トラブルシューティング: redirect_uri_mismatch（callback URL 不一致の診断フロー）](./troubleshooting.md#oauth-callback-url-mismatch) を追加で確認してください。  
 本番切替時の確認で迷ったら [トラブルシューティング: 障害時の参照順（最短導線）](./troubleshooting.md#障害時の参照順最短導線) から再開してください。  
 前提の設定差分は [インストール: profile別の環境変数優先順位](../installation.md#profile別の環境変数優先順位) を参照してください。
 
@@ -180,12 +181,13 @@ API 契約とレスポンス例は [ユーザーAPI: プロバイダ情報から
 - インストール: [OAuth認証情報](../installation.md#oauth認証情報)
 - クイックスタート: [2.5 コールバックURLの検証](../getting-started.md#25-コールバックurlの検証)
 - トラブルシューティング: [401 Unauthorized / invalid_client](./troubleshooting.md#401-unauthorized--invalid_client)
+- トラブルシューティング: [redirect_uri_mismatch（callback URL 不一致の診断フロー）](./troubleshooting.md#oauth-callback-url-mismatch)
 
 受け入れ時は、次の3点を満たしていることを確認してください。
 
 1. FAQ の順序チェック項目が3つ以上あり、今回の運用順（profile固定 → secret配置 → callback一致 → 認可導線確認）を説明できる
 2. 参照リンクが [インストール](../installation.md#oauth認証情報) と [クイックスタート](../getting-started.md#25-コールバックurlの検証) を指している
-3. [FAQ](./faq.md#複数providerを有効化するときの順序チェックは) / [installation](../installation.md#oauth認証情報) / [troubleshooting](./troubleshooting.md#401-unauthorized--invalid_client) の三点同期（手順・用語・リンク先）が保たれている
+3. [FAQ](./faq.md#複数providerを有効化するときの順序チェックは) / [installation](../installation.md#oauth認証情報) / [troubleshooting](./troubleshooting.md#oauth-callback-url-mismatch) の三点同期（手順・用語・リンク先）が保たれている
 
 ### preflight で valkey 到達確認を最短で行うには？
 

--- a/docs/help/troubleshooting.md
+++ b/docs/help/troubleshooting.md
@@ -421,7 +421,9 @@ curl -sS -X POST -H "Authorization: Bearer ${TOKEN}" \
 
 ---
 
-### `redirect_uri_mismatch`（正規化差分の診断）
+<a id="oauth-callback-url-mismatch"></a>
+
+### `redirect_uri_mismatch`（callback URL 不一致の診断フロー）
 
 **症状:** OAuth callback が `400` で失敗し、provider 側の `redirect_uri_mismatch` が疑われる
 
@@ -440,37 +442,16 @@ curl -sS -X POST -H "Authorization: Bearer ${TOKEN}" \
    - provider 管理画面に登録した callback が `https://<api-domain>/api/v1/auth/{provider}/callback` と完全一致しているか確認する（スキーム・ポート・末尾スラッシュを含む）
    - `API_URL` が実アクセスURL（reverse proxy 経由の公開URL）と一致しているか確認する
    - OAuth 開始は必ず `GET /api/v1/auth/{provider}` から行い、callback URL を直接開いていないことを確認する
-5. 導線確認として、導入前提は [installation](../installation.md#oauth-導入前の3点チェック) を、運用時チェックは [OAuth設定ガイド](../guides/oauth/index.md#oauth-callback-checklist) を参照する
+5. provider ごとの実装差分を確認する
+   - 共通手順: [OAuth設定ガイド（Callback確認の共通チェックリスト）](../guides/oauth/index.md#oauth-callback-checklist)
+   - provider 別手順: [OAuth設定ガイド（対応プロバイダー）](../guides/oauth/index.md#対応プロバイダー)
+6. 導線確認として、導入前提は [installation](../installation.md#oauth-導入前の3点チェック) を参照する
 
 | 観測シグナル | 主な原因 | 対処 |
 | --- | --- | --- |
 | `redirect_uri_changed=True` かつ provider 設定と不一致 | スキーム/ポート/末尾スラッシュ差異 | provider 設定と `API_URL` を一致させる |
 | `provider_error` に `redirect_uri_mismatch` を含む | callback URL の登録漏れ | provider 側に callback URI を追加 |
-| `provider_error` が `invalid_client` へ遷移 | credentials 不整合 | `client_id` / `client_secret` を再確認 |
-
----
-
-### `redirect_uri_mismatch`（正規化差分の診断）
-
-**症状:** OAuth callback が `400` で失敗し、provider 側の `redirect_uri_mismatch` が疑われる
-
-**確認手順:**
-
-1. API ログで code exchange 失敗ログを抽出
-   ```bash
-   docker compose logs api --since=30m | rg -n "OAuth code exchange failed|redirect_uri_mismatch"
-   ```
-2. 次のログ項目を比較
-   - `redirect_uri_raw`: 実際に送信した URI（機密値はマスク）
-   - `redirect_uri_normalized`: スキーム/ホスト小文字化、既定ポート除去、query 整列後の URI（機密値はマスク）
-   - `redirect_uri_changed`: 正規化前後で差分があったか
-3. provider 側設定の callback URI と `redirect_uri_normalized` を突き合わせる
-
-| 観測シグナル | 主な原因 | 対処 |
-| --- | --- | --- |
-| `redirect_uri_changed=True` かつ provider 設定と不一致 | スキーム/ポート/末尾スラッシュ差異 | provider 設定と `API_URL` を一致させる |
-| `provider_error` に `redirect_uri_mismatch` を含む | callback URL の登録漏れ | provider 側に callback URI を追加 |
-| `provider_error` が `invalid_client` へ遷移 | credentials 不整合 | `client_id` / `client_secret` を再確認 |
+| `provider_error` が `invalid_client` へ遷移 | credentials 不整合 | `client_id` / `client_secret` を再確認し、[`401 Unauthorized` / `invalid_client`](#401-unauthorized--invalid_client) の手順へ移る |
 
 ---
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -623,6 +623,7 @@ rg -n "/api/v1/auth/\\{provider\\}/callback|invalid_client|Invalid or expired st
 2. [クイックスタート](getting-started.md#4-動作確認)で API 到達性を確認する
 3. [トラブルシューティング: 障害時の参照順（最短導線）](help/troubleshooting.md#障害時の参照順最短導線) で `health -> auth -> provider -> webhook` の順に切り分ける
 4. `auth` / `provider` で詰まった場合は [state mismatch](help/troubleshooting.md#state-mismatch-flow) と [`401 Unauthorized` / `invalid_client`](help/troubleshooting.md#401-unauthorized--invalid_client) を順に確認する
+5. callback URL 不一致が疑われる場合は [redirect_uri_mismatch（callback URL 不一致の診断フロー）](help/troubleshooting.md#oauth-callback-url-mismatch) を参照する
 
 ## セルフホスト向け秘密情報配置例
 


### PR DESCRIPTION
## 概要
- `docs/help/troubleshooting.md` の `redirect_uri_mismatch` 節を1つに統合し、callback URL 不一致の診断フローを明確化
- provider ガイド導線を強化（共通チェックリスト / 対応プロバイダー）
- `docs/help/faq.md` と `docs/installation.md` から新フローへの参照を追加し、三点同期を更新

## 変更ファイル
- docs/help/troubleshooting.md
- docs/help/faq.md
- docs/installation.md

## 検証
- `rg -n "oauth-callback-url-mismatch|redirect_uri_mismatch|401 Unauthorized / invalid_client|state mismatch" docs/help/troubleshooting.md docs/help/faq.md docs/installation.md`
- `rg -n "guides/oauth/index.md#oauth-callback-checklist|guides/oauth/index.md#対応プロバイダー|help/troubleshooting.md#oauth-callback-url-mismatch" docs/help/troubleshooting.md docs/help/faq.md docs/installation.md docs/guides/oauth/index.md`

Closes #341
