### PR TITLE
fix: unify JWT kid-missing error classification (#427)

### DIFF
--- a/api/tests/test_users_me_auth.py
+++ b/api/tests/test_users_me_auth.py
@@ -82,3 +82,45 @@ async def test_users_me_rejects_token_without_kid_header(client: AsyncClient):
             "token_header_fields": ["alg", "typ"],
         }
     }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("jwt_headers", "expected_header_fields"),
+    [
+        ({"kid": ""}, ["alg", "kid", "typ"]),
+        ({"kid": 123}, ["alg", "kid", "typ"]),
+    ],
+)
+async def test_users_me_rejects_token_with_invalid_kid_header_value(
+    client: AsyncClient,
+    jwt_headers: dict[str, object],
+    expected_header_fields: list[str],
+):
+    """GET /api/v1/users/me keeps invalid_token_header for invalid kid values."""
+    settings = get_settings()
+    token = jwt.encode(
+        {
+            "sub": "00000000-0000-0000-0000-000000000001",
+            "email": "user@example.com",
+            "exp": datetime.now(UTC) + timedelta(minutes=5),
+            "type": "access",
+        },
+        settings.JWT_SECRET,
+        algorithm=settings.JWT_ALGORITHM,
+        headers=jwt_headers,
+    )
+
+    response = await client.get(
+        "/api/v1/users/me",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert response.status_code == 401
+    assert response.json() == {
+        "detail": {
+            "code": "invalid_token_header",
+            "message": "Invalid token header",
+            "token_header_fields": expected_header_fields,
+        }
+    }

--- a/docs/api/auth.md
+++ b/docs/api/auth.md
@@ -47,6 +47,25 @@
 
 `/api/v1/auth/logout` や `/api/v1/auth/refresh` でトークン検証に失敗した場合は `401` を返します。`403` は「誰かは特定できるが、その操作は許可しない」ケースで返します。
 
+### 保護エンドポイントの JWT ヘッダー検証（`kid`）
+
+`Authorization: Bearer <access_token>` を受け取る保護エンドポイント（例: `GET /api/v1/users/me`）では、JWT ヘッダーの `kid` を必須として扱います。
+
+- `kid` 欠落、空文字、非文字列の場合: `401 Unauthorized`
+- エラー本文:
+
+```json
+{
+  "detail": {
+    "code": "invalid_token_header",
+    "message": "Invalid token header",
+    "token_header_fields": ["alg", "typ"]
+  }
+}
+```
+
+`token_header_fields` は受信 JWT ヘッダーのキー一覧（ソート済み）で、切り分け用に返されます。
+
 ---
 
 ## OAuth認証フロー


### PR DESCRIPTION
## 概要
- `kid` 欠落だけでなく、`kid` が空文字/非文字列のケースも `invalid_token_header` に統一される契約をAPIテストで固定
- 認証APIドキュメントに `kid` ヘッダー検証ルール（401 と `token_header_fields`）を追記

## 変更ファイル
- `api/tests/test_users_me_auth.py`
- `docs/api/auth.md`

## テスト
- `uv run --python 3.11 --with-requirements api/requirements.txt pytest api/tests/test_users_me_auth.py -q`

## 公開時の影響
- OAuth 導入容易化: JWT ヘッダー不備時の失敗理由が固定され、初期導入時の切り分けが容易
- セルフホスト運用性: `token_header_fields` の意味を docs に明記し、運用ログとの突合がしやすい
- OSSドキュメント整備: 認証失敗系の契約が文書化され、外部利用者が再現しやすい

Closes #427
