### PR TITLE
fix: validate webhook events for empty and duplicate entries

### DIFF
--- a/api/app/webhooks/config.py
+++ b/api/app/webhooks/config.py
@@ -202,6 +202,27 @@ class WebhookConfigLoader:
             raise ValueError(f"Endpoint '{endpoint_id}' missing 'secret' field")
         if not events:
             raise ValueError(f"Endpoint '{endpoint_id}' missing 'events' field")
+        if not isinstance(events, list):
+            raise ValueError(f"Endpoint '{endpoint_id}' events must be an array")
+
+        normalized_events: list[str] = []
+        seen_events: set[str] = set()
+        for idx, event in enumerate(events):
+            if not isinstance(event, str):
+                raise ValueError(
+                    f"Endpoint '{endpoint_id}' events[{idx}] must be a string"
+                )
+            normalized_event = event.strip()
+            if not normalized_event:
+                raise ValueError(
+                    f"Endpoint '{endpoint_id}' events contains empty element at index {idx}"
+                )
+            if normalized_event in seen_events:
+                raise ValueError(
+                    f"Endpoint '{endpoint_id}' events contains duplicated element: {normalized_event}"
+                )
+            seen_events.add(normalized_event)
+            normalized_events.append(normalized_event)
 
         # Validate HTTPS
         if not url.startswith("https://"):
@@ -219,7 +240,7 @@ class WebhookConfigLoader:
             id=endpoint_id,
             url=url,
             secret=secret,
-            events=events,
+            events=normalized_events,
             enabled=enabled,
             description=description,
         )

--- a/api/tests/test_webhook_config.py
+++ b/api/tests/test_webhook_config.py
@@ -214,6 +214,56 @@ class TestWebhookConfigValidation:
         finally:
             config_path.unlink()
 
+    def test_events_with_empty_element_is_rejected(self):
+        """events 配列に空要素がある endpoint は読み込み対象外にする。"""
+        config = {
+            "endpoints": [
+                {
+                    "id": "test-endpoint",
+                    "url": "https://example.com/webhook",
+                    "secret": "test-secret",
+                    "events": ["user.created", "  ", "user.updated"],
+                }
+            ]
+        }
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            yaml.dump(config, f)
+            config_path = Path(f.name)
+
+        try:
+            with patch.object(config_module, "CONFIG_PATH", config_path):
+                WebhookConfigLoader._config = None
+                result = WebhookConfigLoader.load()
+            assert len(result.endpoints) == 0
+        finally:
+            config_path.unlink()
+
+    def test_events_with_duplicated_element_is_rejected(self):
+        """events 配列に重複がある endpoint は読み込み対象外にする。"""
+        config = {
+            "endpoints": [
+                {
+                    "id": "test-endpoint",
+                    "url": "https://example.com/webhook",
+                    "secret": "test-secret",
+                    "events": ["user.created", "user.created"],
+                }
+            ]
+        }
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            yaml.dump(config, f)
+            config_path = Path(f.name)
+
+        try:
+            with patch.object(config_module, "CONFIG_PATH", config_path):
+                WebhookConfigLoader._config = None
+                result = WebhookConfigLoader.load()
+            assert len(result.endpoints) == 0
+        finally:
+            config_path.unlink()
+
     def test_env_var_secret_resolution(self):
         """Test that environment variable secrets are resolved."""
         config = {


### PR DESCRIPTION
## Summary
- add webhook endpoint config validation for `events` array elements
- reject empty/blank event entries and duplicated event names
- normalize stored event names by trimming whitespace during parsing
- add regression tests for empty-element and duplicate-element cases

## Testing
- `cd api && uv run --python 3.11 pytest tests/test_webhook_config.py -k "empty_events_is_rejected or events_with_empty_element_is_rejected or events_with_duplicated_element_is_rejected"`

Closes #478
