### PR TITLE
docs: add weekly git inventory runbook for issue #560

### DIFF
--- a/docs/help/weekly-git-inventory.md
+++ b/docs/help/weekly-git-inventory.md
@@ -1,0 +1,33 @@
+# 週次Git棚卸し Runbook
+
+この手順は、`yesod-auth` の Git 状態を週次で確認し、重複コメントを避けながら記録するための運用手順です。
+
+## 目的
+
+- 未整理ブランチ、未コミット変更、不要な差分の早期発見
+- Issue `#560`（週次Git棚卸し）への定期記録の標準化
+- OSS 運用時の再現性確保
+
+## 実行コマンド
+
+```bash
+bash scripts/weekly_git_inventory.sh
+```
+
+## 出力に含まれる内容
+
+- JST 日付付きの棚卸しヘッダー
+- working tree の clean/dirty 状態
+- 直近ローカルブランチ一覧（最大20件）
+- `origin/main` 比較の ahead/behind
+- `origin/main` にマージ済みの `origin/codex/issue-*` 候補
+
+## Issue 追記ルール
+
+1. 同一 JST 日付のコメントが既にある場合は重複投稿しない
+2. 未確認項目は推測で埋めず `未確認` として残す
+3. コメント先は `mashirou1234/yesod-auth` の `#560` のみ
+
+## 参考
+
+- [週次Git棚卸し Issue #560](https://github.com/mashirou1234/yesod-auth/issues/560)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -80,6 +80,7 @@ nav:
     - FAQ: help/faq.md
     - 初回起動トラブルシュート: help/first-start-troubleshooting.md
     - トラブルシューティング: help/troubleshooting.md
+    - 週次Git棚卸し Runbook: help/weekly-git-inventory.md
 
 extra:
   social:

--- a/scripts/weekly_git_inventory.sh
+++ b/scripts/weekly_git_inventory.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT_DIR"
+
+JST_DATE="$(TZ=Asia/Tokyo date +%F)"
+CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+REMOTE_MAIN="origin/main"
+
+if ! git rev-parse --verify "$REMOTE_MAIN" >/dev/null 2>&1; then
+  git fetch origin main >/dev/null 2>&1 || true
+fi
+
+echo "## 週次Git棚卸し（${JST_DATE}）"
+echo
+echo "- Repository: $(basename "$ROOT_DIR")"
+echo "- Current branch: ${CURRENT_BRANCH}"
+echo
+echo "### Working tree"
+if [ -n "$(git status --porcelain)" ]; then
+  git status --short
+else
+  echo "- clean"
+fi
+echo
+echo "### Local branch summary"
+git for-each-ref refs/heads \
+  --sort=-committerdate \
+  --format='- %(refname:short) | %(committerdate:short) | %(authorname) | %(subject)' \
+  | head -n 20
+echo
+echo "### Ahead/behind vs origin/main"
+if git rev-parse --verify "$REMOTE_MAIN" >/dev/null 2>&1; then
+  git rev-list --left-right --count "${REMOTE_MAIN}...HEAD" \
+    | awk '{printf("- ahead=%s behind=%s\n", $2, $1)}'
+else
+  echo "- origin/main が未取得のため未確認"
+fi
+echo
+echo "### Remote branch candidates (merged into origin/main)"
+if git rev-parse --verify "$REMOTE_MAIN" >/dev/null 2>&1; then
+  git branch -r --merged "$REMOTE_MAIN" \
+    | sed 's/^ *//' \
+    | rg '^origin/codex/issue-' \
+    | head -n 20 || true
+else
+  echo "- origin/main が未取得のため未確認"
+fi


### PR DESCRIPTION
## Summary
- add `scripts/weekly_git_inventory.sh` to standardize weekly Git inventory output
- add docs runbook `docs/help/weekly-git-inventory.md` for OSS operators
- add MkDocs nav entry under Help

## Validation
- `bash scripts/weekly_git_inventory.sh`
- `mkdocs build -q` (failed: `mkdocs` command not found in local env)

## Related
- refs #560
