### PR TITLE
fix: add fail-fast preflight inventory for generate-types

### DIFF
--- a/scripts/generate-types.sh
+++ b/scripts/generate-types.sh
@@ -16,23 +16,49 @@ OUTPUT_DIR="${1:-./generated}"
 API_URL="${API_URL:-http://localhost:8000}"
 OPENAPI_URL="${API_URL}/openapi.json"
 DOC_REF="docs/api/auth.md"
+DOC_INDEX_REF="docs/index.md"
+MISSING_ITEMS=()
 
 print_help_hint() {
     echo "   次の確認手順: ${DOC_REF} を参照してください。"
 }
 
+add_missing() {
+    MISSING_ITEMS+=("$1")
+}
+
 require_cmd() {
     local cmd="$1"
     if ! command -v "${cmd}" >/dev/null 2>&1; then
-        echo "❌ Error: '${cmd}' コマンドが見つかりません"
-        echo "   復旧手順: 必要コマンドをインストール後に再実行してください。"
+        add_missing "コマンド: ${cmd}"
+    fi
+}
+
+require_file() {
+    local path="$1"
+    if [ ! -f "${path}" ]; then
+        add_missing "ファイル: ${path}"
+    fi
+}
+
+run_preflight() {
+    require_cmd curl
+    require_cmd npx
+    require_file "${DOC_REF}"
+    require_file "${DOC_INDEX_REF}"
+
+    if [ "${#MISSING_ITEMS[@]}" -gt 0 ]; then
+        echo "❌ Error: preflight check failed (不足項目あり)"
+        for item in "${MISSING_ITEMS[@]}"; do
+            echo "   - ${item}"
+        done
+        echo "   復旧手順: 不足項目を解消してから再実行してください。"
         print_help_hint
         exit 1
     fi
 }
 
-require_cmd curl
-require_cmd npx
+run_preflight
 
 echo "🔍 Fetching OpenAPI schema from ${OPENAPI_URL}..."
 


### PR DESCRIPTION
## Summary
- `scripts/generate-types.sh` の preflight を一覧型に変更し、前提不足をまとめて表示して fail-fast するようにしました。
- 既存の型生成フロー（OpenAPI 取得 -> `npx openapi-typescript`）と復旧ヒントの導線は維持しています。
- 参照ドキュメント `docs/api/auth.md` と `docs/index.md` を preflight 対象に追加しました。

## Test
- `API_URL='https://petstore3.swagger.io/api/v3' bash scripts/generate-types.sh /tmp/yesod-auth-types`
- `PATH='/usr/bin:/bin' bash scripts/generate-types.sh /tmp/yesod-auth-types` （`npx` 不足を一覧表示して fail-fast）

## Impact
- OAuth 導入容易化: 依存不足時に即時判別でき、初回導入の復旧時間を短縮。
- セルフホスト運用性: CI/ローカルの前提不足をログ1回で特定可能。
- OSS ドキュメント整備: 参照導線を維持し、公開環境でのトラブルシュートしやすさを向上。

Closes #452
