### PR TITLE
test: webhook retry jitter calculation coverage

### DIFF
--- a/api/app/webhooks/config.py
+++ b/api/app/webhooks/config.py
@@ -41,6 +41,7 @@ class WebhookSettings:
     max_retries: int = 5
     retry_base_delay_seconds: int = 2
     retry_max_delay_seconds: int = 60
+    retry_jitter_ratio: float = 0.0
     delivery_timeout_seconds: int = 30
     log_retention_days: int = 30
 
@@ -95,6 +96,7 @@ class WebhookConfigLoader:
             max_retries=settings_data.get("max_retries", 5),
             retry_base_delay_seconds=settings_data.get("retry_base_delay_seconds", 2),
             retry_max_delay_seconds=settings_data.get("retry_max_delay_seconds", 60),
+            retry_jitter_ratio=float(settings_data.get("retry_jitter_ratio", 0.0)),
             delivery_timeout_seconds=settings_data.get("delivery_timeout_seconds", 30),
             log_retention_days=settings_data.get("log_retention_days", 30),
         )
@@ -124,6 +126,11 @@ class WebhookConfigLoader:
                 "settings.retry_max_delay_seconds must be greater than or equal to "
                 "settings.retry_base_delay_seconds"
             )
+        retry_jitter_ratio = settings_data.get("retry_jitter_ratio", 0.0)
+        if not isinstance(retry_jitter_ratio, int | float):
+            raise ValueError("settings.retry_jitter_ratio must be a number")
+        if retry_jitter_ratio < 0 or retry_jitter_ratio > 1:
+            raise ValueError("settings.retry_jitter_ratio must be in range [0, 1]")
 
         retry_backoff_ms = settings_data.get("retry_backoff_ms")
         if retry_backoff_ms is None:

--- a/api/app/webhooks/worker.py
+++ b/api/app/webhooks/worker.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import random
 import time
 import uuid
 from dataclasses import dataclass
@@ -124,6 +125,7 @@ class WebhookWorker:
         max_retries = config.settings.max_retries
         base_delay = config.settings.retry_base_delay_seconds
         max_delay = config.settings.retry_max_delay_seconds
+        jitter_ratio = config.settings.retry_jitter_ratio
         timeout = config.settings.delivery_timeout_seconds
         delivery_id = uuid.uuid4()
 
@@ -133,13 +135,17 @@ class WebhookWorker:
             result.attempt_count = attempt + 1
 
             if attempt > 0:
-                # Exponential backoff
                 raw_delay = base_delay * (2 ** (attempt - 1))
-                delay = min(raw_delay, max_delay)
+                delay = self._calculate_retry_delay(
+                    attempt=attempt,
+                    base_delay=base_delay,
+                    max_delay=max_delay,
+                    jitter_ratio=jitter_ratio,
+                )
                 logger.info(
                     (
                         "Retrying webhook delivery to %s (attempt %d/%d) after %ds "
-                        "(raw_delay=%ds, max_delay=%ds)"
+                        "(raw_delay=%ds, max_delay=%ds, jitter_ratio=%.3f)"
                     ),
                     endpoint.id,
                     attempt + 1,
@@ -147,6 +153,7 @@ class WebhookWorker:
                     delay,
                     raw_delay,
                     max_delay,
+                    jitter_ratio,
                 )
                 await asyncio.sleep(delay)
 
@@ -204,6 +211,26 @@ class WebhookWorker:
         await self._log_delivery(delivery_id, event, endpoint, result)
 
         return result
