### PR TITLE
docs: sync production deployment cutover docs

### DIFF
--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -2,6 +2,19 @@
 
 ## 本番環境の準備
 
+本番切替では、`docs/installation.md` と `docs/help/faq.md` と同じ順で確認します。順序を固定すると、Mock OAuth の残留、secret 不足、callback URL 不一致を切り分けやすくなります。
+
+1. `MOCK_OAUTH_ENABLED=0` を本番構成で確認する
+2. 有効化する provider 分だけ `*_client_id` / `*_client_secret` と `jwt_secret` を確認する
+3. provider 管理画面の callback URL を `https://<api-domain>/api/v1/auth/{provider}/callback` に更新する
+4. API を再起動/再デプロイし、`/health` と callback 監視の最小3点を確認する
+
+関連導線:
+
+- [インストール: profile別の環境変数優先順位](../installation.md#profile別の環境変数優先順位)
+- [インストール: OAuth認証情報](../installation.md#oauth認証情報)
+- [FAQ: 本番環境で必要な設定は？](../help/faq.md#本番環境で必要な設定は)
+
 ### 1. 環境変数の設定
 
 ```bash
@@ -13,9 +26,16 @@ export FRONTEND_URL=https://your-frontend.com
 export MOCK_OAUTH_ENABLED=0  # 本番では無効化
 ```
 
+`MOCK_OAUTH_ENABLED` のアプリ既定値は `0` ですが、Compose の `default` / `full` / `ci` profile は開発・CI 向けに `1` へ上書きします。本番用の `compose.prod.yml` やホスティング設定では `0` を明示し、実際の解決結果を確認してください。
+
+```bash
+docker compose config | rg -n "MOCK_OAUTH_ENABLED"
+# compose.prod.yml などの本番用 overlay を使う場合は `-f` を追加して同じ確認を実行します。
+```
+
 ### 2. シークレットの管理
 
-本番環境ではDocker Secretsを使用してください：
+本番環境では Docker Secrets を使用してください。YESOD Auth は `/run/secrets/<name>` を環境変数より優先して読み込みます。必須なのは `jwt_secret` と、有効化する provider 分の `*_client_id` / `*_client_secret` です。
 
 ```bash
 # Docker Swarmモードの場合
@@ -24,12 +44,19 @@ echo "your-google-client-id" | docker secret create google_client_id -
 # ...
 ```
 
+Compose 運用では、対象 provider の secret mount が本番構成に含まれることを確認します。
+
+```bash
+docker compose config | rg -n "jwt_secret|<provider>_client_(id|secret)"
+# compose.prod.yml などの本番用 overlay を使う場合は `-f` を追加して同じ確認を実行します。
+```
+
 ### 3. OAuthリダイレクトURIの更新
 
 使用する各OAuthプロバイダーの管理画面で、リダイレクトURIを本番ドメインへ更新：
 
 ```
-https://api.your-domain.com/api/v1/auth/{provider}/callback
+https://<api-domain>/api/v1/auth/{provider}/callback
 ```
 
 代表例:
@@ -38,6 +65,8 @@ https://api.your-domain.com/api/v1/auth/{provider}/callback
 - `https://api.your-domain.com/api/v1/auth/github/callback`
 - `https://api.your-domain.com/api/v1/auth/discord/callback`
 - `https://api.your-domain.com/api/v1/auth/x/callback`
+
+更新後は provider 管理画面の登録値と、実際に利用者が到達する API ドメイン・scheme・path が完全一致していることを確認します。callback URL の切り分けは [OAuth設定ガイドの callback チェック](./oauth/index.md#oauth-callback-checklist) と [FAQ の本番設定](../help/faq.md#本番環境で必要な設定は) に接続します。
 
 ---
 

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -279,10 +279,28 @@ curl "http://localhost:8000/api/v1/auth/mock/login?user=alice&provider=google"
 
 ### 本番環境で必要な設定は？
 
-1. `MOCK_OAUTH_ENABLED=0`に設定
-2. OAuthリダイレクトURIを本番ドメインに更新
-3. Docker Secretsでシークレットを管理
-4. HTTPSを有効化
+本番切替前は、インストールとデプロイの手順と同じ順で確認してください。
+
+1. `MOCK_OAUTH_ENABLED=0` を本番構成で確認する
+   - アプリ既定値は `0` ですが、Compose の `default` / `full` / `ci` profile は開発・CI 向けに `1` へ上書きします。
+   - 本番用 overlay、ホスティング環境変数、Secret Store のいずれかで `0` を明示してください。
+2. secret は Docker Secrets を第一候補にする
+   - 必須なのは `jwt_secret` と、有効化する OAuth provider 分の `*_client_id` / `*_client_secret` です。
+   - `/run/secrets/<name>` は同名の環境変数より優先されます。
+3. OAuth callback URL を本番 API ドメインに更新する
+   - provider 管理画面では `https://<api-domain>/api/v1/auth/{provider}/callback` に統一します。
+   - `localhost`、古いドメイン、scheme 差分、末尾 `/` の差分が残っていないか確認します。
+4. 再起動/再デプロイ後に疎通と監視を確認する
+   - `/health` が `200` を返すこと
+   - `GET /api/v1/auth/{provider}` が認可画面へ遷移すること
+   - callback 失敗ログ件数、callback URL の 4xx/5xx、callback 処理遅延の最小3点を監視できること
+5. HTTPS を有効化し、`FRONTEND_URL` と `CORS_ORIGINS` を本番 URL に合わせる
+
+関連手順:
+
+- [デプロイ: 本番環境の準備](../guides/deployment.md#本番環境の準備)
+- [インストール: 本番切替前チェック](../installation.md#production-cutover-check)
+- [OAuth設定: Callback確認の共通チェックリスト](../guides/oauth/index.md#oauth-callback-checklist)
 
 ### スケールアウトできる？
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -556,6 +556,32 @@ docker compose --profile ci config | rg -n "MOCK_OAUTH_ENABLED"
    - Installation: [profile別の環境変数優先順位](#profile別の環境変数優先順位)  
    - Troubleshooting: [secrets 権限不備で `Permission denied` が出る](./help/troubleshooting.md#secrets-permission-recovery)
 
+<a id="production-cutover-check"></a>
+
+### 本番切替前チェック（deployment / FAQ 同期）
+
+本番へ切り替える前は、[デプロイ: 本番環境の準備](guides/deployment.md#本番環境の準備) と [FAQ: 本番環境で必要な設定は？](help/faq.md#本番環境で必要な設定は) と同じ順で確認してください。
+
+1. `MOCK_OAUTH_ENABLED=0` を本番構成で確認する
+   - アプリ既定値は `0` ですが、Compose の `default` / `full` / `ci` profile は `1` に上書きします。
+   - 本番用 overlay やホスティング設定で `0` を明示し、`docker compose config` の結果を保存します。
+2. secret の入力元を固定する
+   - Docker Secrets を第一候補にし、`jwt_secret` と有効化する provider 分の `*_client_id` / `*_client_secret` だけを必須にします。
+   - `secret/環境変数の解決優先順位` のとおり、`/run/secrets/<name>` が環境変数より優先されます。
+3. callback URL を本番 API ドメインへ更新する
+   - provider 管理画面には `https://<api-domain>/api/v1/auth/{provider}/callback` を登録します。
+   - ローカル値、古いドメイン、末尾 `/` の差分が残っていないか確認します。
+4. 再起動/再デプロイ後に最小確認を実施する
+   - `/health` が `200` を返すこと
+   - `GET /api/v1/auth/{provider}` が認可画面へ遷移すること
+   - callback 監視の最小3点（失敗ログ件数、4xx/5xx 増加、処理遅延）を deployment から追えること
+
+確認コマンド例:
+
+```bash
+rg -n "MOCK_OAUTH_ENABLED|callback|secret|production|本番" docs/guides/deployment.md docs/installation.md docs/help/faq.md
+```
+
 ## リフレッシュトークン運用時の注意
 
 `/api/v1/auth/refresh` は「アクセストークンの延命」ではなく「ローテーションを伴う再発行」です。導入時は次の3点を必ず満たしてください。


### PR DESCRIPTION
## Summary
- Sync production cutover order across deployment, installation, and FAQ docs
- Clarify MOCK_OAUTH_ENABLED production value versus Compose profile overrides
- Add consistent secrets, callback URL, restart, and callback monitoring checks

## Verification
- rg -n "MOCK_OAUTH_ENABLED|callback|secret|production|本番" docs/guides/deployment.md docs/installation.md docs/help/faq.md
- git diff --check

## Notes
- mkdocs build --strict was not run because mkdocs is not installed in this environment.

Fixes #615
