### PR TITLE
[Bench-80][02][Auth] accounts link callback URL normalization

### DIFF
--- a/api/app/accounts/router.py
+++ b/api/app/accounts/router.py
@@ -1,7 +1,9 @@
 """OAuth account linking/unlinking router."""
 
+import logging
 import secrets
 import uuid
+from urllib.parse import urlsplit, urlunsplit
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import RedirectResponse
@@ -26,6 +28,7 @@ from .schemas import (
 
 settings = get_settings()
 router = APIRouter(prefix="/accounts", tags=["accounts"])
+logger = logging.getLogger(__name__)
 
 # API prefix for building URLs
 API_V1_PREFIX = "/api/v1"
@@ -62,6 +65,52 @@ def _get_client_info(request: Request | None) -> tuple[str | None, str | None]:
     device_info = request.headers.get("User-Agent")
     ip_address = request.client.host if request.client else None
     return device_info, ip_address
+
+
+def _normalize_callback_url(url: str) -> str:
+    """Normalize callback URL by dropping only trailing slash and query/fragment."""
+    parsed = urlsplit(url)
+    path = parsed.path
+    if path.endswith("/") and path != "/":
+        path = path[:-1]
+    return urlunsplit((parsed.scheme, parsed.netloc, path, "", ""))
+
+
+def _build_link_redirect_uri(provider: str) -> str:
+    """Build canonical redirect URI for account-link callback."""
+    return (
+        f"{settings.API_URL.rstrip('/')}{API_V1_PREFIX}/accounts/link/{provider}/callback"
+    )
+
+
+def _validate_link_callback_url_or_raise(
+    *, request: Request, provider: str, expected_callback_url: str
+) -> None:
+    """Validate account-link callback URL with trailing-slash normalization."""
+    actual_callback_url = str(request.url.replace(query="", fragment=""))
+    normalized_expected = _normalize_callback_url(expected_callback_url)
+    normalized_actual = _normalize_callback_url(actual_callback_url)
+    if normalized_expected == normalized_actual:
+        if expected_callback_url != actual_callback_url:
+            logger.info(
+                "OAuth account-link callback URL normalized for provider=%s expected=%s actual=%s normalized_expected=%s normalized_actual=%s",
+                provider,
+                expected_callback_url,
+                actual_callback_url,
+                normalized_expected,
+                normalized_actual,
+            )
+        return
+
+    logger.warning(
+        "OAuth account-link callback URL mismatch for provider=%s expected=%s actual=%s normalized_expected=%s normalized_actual=%s",
+        provider,
+        expected_callback_url,
+        actual_callback_url,
+        normalized_expected,
+        normalized_actual,
+    )
+    raise HTTPException(status_code=400, detail="OAuth callback URL mismatch")
 
 
 @router.get("", response_model=list[OAuthAccountResponse])
@@ -101,12 +150,12 @@ async def start_link_account(
 
         await OAuthStateStore.save_with_data(state, state_data)
 
-        redirect_uri = f"{settings.API_URL}{API_V1_PREFIX}/accounts/link/google/callback"
+        redirect_uri = _build_link_redirect_uri("google")
         authorize_url = GoogleOAuth.get_authorize_url(redirect_uri, state, code_challenge)
     else:
         await OAuthStateStore.save_with_data(state, state_data)
 
-        redirect_uri = f"{settings.API_URL}{API_V1_PREFIX}/accounts/link/discord/callback"
+        redirect_uri = _build_link_redirect_uri("discord")
         authorize_url = DiscordOAuth.get_authorize_url(redirect_uri, state)
 
     return RedirectResponse(url=authorize_url)
@@ -127,7 +176,12 @@ async def google_link_callback(
     user_id = state_data.get("user_id")
     code_verifier = state_data.get("code_verifier")
 
-    redirect_uri = f"{settings.API_URL}{API_V1_PREFIX}/accounts/link/google/callback"
+    redirect_uri = _build_link_redirect_uri("google")
+    _validate_link_callback_url_or_raise(
+        request=request,
+        provider="google",
+        expected_callback_url=redirect_uri,
+    )
     token_data = await GoogleOAuth.exchange_code(code, redirect_uri, code_verifier)
     if not token_data:
         raise HTTPException(status_code=400, detail="Failed to exchange code")
@@ -200,7 +254,12 @@ async def discord_link_callback(
 
     user_id = state_data.get("user_id")
 
-    redirect_uri = f"{settings.API_URL}{API_V1_PREFIX}/accounts/link/discord/callback"
+    redirect_uri = _build_link_redirect_uri("discord")
+    _validate_link_callback_url_or_raise(
+        request=request,
+        provider="discord",
+        expected_callback_url=redirect_uri,
+    )
     token_data = await DiscordOAuth.exchange_code(code, redirect_uri)
     if not token_data:
         raise HTTPException(status_code=400, detail="Failed to exchange code")

--- a/api/tests/test_accounts.py
+++ b/api/tests/test_accounts.py
@@ -1,14 +1,20 @@
 """Accounts API tests."""
 
+import importlib
+import logging
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from fastapi import HTTPException
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.accounts.schemas import UNLINK_LAST_AUTH_METHOD_ERROR_DETAIL
 from app.auth.tokens import create_access_token
 from app.models import OAuthAccount, User
+
+accounts_router_module = importlib.import_module("app.accounts.router")
 
 
 @pytest.mark.asyncio
@@ -194,3 +200,58 @@ async def test_unlink_account_logs_audit_with_request_actor_target(
     assert details["request_id"] == "req-accounts-unlink-123"
     assert details["actor"] == str(user.id)
     assert details["target"] == "oauth-account:google:google-user-audit-1"
+
+
+def test_link_normalize_callback_url_trims_only_trailing_slash():
+    """Only trailing slash should be normalized for account-link callback."""
+    normalized = accounts_router_module._normalize_callback_url(
+        "https://api.example.com/api/v1/accounts/link/google/callback/?code=abc#frag"
+    )
+    assert normalized == "https://api.example.com/api/v1/accounts/link/google/callback"
+
+
+def test_link_validate_callback_url_allows_trailing_slash_difference(caplog):
+    """Trailing slash difference must be accepted for account-link callback."""
+    caplog.set_level(logging.INFO, logger=accounts_router_module.logger.name)
+    request = SimpleNamespace(
+        url=SimpleNamespace(
+            replace=lambda **kwargs: (
+                "https://api.example.com/api/v1/accounts/link/google/callback/"
+            )
+        )
+    )
+
+    accounts_router_module._validate_link_callback_url_or_raise(
+        request=request,
+        provider="google",
+        expected_callback_url="https://api.example.com/api/v1/accounts/link/google/callback",
+    )
+
+    assert (
+        "OAuth account-link callback URL normalized for provider=google "
+        "expected=https://api.example.com/api/v1/accounts/link/google/callback "
+        "actual=https://api.example.com/api/v1/accounts/link/google/callback/ "
+        "normalized_expected=https://api.example.com/api/v1/accounts/link/google/callback "
+        "normalized_actual=https://api.example.com/api/v1/accounts/link/google/callback"
+    ) in caplog.text
+
+
+def test_link_validate_callback_url_rejects_real_mismatch():
+    """Real mismatch should keep stable 400 contract."""
+    request = SimpleNamespace(
+        url=SimpleNamespace(
+            replace=lambda **kwargs: (
+                "https://api.example.com/api/v1/accounts/link/google/other-callback"
+            )
+        )
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        accounts_router_module._validate_link_callback_url_or_raise(
+            request=request,
+            provider="google",
+            expected_callback_url="https://api.example.com/api/v1/accounts/link/google/callback",
+        )
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail == "OAuth callback URL mismatch"


### PR DESCRIPTION
## 概要
- `api/app/accounts/router.py` に auth と同じ callback URL 正規化ロジックを追加
- Google/Discord の account-link callback で URL 正規化を使った検証を導入
- redirect URI 生成を `settings.API_URL.rstrip('/')` ベースに共通化

## テスト
- `api/.venv/bin/python -m pytest api/tests/test_auth_callback_url_normalization.py`
- `api/.venv/bin/python -m pytest api/tests/test_accounts.py -k link`

## 影響
- trailing slash / query / fragment の差分で accounts link callback が誤判定しにくくなります
- unsupported provider の 400 や link 成功時 redirect の契約は維持しています

Closes #603