+
+    @staticmethod
+    def _calculate_retry_delay(
+        attempt: int,
+        base_delay: int,
+        max_delay: int,
+        jitter_ratio: float,
+    ) -> int:
+        """Calculate retry delay with capped exponential backoff and bounded jitter."""
+        raw_delay = base_delay * (2 ** (attempt - 1))
+        capped_delay = min(raw_delay, max_delay)
+        if jitter_ratio <= 0 or capped_delay <= 0:
+            return capped_delay
+
+        jitter_span = int(capped_delay * jitter_ratio)
+        if jitter_span <= 0:
+            return capped_delay
+
+        jitter = random.randint(-jitter_span, jitter_span)
+        return max(0, min(max_delay, capped_delay + jitter))
 
     async def _attempt_delivery(
         self,

--- a/api/tests/test_webhook_config.py
+++ b/api/tests/test_webhook_config.py
@@ -528,3 +528,32 @@ class TestWebhookConfigValidation:
                     WebhookConfigLoader.load()
         finally:
             config_path.unlink()
+
+    @pytest.mark.parametrize("invalid_jitter_ratio", [-0.1, 1.1, "0.5"])
+    def test_retry_jitter_ratio_invalid_raises_startup_error(self, invalid_jitter_ratio):
+        """retry_jitter_ratio が範囲外または非数値なら設定エラーにする。"""
+        config = {
+            "endpoints": [
+                {
+                    "id": "test-endpoint",
+                    "url": "https://example.com/webhook",
+                    "secret": "secret",
+                    "events": ["user.created"],
+                }
+            ],
+            "settings": {
+                "retry_jitter_ratio": invalid_jitter_ratio,
+            },
+        }
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            yaml.dump(config, f)
+            config_path = Path(f.name)
+
+        try:
+            with patch.object(config_module, "CONFIG_PATH", config_path):
+                WebhookConfigLoader._config = None
+                with pytest.raises(ValueError, match="settings\\.retry_jitter_ratio"):
+                    WebhookConfigLoader.load()
+        finally:
+            config_path.unlink()

--- a/api/tests/test_webhook_worker.py
+++ b/api/tests/test_webhook_worker.py
@@ -118,6 +118,38 @@ class TestWebhookWorkerRetry:
             assert delays[i] >= delays[i - 1]
             assert delays[i] == base_delay * (2**i)
 
+    def test_calculate_retry_delay_without_jitter(self):
+        """ジッタ比率0では従来どおりの指数バックオフ遅延を返す。"""
+        delay = WebhookWorker._calculate_retry_delay(
+            attempt=3,
+            base_delay=2,
+            max_delay=60,
+            jitter_ratio=0.0,
+        )
+        assert delay == 8
+
+    def test_calculate_retry_delay_with_jitter_is_bounded(self):
+        """ジッタ付き遅延は [0, max_delay] の範囲に収まる。"""
+        with patch("app.webhooks.worker.random.randint", return_value=5):
+            delay = WebhookWorker._calculate_retry_delay(
+                attempt=2,
+                base_delay=10,
+                max_delay=25,
+                jitter_ratio=0.5,
+            )
+        assert delay == 25
+
+    def test_calculate_retry_delay_with_negative_jitter_is_non_negative(self):
+        """負方向ジッタでも遅延は負値にならない。"""
+        with patch("app.webhooks.worker.random.randint", return_value=-10):
+            delay = WebhookWorker._calculate_retry_delay(
+                attempt=1,
+                base_delay=1,
+                max_delay=10,
+                jitter_ratio=1.0,
+            )
+        assert delay == 0
+
     @pytest.mark.asyncio
     async def test_no_retry_on_4xx(self, sample_endpoint, sample_event, sample_config):
         """Test that 4xx errors don't trigger retries."""

--- a/docs/guides/webhooks.md
+++ b/docs/guides/webhooks.md
@@ -50,6 +50,8 @@ settings:
   max_retries: 5
   retry_base_delay_seconds: 2
   retry_max_delay_seconds: 60
+  # 任意: ジッタ比率（0.0-1.0）。未指定または0でジッタ無効
+  retry_jitter_ratio: 0.0
   # 任意: 再送バックオフを明示する場合は非負・単調増加（ms）
   retry_backoff_ms: [500, 1000, 2000]
   delivery_timeout_seconds: 30


### PR DESCRIPTION
## 概要
- `WebhookWorker` に再試行遅延計算ヘルパーを追加（指数バックオフ + 上限 + 任意ジッタ）
- `retry_jitter_ratio` 設定（既定 0.0）を追加し、既定動作は従来互換
- ジッタ計算のユニットテストと設定バリデーションテストを追加

## テスト
- `cd api && uv run pytest -q tests/test_webhook_worker.py tests/test_webhook_signer.py`
- `cd api && uv run pytest -q tests/test_webhook_config.py -k jitter_ratio`

## 影響
- OAuth 導入容易化/セルフホスト運用性: Webhook再送の調整パラメータを明示化し、障害時の切り分けを容易化
- OSS 向けドキュメント: `docs/guides/webhooks.md` に設定例を追記
