### PR TITLE
fix: unify accounts unlink last-method error contract

### DIFF
--- a/api/app/accounts/router.py
+++ b/api/app/accounts/router.py
@@ -17,7 +17,12 @@ from app.db.session import get_db
 from app.models import OAuthAccount, User
 from app.valkey import OAuthStateStore
 
-from .schemas import OAuthAccountResponse, SUPPORTED_ACCOUNT_PROVIDERS, UnlinkResponse
+from .schemas import (
+    OAuthAccountResponse,
+    SUPPORTED_ACCOUNT_PROVIDERS,
+    UNLINK_LAST_AUTH_METHOD_ERROR_DETAIL,
+    UnlinkResponse,
+)
 
 settings = get_settings()
 router = APIRouter(prefix="/accounts", tags=["accounts"])
@@ -274,7 +279,7 @@ async def unlink_account(
     account_count = count_result.scalar()
 
     if account_count <= 1:
-        raise HTTPException(status_code=400, detail="Cannot unlink the last authentication method")
+        raise HTTPException(status_code=400, detail=UNLINK_LAST_AUTH_METHOD_ERROR_DETAIL)
 
     # Find and delete the OAuth account
     result = await db.execute(

--- a/api/app/accounts/schemas.py
+++ b/api/app/accounts/schemas.py
@@ -30,3 +30,6 @@ class UnlinkResponse(BaseModel):
 
     message: str
     provider: AccountProvider
+
+
+UNLINK_LAST_AUTH_METHOD_ERROR_DETAIL = "Cannot unlink the last authentication method"

--- a/api/tests/test_accounts.py
+++ b/api/tests/test_accounts.py
@@ -6,6 +6,7 @@ import pytest
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.accounts.schemas import UNLINK_LAST_AUTH_METHOD_ERROR_DETAIL
 from app.auth.tokens import create_access_token
 from app.models import OAuthAccount, User
 
@@ -127,7 +128,7 @@ async def test_unlink_account_returns_400_when_last_authentication_method(
 
     assert response.status_code == 400
     data = response.json()
-    assert data["detail"] == "Cannot unlink the last authentication method"
+    assert data["detail"] == UNLINK_LAST_AUTH_METHOD_ERROR_DETAIL
 
 
 def test_build_audit_actor_uses_fallback_for_empty_value():


### PR DESCRIPTION
## Summary
- accounts unlink の「最終認証手段」エラー文言を `api/app/accounts/schemas.py` の定数へ集約
- `api/app/accounts/router.py` で定数参照に統一し、契約の重複定義を解消
- `api/tests/test_accounts.py` でも同じ定数を参照してエラー契約を固定

## Test
- `cd api && uv run --python 3.11 --with-requirements requirements.txt pytest tests/test_accounts.py -k unlink -q`
- `cd api && uv run --python 3.11 --with-requirements requirements.txt pytest tests/test_auth_refresh.py -q`

## Public impact
- 唯一連携解除時の 400 エラー detail がコード上で単一管理され、将来の文言ドリフトを防止
- 既存 API レスポンス仕様（status/detail）は変更なし

Closes #471
