### PR TITLE
fix: reject non-positive webhook retry_backoff_ms at startup

### DIFF
--- a/api/app/webhooks/config.py
+++ b/api/app/webhooks/config.py
@@ -152,8 +152,8 @@ class WebhookConfigLoader:
             return
 
         if isinstance(retry_backoff_ms, int):
-            if retry_backoff_ms < 0:
-                raise ValueError("settings.retry_backoff_ms must be a non-negative integer")
+            if retry_backoff_ms <= 0:
+                raise ValueError("settings.retry_backoff_ms must be a positive integer")
             return
 
         if not isinstance(retry_backoff_ms, list) or not retry_backoff_ms:
@@ -161,9 +161,9 @@ class WebhookConfigLoader:
 
         prev_value = -1
         for idx, value in enumerate(retry_backoff_ms):
-            if not isinstance(value, int) or value < 0:
+            if not isinstance(value, int) or value <= 0:
                 raise ValueError(
-                    f"settings.retry_backoff_ms[{idx}] must be a non-negative integer"
+                    f"settings.retry_backoff_ms[{idx}] must be a positive integer"
                 )
             if idx > 0 and value < prev_value:
                 raise ValueError(

--- a/api/tests/test_webhook_config.py
+++ b/api/tests/test_webhook_config.py
@@ -487,9 +487,9 @@ class TestWebhookConfigValidation:
             default_path.unlink()
             override_path.unlink()
 
-    @pytest.mark.parametrize("invalid_backoff_ms", [-1])
-    def test_retry_backoff_ms_negative_raises_startup_error(self, invalid_backoff_ms: int):
-        """retry_backoff_ms が負値なら起動時に設定エラーとする。"""
+    @pytest.mark.parametrize("invalid_backoff_ms", [0, -1])
+    def test_retry_backoff_ms_non_positive_raises_startup_error(self, invalid_backoff_ms: int):
+        """retry_backoff_ms が 0/負値なら起動時に設定エラーとする。"""
         config = {
             "endpoints": [
                 {
@@ -520,6 +520,7 @@ class TestWebhookConfigValidation:
         ("retry_backoff_ms", "error_key"),
         [
             ([], "settings.retry_backoff_ms"),
+            ([0, 100, 300], "settings.retry_backoff_ms\\[0\\]"),
             ([100, -1, 300], "settings.retry_backoff_ms\\[1\\]"),
             ([300, 100, 500], "settings.retry_backoff_ms\\[1\\]"),
         ],
@@ -529,7 +530,7 @@ class TestWebhookConfigValidation:
         retry_backoff_ms: list[int],
         error_key: str,
     ):
-        """retry_backoff_ms 配列が非負・単調増加でなければ起動時に設定エラーとする。"""
+        """retry_backoff_ms 配列が正の整数・単調増加でなければ起動時に設定エラーとする。"""
         config = {
             "endpoints": [
                 {
@@ -557,7 +558,7 @@ class TestWebhookConfigValidation:
             config_path.unlink()
 
     def test_retry_backoff_ms_list_non_decreasing_is_accepted(self):
-        """retry_backoff_ms 配列が非負かつ単調増加なら設定を受理する。"""
+        """retry_backoff_ms 配列が正の整数かつ単調増加なら設定を受理する。"""
         config = {
             "endpoints": [
                 {

--- a/docs/guides/webhooks.md
+++ b/docs/guides/webhooks.md
@@ -52,7 +52,7 @@ settings:
   retry_max_delay_seconds: 60
   # 任意: ジッタ比率（0.0-1.0）。未指定または0でジッタ無効
   retry_jitter_ratio: 0.0
-  # 任意: 再送バックオフを明示する場合は非負・単調増加（ms）
+  # 任意: 再送バックオフを明示する場合は正の整数・単調増加（ms）
   retry_backoff_ms: [500, 1000, 2000]
   delivery_timeout_seconds: 30
 ```

--- a/docs/help/troubleshooting.md
+++ b/docs/help/troubleshooting.md
@@ -696,7 +696,7 @@ API 側の項目定義は [Webhook API: 配信履歴から障害対応へ進む�
 4. 起動時に `settings.retry_*` エラーが出る場合は設定値の関係を確認
    - `settings.retry_base_delay_seconds` と `settings.retry_max_delay_seconds` は非負整数
    - `settings.retry_max_delay_seconds >= settings.retry_base_delay_seconds`
-   - `settings.retry_backoff_ms` を配列で指定する場合は「非負・単調増加（ms）」にする
+   - `settings.retry_backoff_ms` を配列で指定する場合は「正の整数・単調増加（ms）」にする
 
 ---
 


### PR DESCRIPTION
## Summary
- `settings.retry_backoff_ms` の検証を「正の整数（0不可）」へ強化
- 配列指定時も各要素を正の整数に制限し、設定キーを含む診断メッセージで起動時エラー化
- 対象テストと Webhook ドキュメントの説明（非負→正）を同期

## Test
- `uv run --python 3.11 --with-requirements api/requirements.txt pytest api/tests/test_webhook_config.py -k retry_backoff_ms`

## Impact
- OAuth導入容易化/セルフホスト運用性: 設定ミス（`retry_backoff_ms=0`）を起動時に即検出できるため障害切り分けが容易
- OSS向け文書: Webhookバックオフ設定の許容値定義を実装と一致させ、再現性を向上

Closes #428
