### PR TITLE
test: stabilize accounts unlink boundary error contracts

### DIFF
--- a/api/tests/test_accounts.py
+++ b/api/tests/test_accounts.py
@@ -24,8 +24,15 @@ async def test_list_accounts_requires_authentication(client: AsyncClient):
     [
         ("Google", "Unsupported provider"),
         (" google ", "Unsupported provider"),
+        ("github", "Unsupported provider"),
+        ("discord%09", "Unsupported provider"),
     ],
-    ids=["provider_uppercase", "provider_surrounded_by_spaces"],
+    ids=[
+        "provider_uppercase",
+        "provider_surrounded_by_spaces",
+        "provider_unsupported_literal",
+        "provider_urlencoded_tab",
+    ],
 )
 async def test_unlink_account_returns_400_for_provider_boundary_inputs(
     client: AsyncClient, db_session: AsyncSession, provider_input: str, expected_detail: str
@@ -53,6 +60,43 @@ async def test_unlink_account_returns_400_for_provider_boundary_inputs(
     assert response.status_code == 400
     data = response.json()
     assert data["detail"] == expected_detail
+
+
+@pytest.mark.asyncio
+async def test_unlink_account_returns_404_for_valid_but_unlinked_provider(
+    client: AsyncClient, db_session: AsyncSession
+):
+    """Supported provider without linked account should keep stable 404 error contract."""
+    user = User()
+    db_session.add(user)
+    await db_session.flush()
+    db_session.add(
+        OAuthAccount(
+            user_id=user.id,
+            provider="google",
+            provider_user_id="linked-google-user",
+            access_token="linked-google-token",
+        )
+    )
+    db_session.add(
+        OAuthAccount(
+            user_id=user.id,
+            provider="google",
+            provider_user_id="linked-google-user-2",
+            access_token="linked-google-token-2",
+        )
+    )
+    await db_session.commit()
+
+    access_token = create_access_token(str(user.id), "accounts-unlinked-provider@example.com")
+    response = await client.delete(
+        "/api/v1/accounts/discord",
+        headers={"Authorization": f"Bearer {access_token}"},
+    )
+
+    assert response.status_code == 404
+    data = response.json()
+    assert data["detail"] == "No discord account linked"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary\n- add two additional provider boundary inputs for unlink API and fix case naming\n- add a 404 contract test for supported but unlinked provider\n- keep existing 400 contract test for last authentication method\n\n## Test\n- uv run --python 3.11 --with-requirements api/requirements.txt pytest -q api/tests/test_accounts.py\n\nCloses #449