### PR TITLE
docs: sync session expiry diagnostic paths across docs

### DIFF
--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -104,6 +104,27 @@ rg -n "^### OAuth secretを更新したら再起動は必要？$|^### provider �
   docs/help/faq.md docs/installation.md docs/help/troubleshooting.md
 ```
 
+<a id="session-expiry-hours-recovery"></a>
+
+### `SESSION_EXPIRY_HOURS` の異常値を最短で復旧するには？
+
+次の 3 コマンドを固定順（確認 → 再作成 → ログ確認）で実行してください。
+
+```bash
+docker compose --profile full config | rg -n "SESSION_EXPIRY_HOURS|ADMIN_USER|admin:"
+docker compose --profile full up -d --force-recreate admin
+docker compose logs admin --since=10m | rg -n "SESSION_EXPIRY_HOURS is invalid|using default value 24"
+```
+
+運用メモ:
+
+1. `SESSION_EXPIRY_HOURS` は 1 以上の整数に固定し、0 以下や文字列を混在させない
+2. 値を変更した run では、必ず `--force-recreate admin` を実行して反映する
+3. ログ確認で警告が残る場合は、profile と secrets の読み込み元を再点検する
+
+手順詳細は [トラブルシューティング: `SESSION_EXPIRY_HOURS` が不正値](./troubleshooting.md#session-expiry-hours-invalid)、
+導入手順側の位置づけは [インストール: 管理画面付き](../installation.md#管理画面付き) を参照してください。
+
 <a id="oauth-secret-permission-recovery"></a>
 
 ### OAuth secret の権限不備を最短で復旧するには？

--- a/docs/help/troubleshooting.md
+++ b/docs/help/troubleshooting.md
@@ -96,6 +96,8 @@ ERROR: extension "pg_cron" is not available
 
 ---
 
+<a id="session-expiry-hours-invalid"></a>
+
 ### `SESSION_EXPIRY_HOURS` が不正値
 
 **症状:** 管理画面のセッション期限設定が反映されず、起動ログに警告が出る。
@@ -108,17 +110,23 @@ SESSION_EXPIRY_HOURS is invalid ('<value>'); using default value 24
 
 **原因:** `SESSION_EXPIRY_HOURS` に整数以外、または 0 以下の値が設定されている。
 
-**解決策:**
+**解決策（最短3コマンド: 確認 → 再作成 → ログ確認）:**
 
-1. `SESSION_EXPIRY_HOURS` を 1 以上の整数に修正する
+1. 設定確認（`SESSION_EXPIRY_HOURS` が想定値になっているか確認）
+   ```bash
+   docker compose --profile full config | rg -n "SESSION_EXPIRY_HOURS|ADMIN_USER|admin:"
+   ```
 2. 管理画面コンテナを再作成して反映する
    ```bash
-   docker compose up -d --force-recreate admin
+   docker compose --profile full up -d --force-recreate admin
    ```
-3. 反映確認
+3. ログ確認（同警告が再発していないか確認）
    ```bash
-   docker compose logs admin --since=10m | rg -n "SESSION_EXPIRY_HOURS is invalid"
+   docker compose logs admin --since=10m | rg -n "SESSION_EXPIRY_HOURS is invalid|using default value 24"
    ```
+
+3コマンドの順序は [インストール: 管理画面付き](../installation.md#管理画面付き) と
+[FAQ: SESSION_EXPIRY_HOURS の異常値を最短で復旧するには？](./faq.md#session-expiry-hours-recovery) で同期しています。
 
 ---
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -223,6 +223,17 @@ docker compose --profile full config --services
 
 - ログイン後、指定した `SESSION_EXPIRY_HOURS` が運用要件に合うことを確認する
 
+4. `SESSION_EXPIRY_HOURS` 異常値の最短診断（確認→再作成→ログ確認）
+
+```bash
+docker compose --profile full config | rg -n "SESSION_EXPIRY_HOURS|ADMIN_USER|admin:"
+docker compose --profile full up -d --force-recreate admin
+docker compose logs admin --since=10m | rg -n "SESSION_EXPIRY_HOURS is invalid|using default value 24"
+```
+
+- 3コマンドの詳細は [トラブルシューティング: `SESSION_EXPIRY_HOURS` が不正値](./help/troubleshooting.md#session-expiry-hours-invalid)
+- 運用上の再発防止メモは [FAQ: SESSION_EXPIRY_HOURS の異常値を最短で復旧するには？](./help/faq.md#session-expiry-hours-recovery)
+
 #### 代表的な失敗例
 
 - 症状: `admin` サービスが起動失敗する / ログインできない
@@ -234,9 +245,9 @@ docker compose --profile full config --services
 1. `full` プロファイル手順に `admin_password` の非空チェック（`test -s`）が含まれている
 2. 未設定時の症状（起動失敗/ログイン失敗）と復旧手順が同じ節に記載されている
 3. FAQ / installation / troubleshooting の3点同期を確認できる  
-   - FAQ: [どのsecretを必須で用意すべき？](./help/faq.md#どのsecretを必須で用意すべき)  
+   - FAQ: [SESSION_EXPIRY_HOURS の異常値を最短で復旧するには？](./help/faq.md#session-expiry-hours-recovery)  
    - Installation: [管理画面付き](#管理画面付き)  
-   - Troubleshooting: [認証エラー](./help/troubleshooting.md#認証エラー)
+   - Troubleshooting: [`SESSION_EXPIRY_HOURS` が不正値](./help/troubleshooting.md#session-expiry-hours-invalid)
 
 ### CI相当
 


### PR DESCRIPTION
## 概要
- `SESSION_EXPIRY_HOURS` 異常値の最短診断を 3 文書で同一手順（確認→再作成→ログ確認）に統一
- `installation` / `troubleshooting` / `faq` の相互リンクを追加し、往復導線を固定
- 運用向け再発防止メモを FAQ に追加

## 変更ファイル
- docs/installation.md
- docs/help/troubleshooting.md
- docs/help/faq.md

## テスト
- `rg -n "SESSION_EXPIRY_HOURS" docs/help/faq.md docs/installation.md docs/help/troubleshooting.md`
- `rg -n "確認.?→.?再作成.?→.?ログ確認|config \| rg -n \"SESSION_EXPIRY_HOURS\|ADMIN_USER\|admin:\"|--force-recreate admin|SESSION_EXPIRY_HOURS is invalid\|using default value 24" docs/help/faq.md docs/installation.md docs/help/troubleshooting.md`
- `mkdocs build --strict`（ローカル未導入のため未実行: `mkdocs: command not found`）

## 公開時の影響
- OAuth 導入容易化: 異常値診断の参照導線を導入手順から直接辿れるように改善
- セルフホスト運用性: 3 コマンド固定順の明文化で復旧判断を標準化
- OSS ドキュメント整備: FAQ / installation / troubleshooting の記述差分を解消
