### PR TITLE
Improve invalid bool env parse diagnostics

### DIFF
--- a/api/app/config.py
+++ b/api/app/config.py
@@ -46,7 +46,10 @@ def parse_bool_env(name: str, default: bool = False) -> bool:
         return False
 
     allowed_values = "1,true,yes,0,false,no"
-    raise ValueError(f"Invalid boolean value for {name}: '{raw}'. Allowed values: {allowed_values}")
+    raise ValueError(
+        f"Invalid boolean value for {name}: raw={raw!r}, normalized={normalized!r}. "
+        f"Allowed values: {allowed_values} (case-insensitive, surrounding whitespace is ignored)."
+    )
 
 
 class Settings:

--- a/api/tests/test_config.py
+++ b/api/tests/test_config.py
@@ -103,8 +103,19 @@ def test_parse_bool_env_raises_clear_error_on_invalid_value(monkeypatch):
         assert False, "ValueError was not raised for invalid boolean value"
     except ValueError as exc:
         message = str(exc)
-        assert "Invalid boolean value for TESTING: 'maybe'" in message
+        assert "Invalid boolean value for TESTING: raw='maybe', normalized='maybe'" in message
         assert "Allowed values: 1,true,yes,0,false,no" in message
+
+
+def test_parse_bool_env_raises_with_raw_and_normalized_value(monkeypatch):
+    monkeypatch.setenv("TESTING", "  ON  ")
+
+    with pytest.raises(ValueError) as exc_info:
+        parse_bool_env("TESTING")
+
+    message = str(exc_info.value)
+    assert "raw='  ON  '" in message
+    assert "normalized='on'" in message
 
 
 def test_resolve_cors_origins_raises_when_empty_element_is_present():


### PR DESCRIPTION
## Summary
- improve invalid boolean environment-variable error text with both raw and normalized values
- keep accepted boolean values and behavior unchanged to preserve compatibility
- add a regression test that verifies space/case-normalized invalid input is reported clearly

## Test
- uv run --python 3.11 --with-requirements requirements.txt pytest -q tests/test_config.py -k parse_bool_env

Closes #378