### PR TITLE
Fix mock GitHub ID collision handling

### DIFF
--- a/api/app/auth/mock_oauth.py
+++ b/api/app/auth/mock_oauth.py
@@ -9,6 +9,13 @@ import uuid
 from dataclasses import dataclass
 
 
+def _stable_mock_github_numeric_id(seed: str) -> int:
+    """Build a deterministic numeric GitHub mock user id with low collision risk."""
+    namespace = uuid.uuid5(uuid.NAMESPACE_DNS, "yesod-auth.mock.github")
+    value = uuid.uuid5(namespace, seed).int
+    return (value % 9_000_000_000) + 1_000_000_000
+
+
 def is_mock_oauth_enabled() -> bool:
     """Check if mock OAuth is enabled."""
     return os.getenv("MOCK_OAUTH_ENABLED", "").lower() in ("1", "true", "yes")
@@ -45,8 +52,7 @@ class MockOAuthUser:
 
     def to_github_format(self) -> dict:
         """Convert to GitHub userinfo format."""
-        # Generate a numeric ID from the mock ID
-        numeric_id = int(self.id.split("-")[-1]) if "-" in self.id else 12345
+        numeric_id = _stable_mock_github_numeric_id(self.id)
         return {
             "id": numeric_id,
             "login": self.name.lower().replace(" ", ""),

--- a/api/tests/test_mock_oauth.py
+++ b/api/tests/test_mock_oauth.py
@@ -3,6 +3,8 @@
 import pytest
 from httpx import AsyncClient
 
+from app.auth.mock_oauth import MockOAuthUser
+
 
 @pytest.mark.asyncio
 async def test_mock_login_alice(client: AsyncClient):
@@ -90,3 +92,38 @@ async def test_authenticated_request(client: AsyncClient):
 
     data = response.json()
     assert data["email"] == "alice@example.com"
+
+
+@pytest.mark.asyncio
+async def test_mock_login_github_avoids_provider_user_id_collision(client: AsyncClient, monkeypatch):
+    """GitHub mock provider_user_id must avoid collisions even with same numeric suffix IDs."""
+    collision_users = {
+        "alice": MockOAuthUser(
+            id="mock-alice-999",
+            email="alice@example.com",
+            name="Alice Developer",
+            picture=None,
+        ),
+        "dup-a": MockOAuthUser(
+            id="mock-dup-a-123",
+            email="dup-a@example.com",
+            name="Duplicate A",
+            picture=None,
+        ),
+        "dup-b": MockOAuthUser(
+            id="mock-dup-b-123",
+            email="dup-b@example.com",
+            name="Duplicate B",
+            picture=None,
+        ),
+    }
+    monkeypatch.setattr("app.auth.mock_oauth.MOCK_USERS", collision_users)
+
+    response_a = await client.get("/api/v1/auth/mock/login?provider=github&user=dup-a")
+    response_b = await client.get("/api/v1/auth/mock/login?provider=github&user=dup-b")
+
+    assert response_a.status_code == 200
+    assert response_b.status_code == 200
+    assert response_a.json()["email"] == "dup-a@example.com"
+    assert response_b.json()["email"] == "dup-b@example.com"
+    assert response_a.json()["user_id"] != response_b.json()["user_id"]


### PR DESCRIPTION
## 概要
- GitHub 向け mock user id の生成を、末尾数値依存から stable hash ベースへ変更
- `api/tests/test_mock_oauth.py` に provider_user_id 衝突回避の回帰テストを追加

## 変更詳細
- `api/app/auth/mock_oauth.py`
  - `_stable_mock_github_numeric_id(seed)` を追加
  - `to_github_format()` がこの関数を使うよう更新
- `api/tests/test_mock_oauth.py`
  - `test_mock_login_github_avoids_provider_user_id_collision` を追加

## テスト
- `uv run --python 3.11 --with-requirements api/requirements.txt pytest api/tests/test_mock_oauth.py -q`
- `uv run --python 3.11 --with-requirements api/requirements.txt pytest api/tests/test_auth_refresh.py -q`

Closes #473
