### PR TITLE
docs: sync compose profile checks

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -136,12 +136,13 @@ docker compose --profile ci config | rg "MOCK_OAUTH_ENABLED|api-ci:"
 ### profile別の初回確認コマンド表
 
 初回導入では、使う profile を1つ決めてから次の表の順で実行すると、確認漏れを防げます。
+`valkey` は `default` / `full` / `ci` のすべてで起動対象です。`/health` が失敗する場合は、先に [トラブルシューティング: preflight で valkey 到達確認に失敗する](help/troubleshooting.md#valkey-preflight-failure) で対象 profile の `valkey` を確認してください。
 
 | profile | 使う場面 | 初回確認コマンド（順番どおり） | 合格基準 |
 | --- | --- | --- | --- |
 | `default` | API と Docs の最短導入確認 | `docker compose --profile default up -d`<br>`docker compose --profile default ps`<br>`curl -fsS http://localhost:8000/health` | `db` `valkey` `api` `docs` が `Up`、`{"status":"healthy"}` が返る |
-| `full` | 管理画面 (`admin`) を含めて確認 | `ls -l secrets/admin_password.txt`<br>`docker compose --profile full up -d`<br>`docker compose --profile full config --services` | `secrets/admin_password.txt` が存在し、`admin` が services 一覧に出る |
-| `ci` | CI相当の軽量構成で確認 | `docker compose --profile ci up -d`<br>`docker compose --profile ci config --services`<br>`docker compose --profile ci ps` | `db-ci` `valkey` `api-ci` が起動し、不要な `admin` が含まれない |
+| `full` | 管理画面 (`admin`) を含めて確認 | `ls -l secrets/admin_password.txt`<br>`docker compose --profile full up -d`<br>`docker compose --profile full ps`<br>`curl -fsS http://localhost:8000/health` | `db` `valkey` `admin` `api` `docs` が `Up`、`{"status":"healthy"}` が返る |
+| `ci` | CI相当の軽量構成で確認 | `docker compose --profile ci up -d`<br>`docker compose --profile ci ps`<br>`curl -fsS http://localhost:8001/health` | `db-ci` `valkey` `api-ci` が `Up`、`{"status":"healthy"}` が返る |
 
 詳細な profile 判定観点は [インストール: profile選択チェック表](installation.md#profile選択チェック表) を参照してください。
 ## 3.5 初回ヘルスチェック（推奨）

--- a/docs/help/troubleshooting.md
+++ b/docs/help/troubleshooting.md
@@ -43,15 +43,17 @@ docker compose logs api --since=30m | rg -n "Invalid state|callback|invalid_clie
    docker compose --profile full config --services | rg -x 'valkey'
    docker compose --profile ci config --services | rg -x 'valkey'
    ```
-2. `valkey` コンテナ状態を確認する
+2. 選択した profile で `valkey` コンテナ状態を確認する
    ```bash
-   docker compose ps valkey
-   docker compose logs valkey --since=30m
+   docker compose --profile default ps valkey
+   docker compose --profile default logs valkey --since=30m
    ```
-3. `PING` の再実行で復旧確認する
+   `full` または `ci` を使っている場合は、`--profile default` を対象 profile に置き換えてください。
+3. 同じ profile で `PING` の再実行により復旧確認する
    ```bash
-   docker compose exec valkey sh -lc 'valkey-cli ping || redis-cli ping'
+   docker compose --profile default exec valkey sh -lc 'valkey-cli ping || redis-cli ping'
    ```
+   `PONG` が返れば `health` の依存サービス確認へ戻れます。
 
 **対処:** `valkey` が `Up` で `PING` が `PONG` になるまで、ポート競合・ボリューム破損・起動失敗ログを優先して解消します。導線は [インストール: Docker起動前チェック項目](../installation.md#docker起動前チェック項目) を基準に戻してください。
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,8 +20,8 @@
 
 初回導入時は、次の順序で確認すると最短で環境を立ち上げられます。
 
-1. [インストール](installation.md): 必要要件と `default` / `full` / `ci` プロファイル差分を確認
-2. [クイックスタート](getting-started.md): シークレット作成から起動・ヘルスチェックまで実施
+1. [インストール](installation.md): 必要要件、`default` / `full` / `ci` の profile 選択、`valkey` 前提を確認
+2. [クイックスタート](getting-started.md): 選択した profile でシークレット作成から起動・ヘルスチェックまで実施
 3. [OAuth設定ガイド](guides/oauth/index.md): 使用するプロバイダーだけを有効化
 
 ## 運用者向け最短導線

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -39,19 +39,19 @@ YESOD Authは3つのプロファイルを提供しています：
 
 | プロファイル | 用途 | サービス |
 |-------------|------|---------|
-| `default` | ローカル開発 | db, api, docs (`valkey` は常時有効) |
-| `full` | 管理画面含む | db, api, admin, docs (`valkey` は常時有効) |
-| `ci` | CI/CD | db-ci, api-ci (`valkey` は常時有効) |
+| `default` | ローカル開発 | db, valkey, api, docs |
+| `full` | 管理画面含む | db, valkey, admin, api, docs |
+| `ci` | CI/CD | db-ci, valkey, api-ci |
 
 ### profile選択チェック表
 
-初回導入時は、用途に応じて次の表で profile を選択してください。実行前後に [profile整合確認手順](#profile整合確認手順) で定義との差分を確認すると安全です。
+初回導入時は、用途に応じて次の表で profile を選択してください。`valkey` はすべての profile で起動対象です。実行前後に [profile整合確認手順](#profile整合確認手順) で定義との差分を確認すると安全です。
 
 | profile | この条件なら選ぶ | 最小確認コマンド |
 |---|---|---|
 | `default` | ローカルで API/Docs を最短で確認したい | `docker compose --profile default up -d`<br>`docker compose --profile default ps`<br>`curl -fsS http://localhost:8000/health` |
-| `full` | 管理画面 (`admin`) まで含めて導入確認したい | `ls -l secrets/admin_password.txt`<br>`docker compose --profile full up -d`<br>`docker compose --profile full config --services` |
-| `ci` | CI 相当の軽量構成だけ確認したい | `docker compose --profile ci up -d`<br>`docker compose --profile ci config --services`<br>`docker compose --profile ci ps` |
+| `full` | 管理画面 (`admin`) まで含めて導入確認したい | `ls -l secrets/admin_password.txt`<br>`docker compose --profile full up -d`<br>`docker compose --profile full ps`<br>`curl -fsS http://localhost:8000/health` |
+| `ci` | CI 相当の軽量構成だけ確認したい | `docker compose --profile ci up -d`<br>`docker compose --profile ci ps`<br>`curl -fsS http://localhost:8001/health` |
 
 ### provider 未設定時の最短スキップ手順
 
@@ -70,7 +70,7 @@ OAuth provider をまだ一部用意できていない場合は、次の手順�
 
 ## Docker起動前チェック項目
 
-`docker compose up` 実行前に、次の6項目を確認してください。
+`docker compose up` 実行前に、次の7項目を確認してください。
 
 1. Docker Engine / Docker Compose のバージョン確認
 
@@ -121,6 +121,8 @@ lsof -nP -iTCP:8000 -iTCP:5432 -iTCP:6379 -sTCP:LISTEN
 - 初回導入確認: `default`
 - 管理画面確認まで行う場合: `full`
 - CI相当確認のみ: `ci`
+
+選択した profile の起動後確認は、[クイックスタート: profile別の初回確認コマンド表](getting-started.md#profile別の初回確認コマンド表) と同じ順序で実行してください。
 
 7. Valkey 到達確認（profile別）
 


### PR DESCRIPTION
## Summary
- Sync `installation` and `getting-started` profile tables so `default`, `full`, and `ci` use the same service/health-check semantics.
- Make the shared `valkey` dependency explicit across onboarding docs and troubleshooting.
- Point the docs index at the profile-selection + `valkey` prerequisite before the quick-start flow.

## Public/Operator Impact
- Docs-only change. No Compose services or API behavior changes.
- New self-hosted users get a consistent profile choice and health-check path: `default/full` on port 8000, `ci` on port 8001.

## Verification
- `rg -n "default|full|ci|valkey|health" docs/installation.md docs/getting-started.md docs/help/troubleshooting.md docs/index.md`
- `docker compose config --profiles`
- `docker compose --profile default config --services`
- `docker compose --profile full config --services`
- `docker compose --profile ci config --services`
- `git diff --check`

## Not Run
- `docker compose --profile default run --rm docs build --strict` did not complete because pulling `squidfunk/mkdocs-material:latest` stalled locally; the pull was stopped before the build phase.

Closes #613
