### PR TITLE
fix: refresh失敗監査ログキーを統一

### DIFF
--- a/api/app/auth/router.py
+++ b/api/app/auth/router.py
@@ -149,6 +149,14 @@ def _missing_oauth_callback_params_reason(
     )
 
 
+def _build_refresh_failure_audit_details(token_status: str) -> dict[str, str]:
+    """Build stable audit log keys for refresh failures."""
+    return {
+        "failure_reason": "invalid_or_expired_refresh_token",
+        "token_status": token_status,
+    }
+
+
 def _normalize_callback_url(url: str) -> str:
     """Normalize callback URL by dropping only trailing slash and query/fragment."""
     parsed = urlsplit(url)
@@ -1161,7 +1169,7 @@ async def refresh_tokens(
             db,
             AuthEventType.TOKEN_REFRESH_FAILED,
             None,
-            {"reason": "Invalid or expired token", "token_status": token_status},
+            _build_refresh_failure_audit_details(token_status),
             ip_address,
             device_info,
         )

--- a/api/tests/test_auth_refresh.py
+++ b/api/tests/test_auth_refresh.py
@@ -214,7 +214,7 @@ async def test_refresh_rejects_revoked_session_token(
 async def test_refresh_reuse_logs_revoked_token_status(
     client: AsyncClient, db_session: AsyncSession
 ):
-    """Reusing a rotated refresh token should log token_status=revoked."""
+    """Reusing a rotated refresh token should log stable failure keys."""
     user = User()
     user.emails.append(
         UserEmail(
@@ -248,7 +248,7 @@ async def test_refresh_reuse_logs_revoked_token_status(
     failed_call = mock_log_event.await_args_list[1]
     assert failed_call.args[2] is None
     assert failed_call.args[3] == {
-        "reason": "Invalid or expired token",
+        "failure_reason": "invalid_or_expired_refresh_token",
         "token_status": "revoked",
     }
 

--- a/docs/api/auth.md
+++ b/docs/api/auth.md
@@ -205,6 +205,13 @@ Content-Type: application/json
 
 詳細な切り分け手順は [`トラブルシューティング > 認証エラー`](../help/troubleshooting.md#認証エラー) を参照してください。
 
+`AuthEventType.TOKEN_REFRESH_FAILED` の監査ログ詳細は次のキーで固定します。
+
+| キー | 例 | 説明 |
+| --- | --- | --- |
+| `failure_reason` | `invalid_or_expired_refresh_token` | refresh 失敗の大分類（固定値） |
+| `token_status` | `not_found` / `revoked` / `expired` | 失敗 token の分類 |
+
 ### refresh token 無効時の再認証導線（`401 Invalid or expired refresh token`）
 
 `POST /api/v1/auth/refresh` が `401` かつ `Invalid or expired refresh token` を返した場合は、次の順序で復旧します。


### PR DESCRIPTION
## 概要
- refresh失敗時の監査ログ詳細キーを `failure_reason` / `token_status` に統一
- 監査ログ生成を helper 化してキー定義を一箇所に集約
- refresh異常系テストと API ドキュメントを同じキーに更新

## テスト
- `uv run --python 3.11 python -m pytest -q tests/test_auth_refresh.py::test_refresh_reuse_logs_revoked_token_status tests/test_auth_refresh.py::test_refresh_rejects_invalid_token`
- `uv run --python 3.11 python -m pytest -q tests/test_auth_logout.py::test_logout_without_auth_returns_401`

## 影響
- OAuth/セッション障害時の監査ログ解析を機械処理しやすくし、セルフホスト運用時の切り分け時間を短縮
- OSS利用者向け `docs/api/auth.md` の監査ログキー記載と実装の差異を解消
