### PR TITLE
docs: align OAuth provider callback guidance

### DIFF
--- a/.agent/WORKLOG.md
+++ b/.agent/WORKLOG.md
@@ -1,0 +1,46 @@
+# Worklog
+
+## Goal
+
+Issue #617: OAuth provider index and callback guidance should be easy to follow from installation, FAQ, and provider-specific guides.
+
+## Assumptions
+
+- Scope is documentation only.
+- No provider implementation, callback handler, or new provider changes are required.
+- Linked Project status / priority is N/A because `gh issue view` returned no project items for #617.
+
+## Checklist
+
+- [x] Confirm live issue selection and related PR state.
+- [x] Claim issue #617.
+- [x] Align OAuth provider index with provider guide links and callback examples.
+- [x] Standardize callback guidance in Google / GitHub / Discord guides.
+- [x] Link installation / FAQ back to the OAuth provider guide.
+- [x] Run targeted documentation verification.
+- [x] Self-review diff.
+
+## Verification Commands
+
+- `rg -n "callback|provider|self-hosted|installation|FAQ" docs/guides/oauth/index.md docs/guides/oauth/*.md docs/installation.md docs/help/faq.md`
+
+## Completed
+
+- Live selection chose #617 from normal `codex:queue`.
+- `codex:claimed` was applied.
+- Temporary worktree was created from `origin/main`.
+- OAuth index now lists local and production callback URL examples per provider.
+- Google / GitHub / Discord guides now share a `Callback URL の登録値` section.
+- Installation and FAQ now link back to the OAuth first-setup order.
+- `rg -n "callback|provider|self-hosted|installation|FAQ" ...` completed successfully.
+- `docker run --rm -v "$PWD":/docs squidfunk/mkdocs-material:latest build --strict` completed with `MKDOCS_STATUS=0`.
+- `git diff --check` completed successfully.
+- Self-review confirmed the change is docs/worklog only and does not modify provider implementation.
+
+## Remaining
+
+- PR creation and issue transition.
+
+## Blockers
+
+- None.

