### PR TITLE
docs: connect webhook reload troubleshooting flow

### DIFF
--- a/docs/api/webhooks.md
+++ b/docs/api/webhooks.md
@@ -111,6 +111,21 @@ POST /api/v1/admin/webhooks/reload
 - 切替後に署名検証失敗が増えた場合は、旧鍵へ戻して再度 `reload` することで復旧できます。
 - 詳細手順は [Webhook設定ガイドの署名鍵ローテーション最小手順](../guides/webhooks.md#署名鍵ローテーション最小手順) を参照してください。
 
+<a id="reload-失敗時の最短確認手順"></a>
+
+### `reload` 失敗時の最短確認手順
+
+`POST /api/v1/admin/webhooks/reload` 実行後も webhook の挙動が改善しない場合は、次の順で確認してください。
+
+1. 設定ファイルと読み込み状態を確認する
+   - `config/webhooks.yaml` の構文・参照 secrets
+   - `GET /api/v1/admin/webhooks/endpoints` の応答
+2. 設定変更直後なら `reload` を再実行し、同一イベントを再送して差分を見る
+3. API ログで `webhook` / `reload` / `signature` を確認して、失敗分類を特定する
+4. 改善しない場合は旧設定へ一時ロールバックし、`reload` 後に再送して原因を切り分ける
+
+詳細な切り分けコマンドは [トラブルシューティング: Webhook reload 後も反映されない](../help/troubleshooting.md#webhook-reload-後も反映されない) を参照してください。
+
 ---
 
 ## イベントタイプ

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -242,10 +242,27 @@ curl "http://localhost:8000/api/v1/auth/mock/login?user=alice&provider=google"
 2. エンドポイントが`enabled: true`になっているか確認
 3. URLがHTTPSで始まっているか確認
 4. 配信履歴を確認：`GET /api/v1/admin/webhooks/deliveries`
+5. 設定変更直後は `POST /api/v1/admin/webhooks/reload` を実行し、同一イベントを再送して結果を比較
 
 ### 署名検証の方法は？
 
 [Webhook設定ガイド](../guides/webhooks.md#署名検証)を参照してください。
+
+<a id="webhook-reload-が効かないときの確認順は"></a>
+
+### Webhook reload が効かないときの確認順は？
+
+次の順で確認すると最短で切り分けできます。
+
+1. `GET /api/v1/admin/webhooks/endpoints` で読み込み状態を確認
+2. `POST /api/v1/admin/webhooks/reload` を実行
+3. 同一イベントを再送し、失敗が継続するか確認
+4. API ログ（`webhook` / `reload` / `signature`）を確認
+
+詳細手順:
+
+- [トラブルシューティング: Webhook reload 後も反映されない](./troubleshooting.md#webhook-reload-後も反映されない)
+- [Webhook API: `reload` 失敗時の最短確認手順](../api/webhooks.md#reload-失敗時の最短確認手順)
 
 ---
 

--- a/docs/help/troubleshooting.md
+++ b/docs/help/troubleshooting.md
@@ -624,6 +624,34 @@ FAQ での方針説明は [FAQ: Adminで未翻訳キーが出たときの表示�
 
 ---
 
+<a id="webhook-reload-後も反映されない"></a>
+
+### Webhook reload 後も反映されない
+
+**切り分け手順（最短）:**
+
+1. 現在の設定が読み込まれているか確認する
+   ```bash
+   curl -fsS http://localhost:8000/api/v1/admin/webhooks/endpoints
+   ```
+2. `reload` を実行し、同一イベントを再送して挙動差分を確認する
+   ```bash
+   curl -X POST http://localhost:8000/api/v1/admin/webhooks/reload
+   ```
+3. API ログで `webhook` / `reload` / `signature` を抽出して失敗分類を確認する
+   ```bash
+   docker compose logs api --since=30m | rg -n "webhook|reload|signature|invalid"
+   ```
+4. 直らない場合は旧設定へ一時ロールバックし、再度 `reload` と再送で差分を確認する
+
+**参照導線:**
+
+- API 仕様側: [Webhook API: `reload` 失敗時の最短確認手順](../api/webhooks.md#reload-失敗時の最短確認手順)
+- FAQ 側: [Webhook reload が効かないときの確認順は？](./faq.md#webhook-reload-が効かないときの確認順は)
+- 導入手順側: [インストール: Webhook reload 障害の最短導線](../installation.md#webhook-reload-障害の最短導線)
+
+---
+
 ### 署名検証に失敗する
 
 **診断手順（最小）:**

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -12,6 +12,26 @@
 | Docker Compose | 2.0+ |
 
 障害時の確認手順は[トラブルシューティング: 障害時の参照順](help/troubleshooting.md#障害時の参照順最短導線)を参照してください。
+Webhook 設定変更後の反映不良は、[Webhook reload 障害の最短導線](#webhook-reload-障害の最短導線) から着手してください。
+
+<a id="webhook-reload-障害の最短導線"></a>
+
+## Webhook reload 障害の最短導線
+
+`config/webhooks.yaml` や secrets を変更したのに webhook 挙動が変わらない場合は、次の 3 手順で確認します。
+
+1. 現在の読み込み状態を確認
+   - `curl -fsS http://localhost:8000/api/v1/admin/webhooks/endpoints`
+2. 設定リロードを実行
+   - `curl -X POST http://localhost:8000/api/v1/admin/webhooks/reload`
+3. 同一イベントを再送し、API ログで `webhook` / `reload` / `signature` を確認
+   - `docker compose logs api --since=30m | rg -n "webhook|reload|signature|invalid"`
+
+補助導線:
+
+- [FAQ: Webhook reload が効かないときの確認順は？](./help/faq.md#webhook-reload-が効かないときの確認順は)
+- [トラブルシューティング: Webhook reload 後も反映されない](./help/troubleshooting.md#webhook-reload-後も反映されない)
+- [Webhook API: `reload` 失敗時の最短確認手順](./api/webhooks.md#reload-失敗時の最短確認手順)
 
 ## Docker Composeプロファイル
 


### PR DESCRIPTION
## Summary
- add a consistent "verify -> reload -> resend/log" diagnostic flow for webhook reload failures
- sync the flow across API docs and troubleshooting
- add cross-links from FAQ and installation so operators can reach the same path quickly

## Testing
- `rg -n "webhooks/reload|Webhook|reload" docs/api/webhooks.md docs/help/faq.md docs/installation.md docs/help/troubleshooting.md`
- `mkdocs build --strict` *(fails locally: `mkdocs: command not found`)*

## Publication impact
- OAuth 導入容易化: callback/secret 更新直後の webhook reload 失敗時に、確認順を一本化
- セルフホスト運用性: installation から直接 reload 障害導線へ遷移可能
- OSS ドキュメント整備: API/FAQ/installation/troubleshooting の導線差分を解消

Closes #477
