### PR TITLE
fix(sessions): stabilize revoke-all response contract

### DIFF
--- a/api/app/sessions/router.py
+++ b/api/app/sessions/router.py
@@ -12,7 +12,12 @@ from app.auth.jwt import get_current_user
 from app.db.session import get_db
 from app.models import RefreshToken, User
 
-from .schemas import RevokeResponse, SessionListResponse, SessionResponse
+from .schemas import (
+    RevokeAllSessionsResponse,
+    RevokeSessionResponse,
+    SessionListResponse,
+    SessionResponse,
+)
 
 router = APIRouter(prefix="/sessions", tags=["sessions"])
 SESSIONS_LIMIT_MAX = 1000
@@ -78,7 +83,7 @@ async def list_sessions(
     )
 
 
-@router.delete("/{session_id}", response_model=RevokeResponse)
+@router.delete("/{session_id}", response_model=RevokeSessionResponse)
 async def revoke_session(
     request: Request,
     session_id: uuid.UUID,
@@ -118,13 +123,13 @@ async def revoke_session(
         device_info,
     )
 
-    return RevokeResponse(
+    return RevokeSessionResponse(
         message="Session revoked successfully",
         session_id=session_id,
     )
 
 
-@router.delete("", response_model=RevokeResponse)
+@router.delete("", response_model=RevokeAllSessionsResponse)
 async def revoke_all_sessions(
     request: Request,
     current_user: User = Depends(get_current_user),
@@ -161,7 +166,7 @@ async def revoke_all_sessions(
         device_info,
     )
 
-    return RevokeResponse(
-        message=f"Revoked {revoked_count} sessions",
+    return RevokeAllSessionsResponse(
+        message="Sessions revoked successfully",
         revoked_count=revoked_count,
     )

--- a/api/app/sessions/schemas.py
+++ b/api/app/sessions/schemas.py
@@ -2,6 +2,7 @@
 
 import uuid
 from datetime import datetime
+from typing import Literal
 
 from pydantic import BaseModel
 
@@ -30,3 +31,19 @@ class RevokeResponse(BaseModel):
     message: str
     session_id: uuid.UUID | None = None
     revoked_count: int | None = None
+
+
+class RevokeSessionResponse(RevokeResponse):
+    """Single-session revoke response contract."""
+
+    message: Literal["Session revoked successfully"] = "Session revoked successfully"
+    session_id: uuid.UUID
+    revoked_count: None = None
+
+
+class RevokeAllSessionsResponse(RevokeResponse):
+    """Revoke-all response contract."""
+
+    message: Literal["Sessions revoked successfully"] = "Sessions revoked successfully"
+    session_id: None = None
+    revoked_count: int

--- a/api/tests/test_sessions_api.py
+++ b/api/tests/test_sessions_api.py
@@ -99,7 +99,11 @@ async def test_revoke_all_sessions_logs_audit_with_revoked_count_and_user_id(
     response = await client.delete("/api/v1/sessions", headers=auth_header)
 
     assert response.status_code == 200
-    assert response.json()["revoked_count"] == 2
+    assert response.json() == {
+        "message": "Sessions revoked successfully",
+        "session_id": None,
+        "revoked_count": 2,
+    }
     mock_log_event.assert_awaited_once()
 
     _, event_type, user_id, details, *_ = mock_log_event.await_args.args
@@ -108,3 +112,26 @@ async def test_revoke_all_sessions_logs_audit_with_revoked_count_and_user_id(
     assert details["audit_key"] == "revoked_count"
     assert details["revoked_count"] == 2
     assert details["user_id"] == str(user.id)
+
+
+@pytest.mark.asyncio
+async def test_revoke_all_sessions_without_active_tokens_returns_schema_contract(
+    client: AsyncClient, db_session: AsyncSession
+):
+    """DELETE /api/v1/sessions keeps response keys stable when revoked_count is zero."""
+    user = User()
+    db_session.add(user)
+    await db_session.commit()
+    await db_session.refresh(user)
+
+    access_token = create_access_token(str(user.id), "revoke-all-empty@example.com")
+    auth_header = {"Authorization": f"Bearer {access_token}"}
+
+    response = await client.delete("/api/v1/sessions", headers=auth_header)
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "message": "Sessions revoked successfully",
+        "session_id": None,
+        "revoked_count": 0,
+    }


### PR DESCRIPTION
## Summary
- split sessions revoke response contracts into schema-specific models (`RevokeSessionResponse` / `RevokeAllSessionsResponse`)
- normalize revoke-all success message to a stable contract string while preserving response keys
- add API regression tests to lock full revoke-all response payload, including zero-session case

## Test
- cd api && uv run --python 3.11 --with-requirements requirements.txt pytest tests/test_sessions_api.py -k revoke -q
- cd api && uv run --python 3.11 --with-requirements requirements.txt pytest tests/test_sessions.py -q

Closes #469
