### PR TITLE
docs: sync codex automation ops rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,9 @@
 - 自動レーンの commit/push は原則許可。Issue 指示やプロンプトで明示禁止がある場合のみ停止する
 - 手動レーン（Power User の直接対応）は一括処理可。ただし `codex:queue` 系ラベル遷移の整合は維持する
 - 手動レーンの push はローカル確認後に 1 回を標準とする
+- issue 選定は `codex:blocked` を最優先し、次に `codex:priority` + `codex:queue`、最後に通常の `codex:queue` を処理する
 - queue 着手前に linked Project の status / priority を確認する。Project 未連携 repo は `N/A` を記録する
 - Issue 状態遷移は `queue -> claimed -> (blocked | pr-opened) -> merge確認 -> close` を標準とする
 - 失敗時は issue コメントと `codex:blocked` を付与する
 - `codex:pr-opened` の Issue は merge 確認後の reconcile で close する（自動レーン主体）
+- docs-only CI 分岐の対象は `docs/**`, `README.md`, `AGENTS.md` に固定し、対象外または判定不能な変更があれば通常 CI を実行する

--- a/README.md
+++ b/README.md
@@ -454,7 +454,7 @@ This repository includes GitHub Actions workflows for automatic PR approval and 
 ```
 
 This script ensures the repository keeps the labels used by Codex / codex-orch automation:
-`codex`, `codex-automation`, `codex:queue`, `codex:claimed`, `codex:blocked`, `codex:pr-opened`.
+`codex`, `codex-automation`, `codex:priority`, `codex:queue`, `codex:claimed`, `codex:blocked`, `codex:pr-opened`.
 
 ### Bench-80 Queue Inventory Normalization
 
@@ -489,6 +489,7 @@ codex-orch 運用の基本方針は、手動レーンと自動レーンで責務
 
 - 自動レーン: commit/push は原則許可（Issue 指示や実行プロンプトで明示禁止がある場合のみ停止）
 - 手動レーン: ローカル確認後に 1 回 push を標準化
+- issue 選定: `codex:blocked` を最優先し、次に `codex:priority` + `codex:queue`、最後に通常の `codex:queue` を処理
 - queue 着手前: linked Project の status / priority を確認（Project 未連携 repo は `N/A` を記録）
 
 ### Issue 状態遷移（標準）
@@ -497,6 +498,12 @@ codex-orch 運用の基本方針は、手動レーンと自動レーンで責務
 
 - `blocked`: issue コメントを残して `codex:blocked` を付与
 - `pr-opened`: merge 確認後、reconcile で close（自動レーン主体）
+
+### docs-only CI 分岐の対象
+
+docs-only として扱う対象は `docs/**`, `README.md`, `AGENTS.md` に固定します。
+これ以外のファイルが 1 つでも含まれる場合、または判定できない場合は通常 CI を実行します。
+branch protection の必須チェック例は `ci/woodpecker/push/woodpecker`, `auto-approve`, `enable-auto-merge` です。
 
 ### Generate TypeScript Types
 

--- a/docs/guides/codex-automation-ops.md
+++ b/docs/guides/codex-automation-ops.md
@@ -10,8 +10,8 @@ README / AGENTS / CI 設定を同時に揃える前提で利用してくださ�
 | `<ORCH_RUN_COMMAND>` | 自動レーン実行コマンド | 実行環境ごとの orch 実コマンド |
 | `<REPO_SLUG>` | `owner/repo` 形式 | `mashirou1234/yesod-auth` |
 | `<BASE_BRANCH>` | 既定マージ先ブランチ | `main` |
-| `<REQUIRED_CHECKS>` | branch protection 必須チェック | `Woodpecker CI`, `PR Auto Merge` など |
-| `<LABEL_SET>` | codex 系ラベルセット | `codex`, `codex-automation`, `codex:queue`, `codex:claimed`, `codex:blocked`, `codex:pr-opened` |
+| `<REQUIRED_CHECKS>` | branch protection 必須チェック | `ci/woodpecker/push/woodpecker`, `auto-approve`, `enable-auto-merge` など |
+| `<LABEL_SET>` | codex 系ラベルセット | `codex`, `codex-automation`, `codex:priority`, `codex:queue`, `codex:claimed`, `codex:blocked`, `codex:pr-opened` |
 
 ## 2. 標準運用ルール（テンプレ文面）
 
@@ -19,6 +19,7 @@ README / AGENTS / CI 設定を同時に揃える前提で利用してくださ�
 
 - 自動レーン: commit/push は原則許可。Issue 指示やプロンプトで明示禁止がある場合のみ停止
 - 手動レーン: ローカル確認後に 1 回 push を標準化
+- issue 選定: `codex:blocked` を最優先し、次に `codex:priority` + `codex:queue`、最後に通常の `codex:queue` を処理
 - queue 着手前: linked Project の status / priority を確認し、Project 未連携 repo は `N/A` を記録
 
 ### 2.2 Issue 状態遷移
@@ -60,3 +61,4 @@ README / AGENTS / CI 設定を同時に揃える前提で利用してくださ�
 - [ ] README と AGENTS の文言が矛盾していない
 - [ ] CI 定義（Woodpecker）と README の docs-only 条件が一致している
 - [ ] `queue -> claimed -> (blocked | pr-opened) -> merge確認 -> close` が運用文書で一致している
+- [ ] `codex:priority` を含む issue 選定順が README / AGENTS / 実行プロンプトと矛盾していない


### PR DESCRIPTION
## Summary
- Sync README, AGENTS, and the codex automation ops template around the standard issue lifecycle.
- Add `codex:priority` to the documented label set and issue selection order.
- Document the shared docs-only CI target set: `docs/**`, `README.md`, `AGENTS.md`.

## Verification
- `rg -n "queue -> claimed -> \\(blocked \\| pr-opened\\) -> merge確認 -> close|docs-only CI|docs-only|1 run 1 issue|LABEL_SET|REQUIRED_CHECKS|codex:priority|ci/woodpecker/push/woodpecker|auto-approve|enable-auto-merge" README.md AGENTS.md docs/guides/codex-automation-ops.md`
- `git diff --check`

## Public impact
- Docs-only change. Self-hosted operators get a clearer automation template and label lifecycle; runtime behavior is unchanged.

Closes #616
