### PR TITLE
docs: sync provider unset onboarding path

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -43,17 +43,18 @@ providerごとの必須 secret 名は [OAuth設定ハブの一覧](guides/oauth/
 
 ### provider 未設定時の最短スキップ手順
 
-未設定の provider がある場合でも、初回起動確認は中断せずに進められます。
+OAuth provider をまだ一部用意できていない場合でも、初回起動確認は中断せずに進められます。
 
-1. 起動対象を `default` profile に固定する（Mock OAuth 前提）
+1. `default` profile で起動し、Mock OAuth で疎通確認する
 2. 必須 secret は `jwt_secret` と、今回有効化する provider 分だけ作成する
-3. 未設定 provider は触らず、[3. 起動](#3-起動) と [4. 動作確認](#4-動作確認) まで先に完了させる
-4. 実 OAuth を使うタイミングで、対象 provider の `*_client_id` / `*_client_secret` を追加して再起動する
+3. 未設定 provider の認証導線（`GET /api/v1/auth/<provider>`）は呼ばず、[3. 起動](#3-起動) と [4. 動作確認](#4-動作確認) で `/health` と `/docs` の到達確認を先に完了する
+4. 対象 provider の `*_client_id` / `*_client_secret` を追加し、`docker compose --profile default up -d --force-recreate api` で実 OAuth を再開する
 
 再開ポイント:
-- 起動確認を先に進める場合は [4. 動作確認](#4-動作確認)
-- 実 OAuth を再開する場合は [Mock OAuthから実OAuthへ切り替える最小チェック](#mock-oauthから実oauthへ切り替える最小チェック)
-- 失敗時の切り分けは [トラブルシューティング](help/troubleshooting.md#provider-未設定のまま認証導線を実行した) を参照
+- 起動確認の継続: [4. 動作確認](#4-動作確認)
+- 実 OAuth の再開: [Mock OAuthから実OAuthへ切り替える最小チェック](#mock-oauthから実oauthへ切り替える最小チェック)
+- 失敗時: [トラブルシューティング: provider 未設定のまま認証導線を実行した](help/troubleshooting.md#provider-未設定のまま認証導線を実行した)
+- FAQ での要点確認: [provider 未設定のまま初回導入を進めてもよい？](help/faq.md#provider-未設定のまま初回導入を進めてもよい)
 
 ### FAQ / installation / troubleshooting 同期チェックコマンド
 

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -55,12 +55,16 @@ YESOD AuthはGoogle OAuthでPKCEを自動的に使用します。
 
 可能です。次の順で進めると最短で起動確認できます。
 
-1. `default` profile で起動し、`jwt_secret` と有効化する provider 分だけ先に設定する
-2. 未設定 provider の認証導線は呼ばず、`/health` と `/docs` の到達確認を先に完了する
-3. OAuth 設定がそろった時点で `docker compose --profile default up -d --force-recreate api` を実行して再開する
+1. `default` profile で起動し、Mock OAuth で疎通確認する
+2. 必須 secret は `jwt_secret` と、今回有効化する provider 分だけ作成する
+3. 未設定 provider の認証導線（`GET /api/v1/auth/<provider>`）は呼ばず、`/health` と `/docs` の到達確認を先に完了する
+4. 対象 provider の `*_client_id` / `*_client_secret` を追加し、`docker compose --profile default up -d --force-recreate api` で実 OAuth を再開する
 
-再開ポイントは [クイックスタート: provider 未設定時の最短スキップ手順](../getting-started.md#provider-未設定時の最短スキップ手順) を参照してください。  
-導線全体は [インストール](../installation.md#provider-未設定時の最短スキップ手順) と [トラブルシューティング](./troubleshooting.md#provider-未設定のまま認証導線を実行した) で同期しています。
+再開ポイント:
+- 起動確認の継続: [クイックスタート: provider 未設定時の最短スキップ手順](../getting-started.md#provider-未設定時の最短スキップ手順)
+- 実 OAuth の再開: [Mock OAuthから実OAuthへ切り替える最小確認は？](#mock-oauthから実oauthへ切り替える最小確認は)
+- 失敗時: [トラブルシューティング: provider 未設定のまま認証導線を実行した](./troubleshooting.md#provider-未設定のまま認証導線を実行した)
+- 詳細手順: [インストール: provider 未設定時の最短スキップ手順](../installation.md#provider-未設定時の最短スキップ手順)
 
 ### OAuth secretを更新したら再起動は必要？
 

--- a/docs/help/troubleshooting.md
+++ b/docs/help/troubleshooting.md
@@ -229,13 +229,13 @@ environment:
 **最短対応:**
 
 1. 未設定 provider の導線呼び出しを一度止める
-2. `curl -fsS http://localhost:8000/health` と `curl -fsS -o /dev/null -w '%{http_code}\n' http://localhost:8000/docs` で起動確認を先に完了する
-3. 対象 provider の `*_client_id` / `*_client_secret` を追加し、`docker compose --profile default up -d --force-recreate api` で再開する
+2. `default` profile のまま、`curl -fsS http://localhost:8000/health` と `curl -fsS -o /dev/null -w '%{http_code}\n' http://localhost:8000/docs` で起動確認を先に完了する
+3. 対象 provider の `*_client_id` / `*_client_secret` を追加し、`docker compose --profile default up -d --force-recreate api` で実 OAuth を再開する
 
 再開ポイント:
-- [クイックスタート: provider 未設定時の最短スキップ手順](../getting-started.md#provider-未設定時の最短スキップ手順)
-- [インストール: provider 未設定時の最短スキップ手順](../installation.md#provider-未設定時の最短スキップ手順)
-- [FAQ: Mock OAuthから実OAuthへ切り替える最小確認は？](./faq.md#mock-oauthから実oauthへ切り替える最小確認は)
+- 起動確認の継続: [クイックスタート: provider 未設定時の最短スキップ手順](../getting-started.md#provider-未設定時の最短スキップ手順)
+- 実 OAuth の再開: [FAQ: Mock OAuthから実OAuthへ切り替える最小確認は？](./faq.md#mock-oauthから実oauthへ切り替える最小確認は)
+- 詳細手順: [インストール: provider 未設定時の最短スキップ手順](../installation.md#provider-未設定時の最短スキップ手順)
 
 ---
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -59,8 +59,8 @@ OAuth provider をまだ一部用意できていない場合は、次の手順�
 
 1. `default` profile で起動し、Mock OAuth で疎通確認する
 2. 必須 secret は `jwt_secret` と、今回有効化する provider 分だけ作成する
-3. 未設定 provider は `GET /api/v1/auth/<provider>` を呼ばず、先に health/docs 到達確認を完了する
-4. OAuth 設定完了後に provider の secret を追加し、`docker compose --profile default up -d --force-recreate api` で再開する
+3. 未設定 provider の認証導線（`GET /api/v1/auth/<provider>`）は呼ばず、先に `/health` と `/docs` の到達確認を完了する
+4. 対象 provider の `*_client_id` / `*_client_secret` を追加し、`docker compose --profile default up -d --force-recreate api` で実 OAuth を再開する
 
 再開ポイント:
 - 起動確認の継続: [docker compose利用時の最小確認手順](#docker-compose利用時の最小確認手順)


### PR DESCRIPTION
## Summary
- Sync provider-unset onboarding wording across getting-started, installation, FAQ, and troubleshooting.
- Standardize the resume point around `default` profile, health/docs verification, and `api` force-recreate for real OAuth.
- Keep the existing `rg` synchronization check usable for future documentation reviews.

## Public impact
- Documentation-only change.
- Self-hosted operators get the same minimum recovery/resume path from all four entry points.

## Verification
- `rg -n "provider 未設定時の最短スキップ手順|再開ポイント" docs/getting-started.md docs/installation.md docs/help/faq.md docs/help/troubleshooting.md`
- `git diff --check`
- `docker compose --profile default config --services`
- `uv run --with-requirements requirements.txt pytest tests/test_health.py` from `api/`
- `uvx --from mkdocs-material mkdocs build --strict`

Closes #612
