### PR TITLE
Reject duplicate webhook endpoint IDs at load time

### DIFF
--- a/api/app/webhooks/config.py
+++ b/api/app/webhooks/config.py
@@ -81,8 +81,11 @@ class WebhookConfigLoader:
             cls._config = WebhookConfig()
             return cls._config
 
+        raw_endpoints = raw_config.get("endpoints", [])
+        cls._validate_unique_endpoint_ids(raw_endpoints)
+
         endpoints = []
-        for ep_data in raw_config.get("endpoints", []):
+        for ep_data in raw_endpoints:
             try:
                 endpoint = cls._parse_endpoint(ep_data)
                 if endpoint:
@@ -112,6 +115,18 @@ class WebhookConfigLoader:
             CONFIG_PATH,
         )
         return cls._config
+
+    @staticmethod
+    def _validate_unique_endpoint_ids(endpoints: list[dict[str, Any]]) -> None:
+        """Reject duplicate endpoint IDs to keep operational references unambiguous."""
+        seen_ids: set[str] = set()
+        for endpoint in endpoints:
+            endpoint_id = endpoint.get("id")
+            if not endpoint_id:
+                continue
+            if endpoint_id in seen_ids:
+                raise ValueError(f"Duplicate webhook endpoint id detected: {endpoint_id}")
+            seen_ids.add(endpoint_id)
 
     @classmethod
     def _validate_settings(cls, settings_data: dict[str, Any]) -> None:

--- a/api/tests/test_webhook_config.py
+++ b/api/tests/test_webhook_config.py
@@ -303,6 +303,40 @@ class TestWebhookConfigValidation:
         finally:
             config_path.unlink()
 
+    def test_duplicate_endpoint_id_is_rejected(self):
+        """Duplicate endpoint IDs should fail load to avoid ambiguous routing."""
+        config = {
+            "endpoints": [
+                {
+                    "id": "duplicate-id",
+                    "url": "https://example.com/webhook-a",
+                    "secret": "secret-a",
+                    "events": ["user.created"],
+                },
+                {
+                    "id": "duplicate-id",
+                    "url": "https://example.com/webhook-b",
+                    "secret": "secret-b",
+                    "events": ["user.updated"],
+                },
+            ]
+        }
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            yaml.dump(config, f)
+            config_path = Path(f.name)
+
+        try:
+            with patch.object(config_module, "CONFIG_PATH", config_path):
+                WebhookConfigLoader._config = None
+                with pytest.raises(
+                    ValueError,
+                    match="Duplicate webhook endpoint id detected: duplicate-id",
+                ):
+                    WebhookConfigLoader.load()
+        finally:
+            config_path.unlink()
+
     def test_get_endpoints_for_event(self):
         """Test filtering endpoints by event type."""
         config = {

--- a/docs/guides/webhooks.md
+++ b/docs/guides/webhooks.md
@@ -57,6 +57,8 @@ settings:
   delivery_timeout_seconds: 30
 ```
 
+`endpoints[].id` は設定全体で一意である必要があります。重複すると `POST /api/v1/admin/webhooks/reload` を含む設定ロードは失敗します。
+
 ### 2. シークレットの設定
 
 #### 本番環境（Docker Secrets推奨）


### PR DESCRIPTION
## 概要
- `WebhookConfigLoader.load()` で `endpoints[].id` の重複を事前検出し、重複時は `ValueError` でロード失敗に変更
- 重複 ID の回帰テスト `test_duplicate_endpoint_id_is_rejected` を追加
- Webhook 運用ドキュメントに「endpoint ID は一意必須」を追記

## 背景
- endpoint ID 重複時に reload 後の参照先が曖昧になる問題を防ぐため

## テスト
- `docker run --rm -v "$PWD/api:/app" -w /app yesod-auth-api-ci:latest pytest tests/test_webhook_config.py -k duplicate_endpoint_id`
- `docker run --rm -v "$PWD/api:/app" -w /app yesod-auth-api-ci:latest pytest tests/test_webhook_config.py`

Closes #602
