### PR TITLE
fix: unsupported webhook event_type を 422 に統一

### DIFF
--- a/api/app/webhooks/router.py
+++ b/api/app/webhooks/router.py
@@ -14,6 +14,15 @@ from app.webhooks.schemas import (
 )
 
 router = APIRouter(prefix="/webhooks", tags=["webhooks-admin"])
+SUPPORTED_WEBHOOK_EVENT_TYPES = (
+    "user.created",
+    "user.updated",
+    "user.deleted",
+    "user.login",
+    "user.oauth_linked",
+    "user.oauth_unlinked",
+)
+UNSUPPORTED_WEBHOOK_EVENT_TYPE_CODE = "unsupported_event_type"
 
 
 @router.post("/reload", response_model=WebhookReloadResponse)
@@ -67,6 +76,17 @@ async def list_deliveries(
 
     Returns delivery history with status, latency, and error details.
     """
+    if event_type and event_type not in SUPPORTED_WEBHOOK_EVENT_TYPES:
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "code": UNSUPPORTED_WEBHOOK_EVENT_TYPE_CODE,
+                "message": "Unsupported webhook event_type",
+                "event_type": event_type,
+                "supported_event_types": list(SUPPORTED_WEBHOOK_EVENT_TYPES),
+            },
+        )
+
     query = select(WebhookDelivery).order_by(desc(WebhookDelivery.created_at))
 
     if event_type:

--- a/api/tests/test_webhooks_router_event_type_validation.py
+++ b/api/tests/test_webhooks_router_event_type_validation.py
@@ -1,0 +1,39 @@
+"""Webhook admin router event_type validation tests."""
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_list_deliveries_rejects_unsupported_event_type(client):
+    response = await client.get(
+        "/api/v1/admin/webhooks/deliveries",
+        params={"event_type": "user.unknown"},
+    )
+
+    assert response.status_code == 422
+    assert response.json() == {
+        "detail": {
+            "code": "unsupported_event_type",
+            "message": "Unsupported webhook event_type",
+            "event_type": "user.unknown",
+            "supported_event_types": [
+                "user.created",
+                "user.updated",
+                "user.deleted",
+                "user.login",
+                "user.oauth_linked",
+                "user.oauth_unlinked",
+            ],
+        }
+    }
+
+
+@pytest.mark.asyncio
+async def test_list_deliveries_allows_supported_event_type(client):
+    response = await client.get(
+        "/api/v1/admin/webhooks/deliveries",
+        params={"event_type": "user.created"},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == []

--- a/docs/api/webhooks.md
+++ b/docs/api/webhooks.md
@@ -38,6 +38,26 @@ GET /api/v1/admin/webhooks/endpoints
 GET /api/v1/admin/webhooks/deliveries
 ```
 
+`event_type` に未対応値を指定した場合は `422` を返します。
+
+```json
+{
+  "detail": {
+    "code": "unsupported_event_type",
+    "message": "Unsupported webhook event_type",
+    "event_type": "user.unknown",
+    "supported_event_types": [
+      "user.created",
+      "user.updated",
+      "user.deleted",
+      "user.login",
+      "user.oauth_linked",
+      "user.oauth_unlinked"
+    ]
+  }
+}
+```
+
 **レスポンス:**
 
 ```json


### PR DESCRIPTION
## 概要
- `/api/v1/admin/webhooks/deliveries` の `event_type` に未対応値が来たとき、HTTP 422 を返すバリデーションを追加
- エラーボディを `code` / `message` / `event_type` / `supported_event_types` に統一
- 422 応答の API ドキュメントを追記

## テスト
- `uv run --python 3.11 --with-requirements api/requirements.txt pytest api/tests/test_webhooks_router_event_type_validation.py api/tests/test_webhook_delivery.py`

Closes #403
