### PR TITLE
fix(auth): 不正 provider エラー詳細を固定化

### DIFF
--- a/api/app/auth/router.py
+++ b/api/app/auth/router.py
@@ -89,7 +89,7 @@ def _validate_supported_oauth_provider(provider: str) -> str:
     if normalized_provider not in OAUTH_PROVIDER_CREDENTIAL_FIELDS:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Unsupported OAuth provider '{normalized_provider}'.",
+            detail="Unsupported OAuth provider 'unknown'.",
         )
     return normalized_provider
 

--- a/api/tests/test_auth_provider_response_codes.py
+++ b/api/tests/test_auth_provider_response_codes.py
@@ -8,6 +8,15 @@ from httpx import AsyncClient
 auth_router_module = importlib.import_module("app.auth.router")
 
 
+@pytest.fixture(autouse=True)
+def bypass_rate_limit(monkeypatch):
+    """Avoid external Redis dependency for endpoint contract tests."""
+    def _fake_check_request_limit(request, *args, **kwargs):
+        request.state.view_rate_limit = None
+
+    monkeypatch.setattr(auth_router_module.limiter, "_check_request_limit", _fake_check_request_limit)
+
+
 @pytest.mark.asyncio
 async def test_oauth_known_provider_disabled_returns_503(client: AsyncClient, monkeypatch):
     """Known provider with missing credentials should return 503."""
@@ -29,6 +38,15 @@ async def test_oauth_known_provider_disabled_returns_503(client: AsyncClient, mo
 async def test_oauth_unsupported_provider_path_returns_400(client: AsyncClient):
     """Unsupported provider path must return explicit 400 contract."""
     response = await client.get("/api/v1/auth/unknown", follow_redirects=False)
+
+    assert response.status_code == 400
+    assert response.json() == {"detail": "Unsupported OAuth provider 'unknown'."}
+
+
+@pytest.mark.asyncio
+async def test_oauth_unsupported_provider_path_variant_keeps_fixed_detail(client: AsyncClient):
+    """Unsupported provider case/space variants must keep fixed 400 detail."""
+    response = await client.get("/api/v1/auth/%20UnKnOwN%20", follow_redirects=False)
 
     assert response.status_code == 400
     assert response.json() == {"detail": "Unsupported OAuth provider 'unknown'."}

--- a/api/tests/test_mock_oauth.py
+++ b/api/tests/test_mock_oauth.py
@@ -43,7 +43,7 @@ async def test_mock_login_invalid_provider(client: AsyncClient):
     """Test mock login with invalid provider."""
     response = await client.get("/api/v1/auth/mock/login?provider=invalid")
     assert response.status_code == 400
-    assert response.json() == {"detail": "Unsupported OAuth provider 'invalid'."}
+    assert response.json() == {"detail": "Unsupported OAuth provider 'unknown'."}
 
 
 @pytest.mark.asyncio
@@ -52,6 +52,14 @@ async def test_mock_login_provider_is_case_insensitive(client: AsyncClient):
     response = await client.get("/api/v1/auth/mock/login?provider=GitHub")
     assert response.status_code == 200
     assert response.json()["provider"] == "github"
+
+
+@pytest.mark.asyncio
+async def test_mock_login_unknown_provider_keeps_fixed_detail(client: AsyncClient):
+    """Unknown provider variants should keep a fixed 400 detail."""
+    response = await client.get("/api/v1/auth/mock/login?provider=%20InVaLiD%20")
+    assert response.status_code == 400
+    assert response.json() == {"detail": "Unsupported OAuth provider 'unknown'."}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 概要
- unknown provider 時の 400 detail を固定文言 `Unsupported OAuth provider 'unknown'.` に統一
- mixed-case/空白付き入力でも同一 detail を返す回帰テストを追加
- provider path contract テストを Redis 非依存で実行できるように調整

## 変更ファイル
- `api/app/auth/router.py`
- `api/tests/test_mock_oauth.py`
- `api/tests/test_auth_provider_response_codes.py`

## テスト
- `uv run --python 3.11 --with-requirements api/requirements.txt pytest -q api/tests/test_auth_provider_response_codes.py api/tests/test_mock_oauth.py api/tests/test_auth_oauth_provider_disabled.py`

## 影響
- OAuth 導線で未知 provider を受けたときの監視・切り分けが入力文字列に依存せず安定
- OAuth 導入（セルフホスト含む）時の異常系運用ログの比較が容易化

Closes #445
