### PR TITLE
docs: align callback troubleshooting flow

### DIFF
--- a/docs/api/auth.md
+++ b/docs/api/auth.md
@@ -80,6 +80,19 @@
 
 `redirect_uri_mismatch` を最短で確認する手順は [クイックスタート](../getting-started.md#25-redirect_uri_mismatch-の最短確認5ステップ) を参照してください。失敗時の切り分けは [トラブルシューティング](../help/troubleshooting.md#認証エラー) へ接続してください。
 
+#### callback 障害時の参照順
+
+callback / state mismatch / `invalid_client` の切り分けは、トラブルシューティングと同じ `health` -> `auth` -> `provider` -> `webhook` の順で進めます。
+
+| 段階 | 確認すること | 最小コマンド/参照先 |
+| --- | --- | --- |
+| `health` | API と依存サービスが起動しているか | `curl -fsS http://localhost:8000/health` |
+| `auth` | callback が二重実行・期限切れ state・認可コード交換失敗のどれか | `docker compose logs api --since=30m \| rg -n "Invalid state\|/api/v1/auth/.*/callback\|Failed to exchange code"` |
+| `provider` | `client_id` / `client_secret` / provider 側 callback URL が一致しているか | [トラブルシューティング: `401 Unauthorized` / `invalid_client`](../help/troubleshooting.md#401-unauthorized--invalid_client) |
+| `webhook` | 認証後イベントの配送遅延・失敗が別問題として起きていないか | [Webhook設定ガイド](../guides/webhooks.md#ローカルテスト) |
+
+`auth` 段階で `Invalid or expired state` が返る場合は [state mismatch の最小診断例](#state-mismatch-の最小診断例) に進み、`invalid_client` が見える場合は `provider` 段階へ進んで secret と provider 管理画面の callback URL を確認してください。
+
 ### 1. 認証開始
 
 ユーザーを認証エンドポイントにリダイレクト：
@@ -377,7 +390,7 @@ Content-Type: application/json
 
 ### `state mismatch` の最小診断例
 
-`GET /api/v1/auth/{provider}/callback` で `400 Invalid or expired state` が返った場合は、次の2コマンドで「再送」か「状態消失」かを先に切り分けます。
+`GET /api/v1/auth/{provider}/callback` で `400 Invalid or expired state` が返った場合は、[callback 障害時の参照順](#callback-障害時の参照順) の `auth` 段階として、次の2コマンドで「再送」か「状態消失」かを先に切り分けます。
 
 ```bash
 # 1) callback の重複実行有無を確認

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -120,17 +120,20 @@ organization 制限が必要な場合は、次を追加実装してください�
 
 ### 認証失敗時の一次分類は？
 
-まずは次の順で確認すると、OAuth 導入初期やセルフホスト運用でも誤判定を減らせます。
+まずはトラブルシューティングと同じ `health` -> `auth` -> `provider` -> `webhook` の順で確認すると、OAuth 導入初期やセルフホスト運用でも誤判定を減らせます。
 
-1. 失敗した API の HTTP ステータスを確定する
-2. API ログから代表メッセージ（`detail` / エラーコード）を拾う
-3. 下表で一次分類し、対応するドキュメントへ遷移する
+1. `health`: `curl -fsS http://localhost:8000/health` で API と依存サービスの生存を確認する
+2. `auth`: 失敗した API の HTTP ステータスを確定し、API ログから `Invalid state` / callback / `invalid_client` を拾う
+3. `provider`: `client_id` / `client_secret` と provider 管理画面の callback URL を確認する
+4. `webhook`: 認証後イベントの配送遅延・失敗が別問題として起きていないか確認する
+5. 下表で一次分類し、対応するドキュメントへ遷移する
 
 | 一次分類 | 典型シグナル | 主な原因 | 初動アクション | 最初に見る場所 |
 | --- | --- | --- | --- | --- |
 | 入力不正（422） | `Field required` / `Input should be a valid string` | `refresh_token` の欠落・型不正 | リクエスト JSON と型を修正して再送 | [`認証API: refresh失敗時エラー分類`](../api/auth.md#refresh失敗時エラー分類) |
 | 認証失敗（401） | `Not authenticated` / `Could not validate credentials` | access/refresh token の期限切れ・失効・改ざん | `/api/v1/auth/refresh` を1回試し、失敗なら再ログイン | [`トラブルシューティング: 認証エラー`](./troubleshooting.md#認証エラー) |
 | state不整合（400） | `Invalid or expired state` | callback 二重実行、Valkey不安定、環境不一致 | 同一 host/scheme で認証開始からやり直し、Valkey ログ確認 | [`トラブルシューティング: state mismatch 診断フロー`](./troubleshooting.md#state-mismatch-flow) |
+| provider設定不整合（400/401） | `invalid_client` / `Failed to exchange code` | provider 側 secret・callback URL・redirect URI の不一致 | secret と provider 管理画面の callback URL を確認 | [`トラブルシューティング: 401 Unauthorized / invalid_client`](./troubleshooting.md#401-unauthorized--invalid_client) |
 | レート制限（429） | `Rate limit exceeded` / `Too Many Requests` | 短時間の連続アクセス、制限値過小 | 連続試行を止め、制限値とアクセス集中を確認 | [`トラブルシューティング: 429 Too Many Requests`](./troubleshooting.md#auth-rate-limit-429) |
 
 運用メモとして、分類時は「発生時刻」「対象エンドポイント」「利用プロバイダー（mock/google/github等）」をセットで記録すると再現調査が容易です。

--- a/docs/help/troubleshooting.md
+++ b/docs/help/troubleshooting.md
@@ -13,7 +13,7 @@
 
 ```bash
 curl -fsS http://localhost:8000/health
-docker compose logs api --since=30m | rg -n "Invalid state|callback|invalid_client|401"
+docker compose logs api --since=30m | rg -n "Invalid state|/api/v1/auth/.*/callback|invalid_client|401"
 ```
 
 段階ごとの参照先ショートカット:
@@ -21,7 +21,7 @@ docker compose logs api --since=30m | rg -n "Invalid state|callback|invalid_clie
 | 段階 | まず見る場所 | 最小確認コマンド |
 | --- | --- | --- |
 | `health` | [初回起動トラブルシュート](./first-start-troubleshooting.md#症状1-health-が失敗する) | `curl -fsS http://localhost:8000/health` |
-| `auth` | [state mismatch 診断フロー](#state-mismatch-flow) | `docker compose logs api --since=30m \| rg "Invalid state\|/auth/.*/callback"` |
+| `auth` | [state mismatch 診断フロー](#state-mismatch-flow) | `docker compose logs api --since=30m \| rg "Invalid state\|/api/v1/auth/.*/callback"` |
 | `provider` | [`401 Unauthorized` / `invalid_client`](#401-unauthorized--invalid_client) | `docker compose logs --tail=100 api \| rg -n "invalid_client\|401\|client_secret\|client_id"` |
 | `webhook` | [Webhook設定ガイド](../guides/webhooks.md#ローカルテスト) | `curl -fsS http://localhost:8000/api/v1/admin/webhooks/endpoints` |
 
@@ -163,14 +163,14 @@ sqlalchemy.exc.OperationalError: could not connect to server
 0. ログ採取ウィンドウを統一する（推奨値）
    ```bash
    SINCE=30m
-   docker compose logs api --since="$SINCE" | rg -n "Invalid state|/auth/.*/callback"
+   docker compose logs api --since="$SINCE" | rg -n "Invalid state|/api/v1/auth/.*/callback"
    docker compose logs valkey --since="$SINCE"
    ```
    - API/Valkey は同一 `--since` を使い、時系列比較を容易にする
    - 例外調査で範囲を広げる場合も、両ログで同じ値にそろえる
 1. 発生時刻とリクエストを特定する（APIログ）
    ```bash
-   docker compose logs api --since="$SINCE" | rg "Invalid state|/auth/.*/callback"
+   docker compose logs api --since="$SINCE" | rg "Invalid state|/api/v1/auth/.*/callback"
    ```
 2. `state` が一度だけ消費される前提を確認する（再送/二重callbackの有無）
    - 同一ブラウザ操作で callback が複数回呼ばれていないか
@@ -285,24 +285,37 @@ environment:
 
 #### invalid_client 再発防止チェック（デプロイ前後で毎回実施）
 
-次の 4 項目を上から順に実施し、すべて満たした場合のみ OAuth 設定変更を完了とします。
+次の 7 項目を上から順に実施し、必要な段階を満たした場合のみ OAuth 設定変更を完了とします。順序は [障害時の参照順](#障害時の参照順最短導線) と同じく `health` -> `auth` -> `provider` -> `webhook` を維持します。
 
-1. 対象 provider の secret ファイルが 2 つとも存在することを確認する
+1. `health` と API ドキュメントの到達性を先に確認する
+   ```bash
+   curl -fsS http://localhost:8000/health
+   curl -fsS -o /dev/null -w '%{http_code}\n' http://localhost:8000/docs
+   ```
+2. `auth` callback の失敗ログを抽出し、`Invalid state` と `invalid_client` を分ける
+   ```bash
+   docker compose logs api --since=30m | rg -n "Invalid state|/api/v1/auth/.*/callback|invalid_client|401"
+   ```
+3. `provider` の secret ファイルが 2 つとも存在することを確認する
    ```bash
    ls -l secrets/github_client_id.txt secrets/github_client_secret.txt
    ```
-2. 変更後の Compose 定義に対象 secret が含まれることを確認する
+4. 変更後の Compose 定義に対象 secret が含まれることを確認する
    ```bash
    docker compose config | rg -n "github_client_id|github_client_secret"
    ```
-3. API 再作成後に `invalid_client` が新規発生していないことを確認する
+5. API 再作成後に `invalid_client` が新規発生していないことを確認する
    ```bash
    docker compose up -d --force-recreate api
    docker compose logs api --since=10m | rg -n "invalid_client|401"
    ```
-4. callback URL が現在の公開 API URL と一致していることを provider 管理画面で確認する
+6. callback URL が現在の公開 API URL と一致していることを provider 管理画面で確認する
    - 形式: `https://<api-domain>/api/v1/auth/{provider}/callback`
    - self-host 運用時の基準は [OAuth設定ガイド](../guides/oauth/index.md#セルフホスト運用チェックリスト) を参照
+7. 認証後の通知が絡む場合だけ `webhook` の配送状態へ進む
+   ```bash
+   curl -fsS http://localhost:8000/api/v1/admin/webhooks/endpoints
+   ```
 
 上記チェックを実施しても再発する場合は、[インストール時の secret 不足診断](../installation.md#1-docker-compose-up-で-secret-未設定エラーになる) を再実行し、secret 名と実ファイル名の不一致を先に解消してください。
 


### PR DESCRIPTION
## Summary
- Align callback / state mismatch / invalid_client troubleshooting order across troubleshooting, auth API, and FAQ docs.
- Add the shared `health -> auth -> provider -> webhook` path to `docs/api/auth.md` and `docs/help/faq.md`.
- Tighten callback log examples to use `/api/v1/auth/{provider}/callback` consistently.

## Public impact
- Docs-only change. Self-hosted operators get a consistent first-10-minute diagnosis path for OAuth callback failures.
- No API behavior, provider configuration, secrets, or runtime defaults are changed.

## Verification
- `rg -n "Invalid state|invalid_client|callback|health|auth|provider|webhook" docs/help/troubleshooting.md docs/api/auth.md docs/help/faq.md`
- `git diff --check`

## Not run
- `mkdocs build --strict` (local `mkdocs` command is not installed in this worktree environment)

Refs #614
