### PR TITLE
fix: CORS_ORIGINS 重複入力の正規化契約を固定

### DIFF
--- a/api/app/config.py
+++ b/api/app/config.py
@@ -24,13 +24,25 @@ def resolve_cors_origins(raw_value: str | None) -> tuple[list[str], bool]:
     if raw_value is None or not raw_value.strip():
         return DEFAULT_CORS_ORIGINS.split(","), True
 
-    origins = [origin.strip() for origin in raw_value.split(",")]
-    if any(not origin for origin in origins):
+    raw_origins = [origin.strip() for origin in raw_value.split(",")]
+    if any(not origin for origin in raw_origins):
         raise ValueError(
             "CORS_ORIGINS contains empty element. "
             "Set non-empty comma-separated values for CORS_ORIGINS."
         )
-    return origins, False
+
+    # Normalize slash/case notation drift and deduplicate while preserving first-seen order.
+    normalized_origins: list[str] = []
+    seen_origins: set[str] = set()
+    for origin in raw_origins:
+        normalized_origin = origin.rstrip("/")
+        canonical_key = normalized_origin.casefold()
+        if canonical_key in seen_origins:
+            continue
+        seen_origins.add(canonical_key)
+        normalized_origins.append(normalized_origin)
+
+    return normalized_origins, False
 
 
 def parse_bool_env(name: str, default: bool = False) -> bool:

--- a/api/tests/test_config.py
+++ b/api/tests/test_config.py
@@ -77,6 +77,22 @@ def test_resolve_cors_origins_uses_env_value_when_set():
     assert using_default is False
 
 
+def test_resolve_cors_origins_normalizes_and_deduplicates_origins():
+    origins, using_default = resolve_cors_origins(
+        " https://Example.com/ ,https://example.com,https://admin.example.com/ "
+    )
+
+    assert origins == ["https://Example.com", "https://admin.example.com"]
+    assert using_default is False
+
+
+def test_resolve_cors_origins_keeps_http_and_https_as_distinct_origins():
+    origins, using_default = resolve_cors_origins("http://example.com,https://example.com,http://example.com/")
+
+    assert origins == ["http://example.com", "https://example.com"]
+    assert using_default is False
+
+
 def test_parse_bool_env_accepts_truthy_value(monkeypatch):
     monkeypatch.setenv("TESTING", "YeS")
 


### PR DESCRIPTION
## 概要
- `CORS_ORIGINS` の解析で重複 origin を正規化（末尾スラッシュ除去 + 大文字小文字ゆれ吸収）して一意化
- 先頭出現順は維持し、`http` と `https` は別 origin として保持
- 空要素を起動時エラー化する既存契約は維持

## 変更内容
- `api/app/config.py`
  - `resolve_cors_origins` に dedupe ロジックを追加
- `api/tests/test_config.py`
  - 重複/表記ゆれの正規化テスト追加
  - `http/https` 混在時の別扱いテスト追加

## テスト
- `cd api && uv run --python 3.11 --with-requirements requirements.txt pytest tests/test_config.py -k cors -q`
- `cd api && uv run --python 3.11 --with-requirements requirements.txt pytest tests/test_health.py -q`

Closes #474
