### PR TITLE
fix: 起動時にOAuth providerの重複client_idを検知する

### DIFF
--- a/api/app/config.py
+++ b/api/app/config.py
@@ -3,7 +3,7 @@
 import os
 from functools import lru_cache
 
-from app.oauth_providers import OAUTH_PROVIDER_CREDENTIAL_KEYS
+from app.oauth_providers import OAUTH_PROVIDER_CREDENTIAL_FIELDS, OAUTH_PROVIDER_CREDENTIAL_KEYS
 
 DEFAULT_CORS_ORIGINS = "http://localhost:3000,http://localhost:5173"
 TRUE_VALUES = {"1", "true", "yes"}
@@ -123,6 +123,7 @@ class Settings:
 
     def __init__(self) -> None:
         self._validate_oauth_provider_secrets()
+        self._validate_oauth_provider_client_ids_are_unique()
 
     def _validate_oauth_provider_secrets(self) -> None:
         for client_id_key, client_secret_key in OAUTH_PROVIDER_CREDENTIAL_KEYS:
@@ -132,6 +133,29 @@ class Settings:
                 raise ValueError(
                     f"OAuth provider secret is empty. Set non-empty value for {client_secret_key}."
                 )
+
+    def _validate_oauth_provider_client_ids_are_unique(self) -> None:
+        normalized_client_id_providers: dict[str, list[str]] = {}
+
+        for provider, credential_keys in OAUTH_PROVIDER_CREDENTIAL_FIELDS.items():
+            client_id_key, _ = credential_keys
+            client_id = str(getattr(self, client_id_key, "")).strip()
+            if not client_id:
+                continue
+            normalized = client_id.casefold()
+            normalized_client_id_providers.setdefault(normalized, []).append(provider)
+
+        duplicate_provider_groups = sorted(
+            sorted(providers)
+            for providers in normalized_client_id_providers.values()
+            if len(providers) > 1
+        )
+        if duplicate_provider_groups:
+            duplicate_message = ", ".join("/".join(providers) for providers in duplicate_provider_groups)
+            raise ValueError(
+                "OAuth provider client_id is duplicated across enabled providers. "
+                f"Resolve duplicates for: {duplicate_message}."
+            )
 
 
 @lru_cache

--- a/api/tests/test_config.py
+++ b/api/tests/test_config.py
@@ -176,6 +176,28 @@ def test_settings_allows_when_provider_secret_is_non_empty(monkeypatch):
     assert settings.GITHUB_CLIENT_SECRET == "github-client-secret"
 
 
+def test_settings_raises_when_provider_client_id_is_duplicated(monkeypatch):
+    monkeypatch.setattr(Settings, "GITHUB_CLIENT_ID", "shared-client-id")
+    monkeypatch.setattr(Settings, "GITHUB_CLIENT_SECRET", "github-client-secret")
+    monkeypatch.setattr(Settings, "GOOGLE_CLIENT_ID", "shared-client-id")
+    monkeypatch.setattr(Settings, "GOOGLE_CLIENT_SECRET", "google-client-secret")
+
+    with pytest.raises(ValueError, match="duplicated across enabled providers"):
+        Settings()
+
+
+def test_settings_allows_when_provider_client_ids_are_unique(monkeypatch):
+    monkeypatch.setattr(Settings, "GITHUB_CLIENT_ID", "github-client-id")
+    monkeypatch.setattr(Settings, "GITHUB_CLIENT_SECRET", "github-client-secret")
+    monkeypatch.setattr(Settings, "GOOGLE_CLIENT_ID", "google-client-id")
+    monkeypatch.setattr(Settings, "GOOGLE_CLIENT_SECRET", "google-client-secret")
+
+    settings = Settings()
+
+    assert settings.GITHUB_CLIENT_ID == "github-client-id"
+    assert settings.GOOGLE_CLIENT_ID == "google-client-id"
+
+
 def test_settings_startup_fails_when_provider_secret_env_is_empty():
     env = os.environ.copy()
     env["GITHUB_CLIENT_ID"] = "github-client-id"


### PR DESCRIPTION
## 概要
- `Settings` 初期化時に、OAuth provider 間で同一 `CLIENT_ID` が重複している場合は起動時 `ValueError` を返す検証を追加
- 既存の secret 空値検証に加えて、`client_id` の重複構成ミスを早期に検知できるよう改善
- `api/tests/test_config.py` に重複ケース/非重複ケースの回帰テストを追加

## 背景への対応
- OAuth 導入容易化: provider設定ミスを起動時に明確化し、導入時の切り分け時間を短縮
- セルフホスト運用性: 実行前に設定不備を失敗として固定し、誤設定のまま稼働するリスクを低減
- OSS 運用: テストで挙動を固定し、将来変更時の回帰を防止

## テスト
- `uv run --python 3.11 --with-requirements api/requirements.txt pytest -q api/tests/test_config.py api/tests/test_auth_provider_registry.py`