--- a/docs/guides/oauth/discord.md
+++ b/docs/guides/oauth/discord.md
@@ -15,6 +15,19 @@
     ```
 3. 「Client ID」と「Client Secret」をコピー
 
+## 2.1 Callback URL の登録値
+
+Discord Developer Portal には、利用環境ごとに次の callback URL を登録します。
+本番では `localhost` を残さず、API の公開ドメインに置き換えてください。
+
+| 環境 | 登録する callback URL | 確認先 |
+|------|------------------------|--------|
+| ローカル開発 | `http://localhost:8000/api/v1/auth/discord/callback` | OAuth2 の `Redirects` |
+| セルフホスト本番 | `https://<api-domain>/api/v1/auth/discord/callback` | 本番アプリの OAuth2 `Redirects` |
+
+開始エンドポイントは `GET /api/v1/auth/discord` です。callback URL を直接開かず、必ず開始エンドポイントから Discord 認可画面へ遷移することを確認してください。
+共通の確認順は [OAuth設定: Callback確認の共通チェックリスト](index.md#oauth-callback-checklist) を参照してください。
+
 ## 3. シークレットファイルの設定
 
 ```bash

--- a/docs/guides/oauth/github.md
+++ b/docs/guides/oauth/github.md
@@ -10,6 +10,19 @@
     - Authorization callback URL: `http://localhost:8000/api/v1/auth/github/callback`
 4. 「Register application」をクリック
 
+## 1.1 Callback URL の登録値
+
+GitHub OAuth App には、利用環境ごとに次の callback URL を登録します。
+本番では `localhost` を残さず、API の公開ドメインに置き換えてください。
+
+| 環境 | 登録する callback URL | 確認先 |
+|------|------------------------|--------|
+| ローカル開発 | `http://localhost:8000/api/v1/auth/github/callback` | OAuth App の `Authorization callback URL` |
+| セルフホスト本番 | `https://<api-domain>/api/v1/auth/github/callback` | 本番 OAuth App の `Authorization callback URL` |
+
+開始エンドポイントは `GET /api/v1/auth/github` です。callback URL を直接開かず、必ず開始エンドポイントから GitHub 認可画面へ遷移することを確認してください。
+共通の確認順は [OAuth設定: Callback確認の共通チェックリスト](index.md#oauth-callback-checklist) を参照してください。
+
 ## 2. クライアントシークレットの生成
 
 1. 作成したアプリの設定ページを開く

--- a/docs/guides/oauth/google.md
+++ b/docs/guides/oauth/google.md
@@ -25,6 +25,19 @@
     ```
 4. クライアントIDとシークレットを保存
 
+## 3.1 Callback URL の登録値
+
+Google Cloud Console には、利用環境ごとに次の callback URL を登録します。
+本番では `localhost` を残さず、API の公開ドメインに置き換えてください。
+
+| 環境 | 登録する callback URL | 確認先 |
+|------|------------------------|--------|
+| ローカル開発 | `http://localhost:8000/api/v1/auth/google/callback` | Google Cloud Console の「承認済みのリダイレクト URI」 |
+| セルフホスト本番 | `https://<api-domain>/api/v1/auth/google/callback` | 本番 OAuth クライアントの「承認済みのリダイレクト URI」 |
+
+開始エンドポイントは `GET /api/v1/auth/google` です。callback URL を直接開かず、必ず開始エンドポイントから Google 認可画面へ遷移することを確認してください。
+共通の確認順は [OAuth設定: Callback確認の共通チェックリスト](index.md#oauth-callback-checklist) を参照してください。
+
 ## 4. シークレットファイルの設定
 
 ```bash

--- a/docs/guides/oauth/index.md
+++ b/docs/guides/oauth/index.md
@@ -4,32 +4,49 @@ YESOD Authは複数のOAuthプロバイダーに対応しています。各プ�
 
 ## 対応プロバイダー
 
-| プロバイダー | 公式PKCE | 独自PKCE | OpenID Connect | 備考 |
-|-------------|----------|----------|----------------|------|
-| [Google](google.md) | ✅ | - | ✅ | 推奨 |
-| [GitHub](github.md) | ✅ | - | ❌ | |
-| [X (Twitter)](x.md) | ✅ | - | ❌ | メールアドレス取得不可 |
-| [LinkedIn](linkedin.md) | ✅ | - | ✅ | |
-| [Facebook](facebook.md) | ✅ | - | ❌ | [Graph API v18.0](https://developers.facebook.com/docs/graph-api/){:target="_blank"} |
-| [Discord](discord.md) | - | ✅ | ❌ | プロバイダーは対応しているが公式ドキュメントなし |
-| [Slack](slack.md) | - | ✅ | ✅ | |
-| [Twitch](twitch.md) | - | ✅ | ❌ | [Helix API](https://dev.twitch.tv/docs/api/){:target="_blank"} |
+初回導入では、利用する provider を1つ決めてから個別ガイドへ進んでください。
+Callback URL は provider 名だけを差し替え、ローカルと本番で同じパス形式に揃えます。
 
-## provider別必須環境変数一覧
+| プロバイダー | 個別ガイド | ローカル callback URL | 本番 callback URL | PKCE | OpenID Connect | 備考 |
+|-------------|------------|----------------------|-------------------|------|----------------|------|
+| Google | [google.md](google.md) | `http://localhost:8000/api/v1/auth/google/callback` | `https://<api-domain>/api/v1/auth/google/callback` | 公式 | ✅ | 推奨 |
+| GitHub | [github.md](github.md) | `http://localhost:8000/api/v1/auth/github/callback` | `https://<api-domain>/api/v1/auth/github/callback` | 公式 | ❌ | |
+| Discord | [discord.md](discord.md) | `http://localhost:8000/api/v1/auth/discord/callback` | `https://<api-domain>/api/v1/auth/discord/callback` | 独自 | ❌ | プロバイダーは対応しているが公式ドキュメントなし |
+| X (Twitter) | [x.md](x.md) | `http://localhost:8000/api/v1/auth/x/callback` | `https://<api-domain>/api/v1/auth/x/callback` | 公式 | ❌ | メールアドレス取得不可 |
+| LinkedIn | [linkedin.md](linkedin.md) | `http://localhost:8000/api/v1/auth/linkedin/callback` | `https://<api-domain>/api/v1/auth/linkedin/callback` | 公式 | ✅ | |
+| Facebook | [facebook.md](facebook.md) | `http://localhost:8000/api/v1/auth/facebook/callback` | `https://<api-domain>/api/v1/auth/facebook/callback` | 公式 | ❌ | [Graph API v18.0](https://developers.facebook.com/docs/graph-api/){:target="_blank"} |
+| Slack | [slack.md](slack.md) | `http://localhost:8000/api/v1/auth/slack/callback` | `https://<api-domain>/api/v1/auth/slack/callback` | 独自 | ✅ | |
+| Twitch | [twitch.md](twitch.md) | `http://localhost:8000/api/v1/auth/twitch/callback` | `https://<api-domain>/api/v1/auth/twitch/callback` | 独自 | ❌ | [Helix API](https://dev.twitch.tv/docs/api/){:target="_blank"} |
+
+<a id="初回導入の読み順"></a>
+
+## 初回導入の読み順 {#oauth-first-setup-order}
+
+セルフホストで最短導入する場合は、次の順で読み進めます。
+
+1. [インストール: provider 未設定時の最短スキップ手順](../../installation.md#provider-未設定時の最短スキップ手順) で、先に `/health` と `/docs` の到達確認を終える
+2. 本ページの [provider別必須環境変数一覧](#oauth-provider-credentials) で、有効化する provider の secret 名と callback URL を確認する
+3. [Callback確認の共通チェックリスト](#oauth-callback-checklist) で、provider 管理画面へ登録する URL を確定する
+4. 対象 provider の個別ガイドを開き、scope / secret / callback の provider 固有差分だけ確認する
+5. 迷った場合は [FAQ: 複数providerを有効化するときの順序チェックは？](../../help/faq.md#複数providerを有効化するときの順序チェックは) から再確認する
+
+<a id="provider別必須環境変数一覧"></a>
+
+## provider別必須環境変数一覧 {#oauth-provider-credentials}
 
 実OAuthで必要なのは、`jwt_secret` と「有効化して使う provider 分の `*_client_id` / `*_client_secret`」だけです。
 `MOCK_OAUTH_ENABLED=1` はローカル疎通用であり、実運用では `MOCK_OAUTH_ENABLED=0` を使用します。
 
-| provider | 必須 secret 名 | 環境変数名（secret未使用時） | 個別ガイド |
-|---|---|---|---|
-| Google | `google_client_id` / `google_client_secret` | `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` | [google.md](google.md) |
-| GitHub | `github_client_id` / `github_client_secret` | `GITHUB_CLIENT_ID` / `GITHUB_CLIENT_SECRET` | [github.md](github.md) |
-| Discord | `discord_client_id` / `discord_client_secret` | `DISCORD_CLIENT_ID` / `DISCORD_CLIENT_SECRET` | [discord.md](discord.md) |
-| X (Twitter) | `x_client_id` / `x_client_secret` | `X_CLIENT_ID` / `X_CLIENT_SECRET` | [x.md](x.md) |
-| LinkedIn | `linkedin_client_id` / `linkedin_client_secret` | `LINKEDIN_CLIENT_ID` / `LINKEDIN_CLIENT_SECRET` | [linkedin.md](linkedin.md) |
-| Facebook | `facebook_client_id` / `facebook_client_secret` | `FACEBOOK_CLIENT_ID` / `FACEBOOK_CLIENT_SECRET` | [facebook.md](facebook.md) |
-| Slack | `slack_client_id` / `slack_client_secret` | `SLACK_CLIENT_ID` / `SLACK_CLIENT_SECRET` | [slack.md](slack.md) |
-| Twitch | `twitch_client_id` / `twitch_client_secret` | `TWITCH_CLIENT_ID` / `TWITCH_CLIENT_SECRET` | [twitch.md](twitch.md) |
+| provider | 必須 secret 名 | 環境変数名（secret未使用時） | callback URL パス | 個別ガイド |
+|---|---|---|---|---|
+| Google | `google_client_id` / `google_client_secret` | `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` | `/api/v1/auth/google/callback` | [google.md](google.md) |
+| GitHub | `github_client_id` / `github_client_secret` | `GITHUB_CLIENT_ID` / `GITHUB_CLIENT_SECRET` | `/api/v1/auth/github/callback` | [github.md](github.md) |
+| Discord | `discord_client_id` / `discord_client_secret` | `DISCORD_CLIENT_ID` / `DISCORD_CLIENT_SECRET` | `/api/v1/auth/discord/callback` | [discord.md](discord.md) |
+| X (Twitter) | `x_client_id` / `x_client_secret` | `X_CLIENT_ID` / `X_CLIENT_SECRET` | `/api/v1/auth/x/callback` | [x.md](x.md) |
+| LinkedIn | `linkedin_client_id` / `linkedin_client_secret` | `LINKEDIN_CLIENT_ID` / `LINKEDIN_CLIENT_SECRET` | `/api/v1/auth/linkedin/callback` | [linkedin.md](linkedin.md) |
+| Facebook | `facebook_client_id` / `facebook_client_secret` | `FACEBOOK_CLIENT_ID` / `FACEBOOK_CLIENT_SECRET` | `/api/v1/auth/facebook/callback` | [facebook.md](facebook.md) |
+| Slack | `slack_client_id` / `slack_client_secret` | `SLACK_CLIENT_ID` / `SLACK_CLIENT_SECRET` | `/api/v1/auth/slack/callback` | [slack.md](slack.md) |
+| Twitch | `twitch_client_id` / `twitch_client_secret` | `TWITCH_CLIENT_ID` / `TWITCH_CLIENT_SECRET` | `/api/v1/auth/twitch/callback` | [twitch.md](twitch.md) |
 
 一覧の定義元は [インストールガイド（OAuth認証情報）](../../installation.md#oauth-credentials) です。
 クイックスタートでの初回導入順は [getting-started](../../getting-started.md#2-シークレットファイルの作成) を参照してください。

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -62,6 +62,7 @@ YESOD AuthはGoogle OAuthでPKCEを自動的に使用します。
 
 再開ポイント:
 - 起動確認の継続: [クイックスタート: provider 未設定時の最短スキップ手順](../getting-started.md#provider-未設定時の最短スキップ手順)
+- provider 選択と callback URL 確認: [OAuth設定: 初回導入の読み順](../guides/oauth/index.md#oauth-first-setup-order)
 - 実 OAuth の再開: [Mock OAuthから実OAuthへ切り替える最小確認は？](#mock-oauthから実oauthへ切り替える最小確認は)
 - 失敗時: [トラブルシューティング: provider 未設定のまま認証導線を実行した](./troubleshooting.md#provider-未設定のまま認証導線を実行した)
 - 詳細手順: [インストール: provider 未設定時の最短スキップ手順](../installation.md#provider-未設定時の最短スキップ手順)
@@ -188,6 +189,7 @@ callback URL 不一致が疑われる場合は [トラブルシューティン�
 導線は次の順で参照してください。
 
 - インストール: [OAuth認証情報](../installation.md#oauth認証情報)
+- OAuth設定: [初回導入の読み順](../guides/oauth/index.md#oauth-first-setup-order)
 - クイックスタート: [2.5 コールバックURLの検証](../getting-started.md#25-コールバックurlの検証)
 - トラブルシューティング: [401 Unauthorized / invalid_client](./troubleshooting.md#401-unauthorized--invalid_client)
 - トラブルシューティング: [redirect_uri_mismatch（callback URL 不一致の診断フロー）](./troubleshooting.md#oauth-callback-url-mismatch)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -64,6 +64,7 @@ OAuth provider をまだ一部用意できていない場合は、次の手順�
 
 再開ポイント:
 - 起動確認の継続: [docker compose利用時の最小確認手順](#docker-compose利用時の最小確認手順)
+- provider 選択と callback URL 確認: [OAuth設定: 初回導入の読み順](./guides/oauth/index.md#oauth-first-setup-order)
 - 実 OAuth の再開: [クイックスタート: Mock OAuthから実OAuthへ切り替える最小チェック](./getting-started.md#mock-oauthから実oauthへ切り替える最小チェック)
 - 失敗時: [トラブルシューティング: provider 未設定のまま認証導線を実行した](./help/troubleshooting.md#provider-未設定のまま認証導線を実行した)
 - FAQ での要点確認: [Mock OAuthから実OAuthへ切り替える最小確認は？](./help/faq.md#mock-oauthから実oauthへ切り替える最小確認は)


### PR DESCRIPTION
## Summary
- add a provider/callback overview table to the OAuth guide index
- add a first-setup reading order that connects installation, callback checks, provider guides, and FAQ
- standardize Google/GitHub/Discord callback registration sections

## Verification
- `rg -n "callback|provider|self-hosted|installation|FAQ" docs/guides/oauth/index.md docs/guides/oauth/*.md docs/installation.md docs/help/faq.md`
- `docker run --rm -v "$PWD":/docs squidfunk/mkdocs-material:latest build --strict` (`MKDOCS_STATUS=0`)
- `git diff --check`

Closes #617
