### PR TITLE
docs: add webhook audit key guide

### DIFF
--- a/docs/api/webhooks.md
+++ b/docs/api/webhooks.md
@@ -86,6 +86,29 @@ GET /api/v1/admin/webhooks/deliveries
 - 受信側は `event_id`（必要に応じて `endpoint_id` も併用）を冪等キーにして重複処理を防止してください。
 - タイムアウトや 5xx の場合は再送が発生するため、同一 `event_id` の処理は再実行しても結果が変わらない実装を推奨します。
 
+<a id="webhook-audit-key-map"></a>
+
+### 監査キーの読み方（再送・重複調査）
+
+Webhook の再送、重複受信、署名失敗を調査するときは、最初に次のキーを同じ調査メモへ集約してください。
+
+| キー | 取得元 | 用途 |
+|------|--------|------|
+| `event_id` | 配信履歴の JSON ボディ / 受信 payload | 同一イベントの再送かを判断する主キー |
+| `endpoint_id` | 配信履歴 / `X-Webhook-ID` / payload の `webhook_id` | どの送信先で発生したかを絞り込む |
+| `request_id` | API ログ / 受信側アクセスログ | API ログと受信側ログを突合する |
+| `X-Webhook-ID` | 受信リクエストヘッダー | 受信側ログで endpoint を確認する |
+| `X-Webhook-Event` | 受信リクエストヘッダー | イベント種別の偏りを確認する |
+| `id` | 配信履歴の delivery レコード | 個別配信レコードを参照する。冪等キーには使わない |
+| `attempt_count` | 配信履歴 | 何回目の試行かを確認する。冪等キーには使わない |
+
+再送調査では `event_id` が同じで `attempt_count` が増えている場合を同一イベントの再試行として扱います。
+`endpoint_id` が異なる場合は別送信先への配信なので、受信側の重複判定では `event_id` と `endpoint_id` を組み合わせてください。
+`request_id` は payload には含まれないため、API ログまたは受信側アクセスログで同時刻・同一 `event_id` と突き合わせます。
+
+関連する調査順は [Webhook設定ガイド: 配信失敗時のログ確認項目](../guides/webhooks.md#配信失敗時のログ確認項目) と
+[トラブルシューティング: Webhook](../help/troubleshooting.md#webhook) を参照してください。
+
 ---
 
 ## 設定リロード

--- a/docs/guides/webhooks.md
+++ b/docs/guides/webhooks.md
@@ -275,6 +275,10 @@ API 契約の詳細は [Webhook API: 冪等性の注意点（再送時）](../ap
 docker compose logs api --since=30m | rg "webhook|delivery|retry|timeout|request_id"
 ```
 
+再送・重複受信の調査では、`event_id` を主キーにし、送信先別の切り分けが必要な場合だけ `endpoint_id` を組み合わせます。
+`X-Webhook-ID` と `X-Webhook-Event` は受信側ログの検索キーとして残し、`request_id` は API ログと受信側ログの突合に使います。
+各キーの取得元と使い分けは [Webhook API: 監査キーの読み方（再送・重複調査）](../api/webhooks.md#webhook-audit-key-map) を参照してください。
+
 詳細な切り分け手順は [トラブルシューティング: Webhook](../help/troubleshooting.md#webhook) を参照してください。
 
 ## 管理API

--- a/docs/help/troubleshooting.md
+++ b/docs/help/troubleshooting.md
@@ -686,6 +686,8 @@ FAQ での方針説明は [FAQ: Adminで未翻訳キーが出たときの表示�
 | `x_webhook_event` | `user.login` | どの通知イベントで失敗したか追跡できるか |
 | `request_id` | `req-...` | APIログと相互参照できるか |
 
+再送・重複処理の調査では、`event_id` と `endpoint_id` の組み合わせを先に確定し、delivery レコードの `id` や `attempt_count` は個別試行の確認だけに使います。
+キーごとの取得元は [Webhook API: 監査キーの読み方（再送・重複調査）](../api/webhooks.md#webhook-audit-key-map) を参照してください。
 署名鍵ローテーション時の手順は [Webhook API の `reload` 説明](../api/webhooks.md#署名鍵ローテーション時の利用) を参照。
 監査ログ項目の完全版は [Webhook設定ガイド: 署名検証失敗時の監査ログ項目](../guides/webhooks.md#署名検証失敗時の監査ログ項目) を参照。
 


### PR DESCRIPTION
## Summary
- Add a centralized webhook audit key map for resend, duplicate handling, and signature failure investigation.
- Link the webhook guide and troubleshooting flow back to the stable API anchor.
- Clarify that `event_id` is the primary resend key, `endpoint_id` scopes delivery targets, and `request_id` is for log correlation.

## Verification
- `rg -n "event_id|X-Webhook-ID|X-Webhook-Event|request_id" docs/api/webhooks.md docs/guides/webhooks.md docs/help/troubleshooting.md`
- `rg -n "FAQ|installation|troubleshooting" docs/help/faq.md docs/installation.md docs/help/troubleshooting.md`
- `docker compose --profile default config`
- `git diff --check`

## Project / Priority
- Linked Project: N/A (`projectItems` empty)
- Selection lane: normal `codex:queue`; no open `codex:blocked` or `codex:priority,codex:queue` issue was eligible

## Public impact
Docs-only change. It improves OSS self-hosted webhook operations by making audit identifiers easier to find; no API, payload, or runtime behavior changes.

Closes #605
