### PR TITLE
fix: webhook retry上限到達時の監査ログ検証を強化

### DIFF
--- a/api/app/webhooks/worker.py
+++ b/api/app/webhooks/worker.py
@@ -177,10 +177,16 @@ class WebhookWorker:
                 break
 
         if not result.success:
+            failure_reason = result.error_message or (
+                f"http_status_{result.http_status}"
+                if result.http_status is not None
+                else "unknown_error"
+            )
             logger.error(
                 (
                     "%s delivery_id=%s endpoint_id=%s event_id=%s attempts=%d "
-                    "max_attempts=%d signature_algo=%s http_status=%s error=%s"
+                    "max_attempts=%d failure_reason=%s signature_algo=%s "
+                    "http_status=%s error=%s"
                 ),
                 MAX_RETRY_EXHAUSTED_LOG_KEY,
                 delivery_id,
@@ -188,6 +194,7 @@ class WebhookWorker:
                 event.event_id,
                 result.attempt_count,
                 max_retries + 1,
+                failure_reason,
                 result.signature_algorithm,
                 result.http_status,
                 result.error_message,

--- a/api/tests/test_webhook_worker.py
+++ b/api/tests/test_webhook_worker.py
@@ -4,6 +4,7 @@ import re
 import uuid
 from unittest.mock import AsyncMock, call, patch
 
+import httpx
 import pytest
 from hypothesis import given, settings
 from hypothesis import strategies as st
@@ -270,7 +271,10 @@ class TestWebhookWorkerRetry:
         assert f"endpoint_id={sample_endpoint.id}" in exhausted_log
         assert f"event_id={sample_event.event_id}" in exhausted_log
         assert "attempts=3" in exhausted_log
+        assert "max_attempts=3" in exhausted_log
+        assert "failure_reason=Server Error" in exhausted_log
         assert "signature_algo=sha256" in exhausted_log
+        assert "http_status=500" in exhausted_log
         assert "error=Server Error" in exhausted_log
 
     @pytest.mark.asyncio
@@ -310,6 +314,46 @@ class TestWebhookWorkerRetry:
         assert result.success is False
         assert result.attempt_count == 5
         assert mock_sleep.await_args_list == [call(10), call(15), call(15), call(15)]
+
+    @pytest.mark.asyncio
+    async def test_logs_retry_exhausted_timeout_reason(
+        self,
+        caplog,
+        sample_endpoint,
+        sample_event,
+        sample_config,
+    ):
+        """タイムアウト時の exhausted ログに失敗理由と試行回数を残す。"""
+        worker = WebhookWorker()
+
+        with (
+            patch(
+                "app.webhooks.worker.WebhookConfigLoader.get_config",
+                return_value=sample_config,
+            ),
+            patch("httpx.AsyncClient") as mock_client_class,
+            caplog.at_level("ERROR", logger="app.webhooks.worker"),
+        ):
+            mock_client = AsyncMock()
+            mock_client.post = AsyncMock(side_effect=httpx.TimeoutException("timeout"))
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=None)
+            mock_client_class.return_value = mock_client
+
+            result = await worker._deliver_to_endpoint(sample_event, sample_endpoint)
+
+        assert result.success is False
+        assert result.attempt_count == 3
+        exhausted_log = next(
+            record.getMessage()
+            for record in caplog.records
+            if MAX_RETRY_EXHAUSTED_LOG_KEY in record.getMessage()
+        )
+        assert "attempts=3" in exhausted_log
+        assert "max_attempts=3" in exhausted_log
+        assert "failure_reason=Request timeout" in exhausted_log
+        assert "http_status=None" in exhausted_log
+        assert "error=Request timeout" in exhausted_log
 
 
 class TestWebhookWorkerOrdering:

--- a/docs/api/webhooks.md
+++ b/docs/api/webhooks.md
@@ -134,6 +134,21 @@ POST /api/v1/admin/webhooks/reload
 
 ---
 
+## 再試行上限到達時の監査ログ
+
+Webhook 配信が再試行上限に到達した場合、ワーカーは固定キー
+`webhook_delivery_retry_exhausted` を含むエラーログを出力します。
+
+最低限、次の key-value を確認してください。
+
+- `attempts`: 実際に試行した回数
+- `max_attempts`: 設定上の最大試行回数
+- `failure_reason`: 失敗理由（HTTP エラー本文または `Request timeout` など）
+- `http_status`: HTTP ステータス（取得できない場合は `None`）
+- `endpoint_id` / `event_id`: 影響範囲の追跡キー
+
+---
+
 ## 署名検証エラー分類
 
 受信側の署名検証では、以下の `failure_reason` を固定値として扱うことを推奨します。


### PR DESCRIPTION
## 概要
- retry 上限到達ログに `failure_reason` を追加し、試行回数・上限回数・HTTP情報と合わせて追跡可能化
- webhook worker テストを拡張し、5xx と timeout の exhausted ログ検証を追加
- Webhook API ドキュメントに固定ログキー `webhook_delivery_retry_exhausted` と確認項目を追記

## テスト
- `cd api && uv run --with-requirements requirements.txt pytest tests -k "webhook and worker"`

Closes #383
