### PR TITLE
docs: sync webhook key rotation guidance

### DIFF
--- a/docs/guides/webhooks.md
+++ b/docs/guides/webhooks.md
@@ -182,11 +182,33 @@ curl -X POST http://localhost:8000/api/v1/admin/webhooks/reload
 ## 署名鍵ローテーション最小手順
 
 `api/app/webhooks/signer.py` のとおり、送信署名は常に単一シークレットで生成されます。切替時は受信側を先に更新し、失敗時は旧鍵へ戻してください。
+初回導入直後に鍵を切り替える場合も、[インストール: Webhook reload 障害の最短導線](../installation.md#webhook-reload-障害の最短導線) と同じ順で、現在値確認 -> `reload` -> 同一イベント再送 -> ログ確認の順序を守ります。
+
+### 切替前
 
 1. 新しい署名鍵を作成し、受信側を「新旧どちらの鍵でも検証可能」な状態にしてからデプロイする。
-2. `secrets/webhook_secret_<endpoint>.txt`（または `WEBHOOK_SECRET_<endpoint>`）を新しい鍵へ更新し、`config/webhooks.yaml` の参照先が変わっていないことを確認する。
-3. `POST /api/v1/admin/webhooks/reload` を実行して設定を再読み込みし、テストイベントを1件送って受信側検証が通ることを確認する。
-4. 確認完了後、受信側の旧鍵受け入れ期間を終了し、運用鍵を新鍵に一本化する。
+2. `config/webhooks.yaml` の `secret` 参照先（例: `${WEBHOOK_SECRET_MY_SERVICE}`）を控え、切替で参照名を変えない方針にする。
+3. 現在の読み込み状態を確認する。
+   ```bash
+   curl -fsS http://localhost:8000/api/v1/admin/webhooks/endpoints
+   ```
+
+### 切替後
+
+1. `secrets/webhook_secret_<endpoint>.txt`（または `WEBHOOK_SECRET_<endpoint>`）の値だけを新しい鍵へ更新する。
+2. `POST /api/v1/admin/webhooks/reload` を実行して設定を再読み込みする。
+   ```bash
+   curl -X POST http://localhost:8000/api/v1/admin/webhooks/reload
+   ```
+3. テストイベントを1件送って受信側検証が通ることを確認する。
+4. 配信履歴と受信側ログで、同一 `event_id` の署名失敗が増えていないことを確認する。
+   ```bash
+   curl -fsS http://localhost:8000/api/v1/admin/webhooks/deliveries
+   docker compose logs api --since=30m | rg -n "webhook|reload|signature|hmac_mismatch"
+   ```
+5. 確認完了後、受信側の旧鍵受け入れ期間を終了し、運用鍵を新鍵に一本化する。
+
+`MOCK_OAUTH_ENABLED` は OAuth 導線の切替値であり、Webhook 署名鍵の解決順には影響しません。署名鍵の切替は `config/webhooks.yaml` と webhook 用 secret の読み込み状態で確認してください。
 
 ### 切替失敗時の戻し手順
 

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -286,6 +286,22 @@ curl "http://localhost:8000/api/v1/auth/mock/login?user=alice&provider=google"
 - [トラブルシューティング: Webhook reload 後も反映されない](./troubleshooting.md#webhook-reload-後も反映されない)
 - [Webhook API: `reload` 失敗時の最短確認手順](../api/webhooks.md#reload-失敗時の最短確認手順)
 
+### Webhook 署名鍵をローテーションするときの最短順は？
+
+本番では受信側を先に新旧どちらの鍵でも検証できる状態にしてから、yesod-auth 側の webhook secret 値だけを切り替えます。
+
+1. `config/webhooks.yaml` の `secret` 参照名を変えないことを確認
+2. `secrets/webhook_secret_<endpoint>.txt` または `WEBHOOK_SECRET_<endpoint>` の値を新鍵へ更新
+3. `POST /api/v1/admin/webhooks/reload` を実行
+4. 同一イベントを再送し、配信履歴と受信側ログで `hmac_mismatch` が増えていないことを確認
+5. 失敗時は旧鍵へ戻して再度 `reload` し、復旧後に原因を直して再実施
+
+詳細手順:
+
+- [Webhook設定ガイド: 署名鍵ローテーション最小手順](../guides/webhooks.md#署名鍵ローテーション最小手順)
+- [インストール: Webhook reload 障害の最短導線](../installation.md#webhook-reload-障害の最短導線)
+- [トラブルシューティング: 署名検証に失敗する](./troubleshooting.md#webhook-signature-verification-failure)
+
 ---
 
 ## デプロイ

--- a/docs/help/troubleshooting.md
+++ b/docs/help/troubleshooting.md
@@ -675,6 +675,8 @@ API 側の項目定義は [Webhook API: 配信履歴から障害対応へ進む�
    ```
 4. 直らない場合は旧設定へ一時ロールバックし、再度 `reload` と再送で差分を確認する
 
+署名鍵ローテーション直後の障害では、旧鍵へ戻す前に `endpoints` の読み込み状態、`reload` 実行結果、同一イベント再送結果、API ログの `hmac_mismatch` 有無を同じ調査メモに残してください。
+
 **参照導線:**
 
 - API 仕様側: [Webhook API: `reload` 失敗時の最短確認手順](../api/webhooks.md#reload-失敗時の最短確認手順)
@@ -709,6 +711,8 @@ API 側の項目定義は [Webhook API: 配信履歴から障害対応へ進む�
 | 時刻ずれや再送遅延 | 特定環境のみ断続的に失敗 | サーバー時刻同期を確認し、遅延経路を短縮 |
 | 再送イベントの重複処理 | 同じ `event_id` で副作用が複数回実行される | 受信側の冪等キーを `event_id`（必要に応じて `endpoint_id` 併用）へ統一し、`delivery id` / `attempt_count` は重複判定に使わない |
 
+ローテーション中に `hmac_mismatch` が増えた場合は、送受信の新旧鍵受け入れ状態を先に確認し、必要なら旧鍵へ戻して `reload` と同一イベント再送で復旧を確認してください。手順の正本は [Webhook設定ガイド: 署名鍵ローテーション最小手順](../guides/webhooks.md#署名鍵ローテーション最小手順) です。
+
 **監査ログで最低限確認する項目:**
 
 | 項目 | 期待値/例 | 確認ポイント |
@@ -721,7 +725,7 @@ API 側の項目定義は [Webhook API: 配信履歴から障害対応へ進む�
 
 再送・重複処理の調査では、`event_id` と `endpoint_id` の組み合わせを先に確定し、delivery レコードの `id` や `attempt_count` は個別試行の確認だけに使います。
 キーごとの取得元は [Webhook API: 監査キーの読み方（再送・重複調査）](../api/webhooks.md#webhook-audit-key-map) を参照してください。
-署名鍵ローテーション時の手順は [Webhook API の `reload` 説明](../api/webhooks.md#署名鍵ローテーション時の利用) を参照。
+署名鍵ローテーション時の手順は [Webhook設定ガイド](../guides/webhooks.md#署名鍵ローテーション最小手順) と [Webhook API の `reload` 説明](../api/webhooks.md#署名鍵ローテーション時の利用) を参照。
 監査ログ項目の完全版は [Webhook設定ガイド: 署名検証失敗時の監査ログ項目](../guides/webhooks.md#署名検証失敗時の監査ログ項目) を参照。
 
 ---

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -19,6 +19,7 @@ Webhook 設定変更後の反映不良は、[Webhook reload 障害の最短導�
 ## Webhook reload 障害の最短導線
 
 `config/webhooks.yaml` や secrets を変更したのに webhook 挙動が変わらない場合は、次の 3 手順で確認します。
+署名鍵ローテーション直後も同じ導線を使い、旧鍵へ戻す前に現在値、`reload` 結果、同一イベント再送結果をそろえてください。
 
 1. 現在の読み込み状態を確認
    - `curl -fsS http://localhost:8000/api/v1/admin/webhooks/endpoints`
@@ -31,6 +32,7 @@ Webhook 設定変更後の反映不良は、[Webhook reload 障害の最短導�
 
 - [FAQ: Webhook reload が効かないときの確認順は？](./help/faq.md#webhook-reload-が効かないときの確認順は)
 - [トラブルシューティング: Webhook reload 後も反映されない](./help/troubleshooting.md#webhook-reload-後も反映されない)
+- [Webhook設定ガイド: 署名鍵ローテーション最小手順](./guides/webhooks.md#署名鍵ローテーション最小手順)
 - [Webhook API: `reload` 失敗時の最短確認手順](./api/webhooks.md#reload-失敗時の最短確認手順)
 
 ## Docker Composeプロファイル
@@ -689,6 +691,7 @@ rg -n "/api/v1/auth/\\{provider\\}/callback|invalid_client|Invalid or expired st
       google_client_secret.txt
       discord_client_id.txt
       discord_client_secret.txt
+      webhook_secret_my_service.txt
       jwt_secret.txt
       admin_password.txt   # --profile full を使う場合のみ
 ```
@@ -699,6 +702,7 @@ rg -n "/api/v1/auth/\\{provider\\}/callback|invalid_client|Invalid or expired st
 mkdir -p /opt/yesod-auth/secrets/current
 cp secrets/*.example /opt/yesod-auth/secrets/current/
 openssl rand -hex 32 > /opt/yesod-auth/secrets/current/jwt_secret.txt
+openssl rand -hex 32 > /opt/yesod-auth/secrets/current/webhook_secret_my_service.txt
 openssl rand -base64 24 > /opt/yesod-auth/secrets/current/admin_password.txt
 chmod 600 /opt/yesod-auth/secrets/current/*.txt
 
@@ -712,6 +716,8 @@ ln -sfn ../secrets/current secrets
 docker compose --profile default config >/dev/null
 docker compose --profile full config >/dev/null
 ```
+
+Webhook 署名鍵を切り替える場合は、`config/webhooks.yaml` の参照名を維持したまま `webhook_secret_<endpoint>.txt` の値を更新し、[Webhook reload 障害の最短導線](#webhook-reload-障害の最短導線) の順で `reload` と同一イベント再送を確認してください。
 
 ### secret/環境変数の解決優先順位
 


### PR DESCRIPTION
## Summary
- reorganize webhook signature key rotation into before / after / rollback steps
- connect installation, FAQ, and troubleshooting paths to the rotation flow
- clarify reload verification order and MOCK_OAUTH_ENABLED non-impact for webhook secrets

## Tests
- `rg -n "ローテーション|reload|secret|installation" docs/guides/webhooks.md docs/installation.md docs/help/troubleshooting.md`
- `git diff --check`
- `uvx --from mkdocs-material mkdocs build --strict` (passes; existing docs emit pre-existing anchor INFO messages)

Refs #628
