### PR TITLE
docs: synchronize OAuth secret restart steps across docs (fix #475)

### DIFF
--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -66,18 +66,25 @@ YESOD AuthはGoogle OAuthでPKCEを自動的に使用します。
 
 | 変更内容 | 再起動要否 | 実行コマンド |
 | --- | --- | --- |
-| `secrets/<provider>_client_id.txt` / `secrets/<provider>_client_secret.txt` を更新 | 必須 | `docker compose up -d --force-recreate api worker` |
-| `secrets/jwt_secret.txt` を更新 | 必須 | `docker compose up -d --force-recreate api worker` |
-| `.env` のみ更新（secretは未変更） | 必須 | `docker compose up -d --force-recreate api worker` |
+| `secrets/<provider>_client_id.txt` / `secrets/<provider>_client_secret.txt` を更新 | 必須 | `docker compose --profile default up -d --force-recreate api` |
+| `secrets/jwt_secret.txt` を更新 | 必須 | `docker compose --profile default up -d --force-recreate api` |
+| `.env` のみ更新（secretは未変更） | 必須 | `docker compose --profile default up -d --force-recreate api` |
 | ドキュメントのみ更新 | 不要 | なし |
 
 再起動後は次の 2 点を固定で確認します。
 
-1. `docker compose ps` で `api` と `worker` が `Up` になっていること
+1. `docker compose --profile default ps` で `api` が `Up` になっていること
 2. `curl -fsS http://localhost:8000/health` が `{"status":"ok"}` を返すこと
 
 シークレットの配置方針は [インストールガイド: OAuth認証情報](../installation.md#oauth認証情報)、
 プロバイダー別の有効化手順は [OAuth設定ガイド](../guides/oauth/index.md#セルフホスト向け最短手順) を参照してください。
+
+3文書の同期確認は次のコマンドで実施できます。
+
+```bash
+rg -n "^### OAuth secretを更新したら再起動は必要？$|^### provider 未設定時の最短スキップ手順$|^### provider 未設定のまま認証導線を実行した$|docker compose --profile default up -d --force-recreate api|docker compose --profile default ps|curl -fsS http://localhost:8000/health" \
+  docs/help/faq.md docs/installation.md docs/help/troubleshooting.md
+```
 
 <a id="oauth-secret-permission-recovery"></a>
 

--- a/docs/help/troubleshooting.md
+++ b/docs/help/troubleshooting.md
@@ -277,9 +277,10 @@ environment:
 1. `secrets/*.txt` を正しい値へ更新（例: `secrets/github_client_id.txt`, `secrets/github_client_secret.txt`）
 2. Compose を再起動して設定を反映
    ```bash
-   docker compose up -d --force-recreate api admin
+   docker compose --profile default up -d --force-recreate api
    ```
-3. 認証を再実行し、失敗時は provider 側アプリ設定（redirect URI / secret再発行）も確認
+3. `docker compose --profile default ps` と `curl -fsS http://localhost:8000/health` で復旧確認する
+4. 認証を再実行し、失敗時は provider 側アプリ設定（redirect URI / secret再発行）も確認
 
 #### invalid_client 再発防止チェック（デプロイ前後で毎回実施）
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -48,6 +48,13 @@ OAuth provider をまだ一部用意できていない場合は、次の手順�
 - 失敗時: [トラブルシューティング: provider 未設定のまま認証導線を実行した](./help/troubleshooting.md#provider-未設定のまま認証導線を実行した)
 - FAQ での要点確認: [Mock OAuthから実OAuthへ切り替える最小確認は？](./help/faq.md#mock-oauthから実oauthへ切り替える最小確認は)
 
+FAQ / installation / troubleshooting の同期確認コマンド:
+
+```bash
+rg -n "^### OAuth secretを更新したら再起動は必要？$|^### provider 未設定時の最短スキップ手順$|^### provider 未設定のまま認証導線を実行した$|docker compose --profile default up -d --force-recreate api|docker compose --profile default ps|curl -fsS http://localhost:8000/health" \
+  docs/help/faq.md docs/installation.md docs/help/troubleshooting.md
+```
+
 ## Docker起動前チェック項目
 
 `docker compose up` 実行前に、次の6項目を確認してください。


### PR DESCRIPTION
## Summary
- FAQ の OAuth secret 更新後手順を `--profile default` + `api` 再作成へ統一
- installation に FAQ/troubleshooting と照合する同期確認コマンドを追加
- troubleshooting の `invalid_client` 復旧手順を同一コマンド・同一確認手順へ揃えた

## Test
- `rg -n "secret|再起動|force-recreate" docs/help/faq.md docs/installation.md docs/help/troubleshooting.md`
- `rg -n "docker compose ps|/health" docs/help/faq.md docs/installation.md docs/help/troubleshooting.md`
- `rg -n "^### OAuth secretを更新したら再起動は必要？$|^### provider 未設定時の最短スキップ手順$|^### provider 未設定のまま認証導線を実行した$|docker compose --profile default up -d --force-recreate api|docker compose --profile default ps|curl -fsS http://localhost:8000/health" docs/help/faq.md docs/installation.md docs/help/troubleshooting.md`

## Public impact
- OAuth 導入時の secret 更新後リカバリ手順が 3 文書で一意になり、セルフホスト運用時の誤操作を減らせます。
