### PR TITLE
docs: connect webhook delivery history to troubleshooting

### DIFF
--- a/.agent/WORKLOG.md
+++ b/.agent/WORKLOG.md
@@ -2,40 +2,41 @@
 
 ## Goal
 
-Issue #617: OAuth provider index and callback guidance should be easy to follow from installation, FAQ, and provider-specific guides.
+Issue #627: Webhook delivery history should lead operators from API fields to troubleshooting without changing API behavior.
 
 ## Assumptions
 
 - Scope is documentation only.
-- No provider implementation, callback handler, or new provider changes are required.
-- Linked Project status / priority is N/A because `gh issue view` returned no project items for #617.
+- No webhook implementation, API schema, or new admin endpoint changes are required.
+- Linked Project status / priority is N/A because `gh issue view` returned no project items for #627.
 
 ## Checklist
 
-- [x] Confirm live issue selection and related PR state.
-- [x] Claim issue #617.
-- [x] Align OAuth provider index with provider guide links and callback examples.
-- [x] Standardize callback guidance in Google / GitHub / Discord guides.
-- [x] Link installation / FAQ back to the OAuth provider guide.
+- [x] Confirm live issue selection and project status.
+- [x] Claim issue #627.
+- [x] Align delivery history field meanings with troubleshooting terms.
+- [x] Add a clear handoff from API docs to troubleshooting.
+- [x] Confirm guide wording still matches API/troubleshooting.
 - [x] Run targeted documentation verification.
 - [x] Self-review diff.
 
 ## Verification Commands
 
-- `rg -n "callback|provider|self-hosted|installation|FAQ" docs/guides/oauth/index.md docs/guides/oauth/*.md docs/installation.md docs/help/faq.md`
+- `rg -n "event_id|endpoint_id|attempt_count|delivery|troubleshooting" docs/api/webhooks.md docs/help/troubleshooting.md`
+- `rg -n "配信履歴|event_id|endpoint_id|attempt_count|Webhook API|トラブルシューティング|self-hosted production callback" docs/api/webhooks.md docs/guides/webhooks.md docs/help/troubleshooting.md docs/help/faq.md docs/installation.md`
+- `git diff --check`
+- `docker run --rm -v "$PWD":/docs squidfunk/mkdocs-material:latest build --strict`
 
 ## Completed
 
-- Live selection chose #617 from normal `codex:queue`.
-- `codex:claimed` was applied.
-- Temporary worktree was created from `origin/main`.
-- OAuth index now lists local and production callback URL examples per provider.
-- Google / GitHub / Discord guides now share a `Callback URL の登録値` section.
-- Installation and FAQ now link back to the OAuth first-setup order.
-- `rg -n "callback|provider|self-hosted|installation|FAQ" ...` completed successfully.
-- `docker run --rm -v "$PWD":/docs squidfunk/mkdocs-material:latest build --strict` completed with `MKDOCS_STATUS=0`.
-- `git diff --check` completed successfully.
-- Self-review confirmed the change is docs/worklog only and does not modify provider implementation.
+- Live selection chose #627 from normal `codex:queue`.
+- `codex:claimed` was applied and the temporary worktree was created from `origin/main`.
+- `docs/api/webhooks.md` now explains how `event_id` / `endpoint_id` / `attempt_count` lead into troubleshooting.
+- `docs/guides/webhooks.md` now tells operators to collect the same keys before moving from delivery history to recovery.
+- `docs/help/troubleshooting.md` now has a delivery-history triage entry before symptom-specific webhook checks.
+- `docs/help/faq.md` no longer uses a docs-internal relative link to repository README, which restored strict docs build success.
+- Targeted `rg` checks, `git diff --check`, and strict MkDocs build completed successfully.
+- Self-review confirmed the change is docs/worklog only and does not modify webhook API behavior.
 
 ## Remaining
 

