### PR TITLE
fix: admin i18n 未翻訳キー fallback を en へ統一 (fix #387)

### DIFF
--- a/admin/i18n.py
+++ b/admin/i18n.py
@@ -21,6 +21,9 @@ _translations_cache: dict[str, dict] = {}
 logger = logging.getLogger(__name__)
 
 
+_MISSING = object()
+
+
 def _resolve_language(lang: str) -> str:
     """Resolve language code to a safe supported value."""
     normalized = (lang or "").strip().lower()
@@ -59,6 +62,17 @@ def _load_translations(lang: str) -> dict:
         return {}
 
 
+def _resolve_key(translations: dict[str, Any], key: str) -> Any:
+    """Resolve a dot-notated key from nested translations."""
+    value: Any = translations
+    for part in key.split("."):
+        if isinstance(value, dict) and part in value:
+            value = value[part]
+        else:
+            return _MISSING
+    return value
+
+
 def get_text(key: str, lang: str = DEFAULT_LANGUAGE, **kwargs: Any) -> str:
     """Get translated text by key.
 
@@ -70,18 +84,17 @@ def get_text(key: str, lang: str = DEFAULT_LANGUAGE, **kwargs: Any) -> str:
     Returns:
         Translated string, or the key if not found
     """
-    translations = _load_translations(lang)
+    resolved_lang = _resolve_language(lang)
+    translations = _load_translations(resolved_lang)
+    value = _resolve_key(translations, key)
 
-    # Navigate nested keys
-    keys = key.split(".")
-    value: Any = translations
+    # Fallback to default language when key is untranslated in the selected locale.
+    if value is _MISSING and resolved_lang != DEFAULT_LANGUAGE:
+        default_translations = _load_translations(DEFAULT_LANGUAGE)
+        value = _resolve_key(default_translations, key)
 
-    for k in keys:
-        if isinstance(value, dict) and k in value:
-            value = value[k]
-        else:
-            # Key not found, return the key itself
-            return key
+    if value is _MISSING:
+        return key
 
     if isinstance(value, str):
         # Apply format arguments if provided

--- a/admin/tests/test_i18n.py
+++ b/admin/tests/test_i18n.py
@@ -1,5 +1,6 @@
 """Tests for admin i18n fallback behavior."""
 import unittest
+from unittest.mock import patch
 
 from i18n import Translator, get_text
 
@@ -21,6 +22,30 @@ class I18nFallbackTests(unittest.TestCase):
     def test_known_locale_is_not_affected(self) -> None:
         self.assertEqual(get_text("nav.overview", "ja"), "📊 概要")
         self.assertEqual(Translator("ja").lang, "ja")
+
+    def test_untranslated_key_falls_back_to_default_language(self) -> None:
+        mock_catalog = {
+            "ja": {"nav": {"overview": "📊 概要"}},
+            "en": {
+                "nav": {"overview": "📊 Overview"},
+                "messages": {"greeting": "Hello {name}"},
+            },
+        }
+
+        with patch("i18n._load_translations", side_effect=lambda lang: mock_catalog[lang]):
+            self.assertEqual(
+                get_text("messages.greeting", "ja", name="Alice"),
+                "Hello Alice",
+            )
+
+    def test_missing_key_in_all_locales_returns_key(self) -> None:
+        mock_catalog = {
+            "ja": {"nav": {"overview": "📊 概要"}},
+            "en": {"nav": {"overview": "📊 Overview"}},
+        }
+
+        with patch("i18n._load_translations", side_effect=lambda lang: mock_catalog[lang]):
+            self.assertEqual(get_text("messages.unknown", "ja"), "messages.unknown")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 概要
- `admin/i18n.py` に未翻訳キー時のフォールバックを追加（選択言語 -> `en`）
- 既存の不正ロケール fallback は維持
- 未翻訳キー fallback と全言語未定義時の key 返却をテストで固定

## テスト
- `PYTHONPATH=admin python3 -m unittest admin/tests/test_i18n.py -v`
- `uv run --project api --with pytest --with-requirements api/requirements.txt pytest -q api/tests/test_auth_rate_limit_provider_path.py`

## 影響
- OAuth 導入/セルフホスト運用時に、部分翻訳の文言欠落で生キー表示されるケースを低減
- OSS 利用者向けドキュメントやUI確認時の再現性を向上
