### PR TITLE
fix: users更新入力の正規化境界を固定 (#470)

### DIFF
--- a/api/app/users/schemas.py
+++ b/api/app/users/schemas.py
@@ -2,8 +2,9 @@
 
 import uuid
 from datetime import datetime
+from urllib.parse import urlparse
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 
 class OAuthAccountInfo(BaseModel):
@@ -47,6 +48,29 @@ class UserUpdateRequest(BaseModel):
     avatar_url: str | None = Field(
         None, max_length=500, description="New avatar URL (max 500 characters)"
     )
+
+    @field_validator("display_name")
+    @classmethod
+    def validate_display_name(cls, value: str | None) -> str | None:
+        """Normalize display_name and reject blank-only input."""
+        if value is None:
+            return None
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("display_name must not be blank")
+        return normalized
+
+    @field_validator("avatar_url")
+    @classmethod
+    def validate_avatar_url(cls, value: str | None) -> str | None:
+        """Normalize avatar_url and allow only http(s) URLs."""
+        if value is None:
+            return None
+        normalized = value.strip()
+        parsed = urlparse(normalized)
+        if not normalized or parsed.scheme not in {"http", "https"} or not parsed.netloc:
+            raise ValueError("avatar_url must be a valid http(s) URL")
+        return normalized
 
 
 class UserDeleteResponse(BaseModel):

--- a/api/tests/test_users_me_auth.py
+++ b/api/tests/test_users_me_auth.py
@@ -10,6 +10,13 @@ from app.auth.tokens import settings as token_settings
 from app.config import get_settings
 
 
+async def _login_auth_header(client: AsyncClient) -> dict[str, str]:
+    login_response = await client.get("/api/v1/auth/mock/login")
+    assert login_response.status_code == 200
+    access_token = login_response.json()["access_token"]
+    return {"Authorization": f"Bearer {access_token}"}
+
+
 @pytest.mark.asyncio
 async def test_users_me_requires_valid_token(client: AsyncClient):
     """GET /api/v1/users/me returns fixed 401 contract for invalid JWT."""
@@ -124,3 +131,54 @@ async def test_users_me_rejects_token_with_invalid_kid_header_value(
             "token_header_fields": expected_header_fields,
         }
     }
+
+
+@pytest.mark.asyncio
+async def test_users_me_update_rejects_blank_display_name(client: AsyncClient):
+    auth_header = await _login_auth_header(client)
+
+    response = await client.patch(
+        "/api/v1/users/me",
+        headers=auth_header,
+        json={"display_name": "   "},
+    )
+
+    assert response.status_code == 422
+    assert response.json()["detail"][0]["loc"] == ["body", "display_name"]
+    assert "display_name must not be blank" in response.json()["detail"][0]["msg"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("avatar_url", ["not-a-url", "ftp://example.com/avatar.png"])
+async def test_users_me_update_rejects_invalid_avatar_url_with_stable_error(
+    client: AsyncClient, avatar_url: str
+):
+    auth_header = await _login_auth_header(client)
+
+    response = await client.patch(
+        "/api/v1/users/me",
+        headers=auth_header,
+        json={"avatar_url": avatar_url},
+    )
+
+    assert response.status_code == 422
+    assert response.json()["detail"][0]["loc"] == ["body", "avatar_url"]
+    assert "avatar_url must be a valid http(s) URL" in response.json()["detail"][0]["msg"]
+
+
+@pytest.mark.asyncio
+async def test_users_me_update_normalizes_trimmed_profile_fields(client: AsyncClient):
+    auth_header = await _login_auth_header(client)
+
+    response = await client.patch(
+        "/api/v1/users/me",
+        headers=auth_header,
+        json={
+            "display_name": "  Updated Name  ",
+            "avatar_url": "  https://example.com/avatar.png  ",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["display_name"] == "Updated Name"
+    assert response.json()["avatar_url"] == "https://example.com/avatar.png"


### PR DESCRIPTION
## Summary
- normalize `display_name` by trimming and rejecting blank-only inputs in `UserUpdateRequest`
- normalize `avatar_url` and enforce a stable `http(s)` validation contract
- add users profile update boundary tests under `test_users_me_auth.py`

## Testing
- `uv run --python 3.11 --with-requirements api/requirements.txt pytest api/tests/test_users_me_auth.py -q`
- `uv run --python 3.11 --with-requirements api/requirements.txt pytest api/tests/test_accounts.py -q`

## Public impact
- profile update now rejects blank-only `display_name` with 422
- profile update now rejects non-`http(s)` `avatar_url` with 422 and stable message
- surrounding whitespace for valid `display_name` / `avatar_url` is normalized