--- a/docs/api/webhooks.md
+++ b/docs/api/webhooks.md
@@ -79,6 +79,23 @@ GET /api/v1/admin/webhooks/deliveries
 ]
 ```
 
+<a id="delivery-history-troubleshooting-flow"></a>
+
+### 配信履歴から障害対応へ進む読み順
+
+配信履歴は個別試行の状態を確認する入口です。失敗が続く場合は、この API だけで復旧判断を完結させず、次の順で [トラブルシューティング: Webhook](../help/troubleshooting.md#webhook-delivery-history-triage) へ引き継いでください。
+
+1. `event_id` で同一イベントの再送かを確認する。
+2. `endpoint_id` で影響を受けている送信先を絞り込む。
+3. `attempt_count` で初回失敗か、再送中か、上限到達に近いかを判断する。
+4. `status` / `http_status` / `error_message` を控え、API ログと受信側ログを同じ時間帯で確認する。
+
+| 配信履歴の項目 | 読み方 | 次に見る場所 |
+| --- | --- | --- |
+| `event_id` | 同じ値なら同一イベントの再送。重複処理や冪等性の確認に使う | [署名検証に失敗する](../help/troubleshooting.md#webhook-signature-verification-failure) |
+| `endpoint_id` | 失敗している送信先の単位。受信側ログでは `X-Webhook-ID` または payload の `webhook_id` と突合する | [Webhookが発火しない](../help/troubleshooting.md#webhook-not-triggered) |
+| `attempt_count` | 何回目の試行かを示す。冪等キーには使わず、再送状況の判断に限定する | [配信失敗時のログ確認項目](../guides/webhooks.md#webhook-delivery-log-checklist) |
+
 ### 冪等性の注意点（再送時）
 
 - 同一イベントの再送では、`event_id` は同じ値のまま `attempt_count` だけ増加します。

--- a/docs/guides/webhooks.md
+++ b/docs/guides/webhooks.md
@@ -257,6 +257,8 @@ HTTP 4xx エラーはリトライしません（クライアントエラーの�
 配信履歴の `id` や `attempt_count` は再送ごとに変わるため、重複判定には使えません。  
 API 契約の詳細は [Webhook API: 冪等性の注意点（再送時）](../api/webhooks.md#冪等性の注意点再送時) を参照してください。
 
+<a id="webhook-delivery-log-checklist"></a>
+
 ### 配信失敗時のログ確認項目
 
 再試行設定の見直し前に、最低でも次の項目を同一 `request_id` 単位で確認してください。
@@ -294,6 +296,10 @@ curl http://localhost:8000/api/v1/admin/webhooks/endpoints
 ```bash
 curl http://localhost:8000/api/v1/admin/webhooks/deliveries
 ```
+
+失敗を調査するときは、まず配信履歴で `event_id` / `endpoint_id` / `attempt_count` を控えてください。
+`event_id` は同一イベントの再送確認、`endpoint_id` は送信先の絞り込み、`attempt_count` は再送状況の把握に使います。
+その後の復旧判断は [Webhook API: 配信履歴から障害対応へ進む読み順](../api/webhooks.md#delivery-history-troubleshooting-flow) から [トラブルシューティング: Webhook](../help/troubleshooting.md#webhook-delivery-history-triage) へ進めます。
 
 ### 設定リロード
 

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -181,7 +181,7 @@ callback URL 不一致が疑われる場合は [トラブルシューティン�
 
 FAQ では次の3手順だけ先に確認してください。
 
-1. provider 管理画面の callback URL が `https://<api-domain>/api/v1/auth/{provider}/callback` と完全一致していることを確認する（README の [self-hosted production callback format](../../README.md#2-set-up-oauth-credentials-client-id--client-secret) と同じ形式）
+1. provider 管理画面の callback URL が `https://<api-domain>/api/v1/auth/{provider}/callback` と完全一致していることを確認する（README の [self-hosted production callback format](https://github.com/mashirou1234/yesod-auth#2-set-up-oauth-credentials-client-id--client-secret) と同じ形式）
 2. `API_URL` と実アクセスURLが一致していることを [インストール: OAuth provider追加時の事前チェック](../installation.md#oauth-provider追加時の事前チェック) で確認する（スキーム、ホスト、ポート、末尾スラッシュを含む）
 3. API ログと復旧手順を [トラブルシューティング: redirect_uri_mismatch（callback URL 不一致の診断フロー）](./troubleshooting.md#oauth-callback-url-mismatch) で確認する
 

--- a/docs/help/troubleshooting.md
+++ b/docs/help/troubleshooting.md
@@ -611,6 +611,22 @@ FAQ での方針説明は [FAQ: Adminで未翻訳キーが出たときの表示�
 
 ## Webhook
 
+<a id="webhook-delivery-history-triage"></a>
+
+### 配信履歴から初動を決める
+
+`GET /api/v1/admin/webhooks/deliveries` で失敗を見つけた場合は、API 文書だけで判断を閉じず、次の 3 キーを先にそろえてから症状別の節へ進んでください。
+
+| キー | 初動での使い方 | 次の確認 |
+| --- | --- | --- |
+| `event_id` | 同じイベントの再送か、重複処理が起きていないかを確認する | 署名失敗や重複処理なら [署名検証に失敗する](#webhook-signature-verification-failure) |
+| `endpoint_id` | 特定の送信先だけ失敗しているかを切り分ける | 設定未読込なら [Webhookが発火しない](#webhook-not-triggered) |
+| `attempt_count` | 初回失敗か再送中かを判断する。冪等キーには使わない | 上限到達が疑われる場合は API ログの `webhook_delivery_retry_exhausted` を確認 |
+
+API 側の項目定義は [Webhook API: 配信履歴から障害対応へ進む読み順](../api/webhooks.md#delivery-history-troubleshooting-flow) を参照してください。
+
+<a id="webhook-not-triggered"></a>
+
 ### Webhookが発火しない
 
 **確認事項:**
@@ -666,6 +682,8 @@ FAQ での方針説明は [FAQ: Adminで未翻訳キーが出たときの表示�
 - 導入手順側: [インストール: Webhook reload 障害の最短導線](../installation.md#webhook-reload-障害の最短導線)
 
 ---
+
+<a id="webhook-signature-verification-failure"></a>
 
 ### 署名検証に失敗する
 


### PR DESCRIPTION
## Summary
- Add a Webhook delivery-history triage path from `event_id` / `endpoint_id` / `attempt_count` to troubleshooting.
- Align `docs/guides/webhooks.md` and `docs/help/troubleshooting.md` so delivery history does not become the final recovery doc.
- Replace one docs-internal FAQ link to repository README with an external GitHub README link so strict docs build succeeds.

## Verification
- `rg -n "event_id|endpoint_id|attempt_count|delivery|troubleshooting" docs/api/webhooks.md docs/help/troubleshooting.md`
- `rg -n "配信履歴|event_id|endpoint_id|attempt_count|Webhook API|トラブルシューティング|self-hosted production callback" docs/api/webhooks.md docs/guides/webhooks.md docs/help/troubleshooting.md docs/help/faq.md docs/installation.md`
- `git diff --check`
- `docker run --rm -v "$PWD":/docs squidfunk/mkdocs-material:latest build --strict`

Closes #627
