### PR TITLE
docs: align webhook failure reason troubleshooting

### DIFF
--- a/.agent/WORKLOG.md
+++ b/.agent/WORKLOG.md
@@ -2,40 +2,39 @@
 
 ## Goal
 
-Issue #627: Webhook delivery history should lead operators from API fields to troubleshooting without changing API behavior.
+Issue #629: Align Webhook failure classification between API docs and troubleshooting without changing API behavior.
 
 ## Assumptions
 
 - Scope is documentation only.
 - No webhook implementation, API schema, or new admin endpoint changes are required.
-- Linked Project status / priority is N/A because `gh issue view` returned no project items for #627.
+- Linked Project status / priority is N/A because `gh issue view` returned no project items for #629.
 
 ## Checklist
 
 - [x] Confirm live issue selection and project status.
-- [x] Claim issue #627.
-- [x] Align delivery history field meanings with troubleshooting terms.
+- [x] Claim issue #629.
+- [x] Align `failure_reason` meanings with troubleshooting terms.
 - [x] Add a clear handoff from API docs to troubleshooting.
-- [x] Confirm guide wording still matches API/troubleshooting.
+- [x] Confirm FAQ / installation / troubleshooting wording still matches.
 - [x] Run targeted documentation verification.
 - [x] Self-review diff.
 
 ## Verification Commands
 
-- `rg -n "event_id|endpoint_id|attempt_count|delivery|troubleshooting" docs/api/webhooks.md docs/help/troubleshooting.md`
-- `rg -n "配信履歴|event_id|endpoint_id|attempt_count|Webhook API|トラブルシューティング|self-hosted production callback" docs/api/webhooks.md docs/guides/webhooks.md docs/help/troubleshooting.md docs/help/faq.md docs/installation.md`
+- `rg -n "failure_reason|missing_signature_header|timestamp_skew|hmac_mismatch|webhook_delivery_retry_exhausted|webhook-failure-reason-map" docs/help/troubleshooting.md docs/api/webhooks.md docs/help/faq.md docs/installation.md`
+- `rg -n "Webhookが届かない|Webhook reload 障害|配信履歴から初動|署名検証に失敗する" docs/help/troubleshooting.md docs/api/webhooks.md docs/help/faq.md docs/installation.md`
 - `git diff --check`
-- `docker run --rm -v "$PWD":/docs squidfunk/mkdocs-material:latest build --strict`
+- `docker run --rm -v "$PWD":/docs squidfunk/mkdocs-material:latest build --strict --site-dir /tmp/yesod-auth-site`
 
 ## Completed
 
-- Live selection chose #627 from normal `codex:queue`.
+- Live selection chose #629 from normal `codex:queue`.
 - `codex:claimed` was applied and the temporary worktree was created from `origin/main`.
-- `docs/api/webhooks.md` now explains how `event_id` / `endpoint_id` / `attempt_count` lead into troubleshooting.
-- `docs/guides/webhooks.md` now tells operators to collect the same keys before moving from delivery history to recovery.
-- `docs/help/troubleshooting.md` now has a delivery-history triage entry before symptom-specific webhook checks.
-- `docs/help/faq.md` no longer uses a docs-internal relative link to repository README, which restored strict docs build success.
-- Targeted `rg` checks, `git diff --check`, and strict MkDocs build completed successfully.
+- `docs/help/troubleshooting.md` now maps API `failure_reason` values to the first troubleshooting step.
+- `docs/api/webhooks.md` now has stable anchors for retry-exhausted and signature failure classifications and links back to troubleshooting.
+- `docs/help/faq.md` and `docs/installation.md` now send `failure_reason` cases to the same troubleshooting map.
+- Targeted `rg` checks, `git diff --check`, and Docker MkDocs strict build completed successfully.
 - Self-review confirmed the change is docs/worklog only and does not modify webhook API behavior.
 
 ## Remaining

--- a/docs/api/webhooks.md
+++ b/docs/api/webhooks.md
@@ -209,6 +209,8 @@ POST /api/v1/admin/webhooks/reload
 
 ---
 
+<a id="webhook-retry-exhausted-log"></a>
+
 ## 再試行上限到達時の監査ログ
 
 Webhook 配信が再試行上限に到達した場合、ワーカーは固定キー
@@ -223,6 +225,8 @@ Webhook 配信が再試行上限に到達した場合、ワーカーは固定キ
 - `endpoint_id` / `event_id`: 影響範囲の追跡キー
 
 ---
+
+<a id="webhook-signature-failure-reasons"></a>
 
 ## 署名検証エラー分類
 
@@ -262,3 +266,4 @@ Webhook 配信が再試行上限に到達した場合、ワーカーは固定キ
 詳細なログ確認コマンドと復旧パターンは [トラブルシューティングの「署名検証に失敗する」](../help/troubleshooting.md#署名検証に失敗する) を参照してください。
 調査時に最低限確認する監査ログ項目（`event_type`, `failure_reason`, `webhook_id`, `x_webhook_event`, `request_id`）は、
 [Webhook設定ガイド: 署名検証失敗時の監査ログ項目](../guides/webhooks.md#署名検証失敗時の監査ログ項目) を参照してください。
+`failure_reason` ごとの初動分類は [トラブルシューティング: `failure_reason` の読み替え表](../help/troubleshooting.md#webhook-failure-reason-map) に対応させています。

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -266,6 +266,8 @@ curl "http://localhost:8000/api/v1/auth/mock/login?user=alice&provider=google"
 4. 配信履歴を確認：`GET /api/v1/admin/webhooks/deliveries`
 5. 設定変更直後は `POST /api/v1/admin/webhooks/reload` を実行し、同一イベントを再送して結果を比較
 
+配信履歴に `failure_reason` がある場合は、[トラブルシューティング: `failure_reason` の読み替え表](./troubleshooting.md#webhook-failure-reason-map) で API 文書と同じ分類へ戻してから確認してください。
+
 ### 署名検証の方法は？
 
 [Webhook設定ガイド](../guides/webhooks.md#署名検証)を参照してください。
@@ -285,6 +287,7 @@ curl "http://localhost:8000/api/v1/auth/mock/login?user=alice&provider=google"
 
 - [トラブルシューティング: Webhook reload 後も反映されない](./troubleshooting.md#webhook-reload-後も反映されない)
 - [Webhook API: `reload` 失敗時の最短確認手順](../api/webhooks.md#reload-失敗時の最短確認手順)
+- [トラブルシューティング: `failure_reason` の読み替え表](./troubleshooting.md#webhook-failure-reason-map)
 
 ### Webhook 署名鍵をローテーションするときの最短順は？
 

--- a/docs/help/troubleshooting.md
+++ b/docs/help/troubleshooting.md
@@ -625,6 +625,24 @@ FAQ での方針説明は [FAQ: Adminで未翻訳キーが出たときの表示�
 
 API 側の項目定義は [Webhook API: 配信履歴から障害対応へ進む読み順](../api/webhooks.md#delivery-history-troubleshooting-flow) を参照してください。
 
+<a id="webhook-failure-reason-map"></a>
+
+### `failure_reason` の読み替え表
+
+署名検証失敗では、API 文書の [署名検証エラー分類](../api/webhooks.md#webhook-signature-failure-reasons) を正本にして、`failure_reason` を次の順で読み替えます。HTTP 失敗やタイムアウト由来の `failure_reason` は [再試行上限到達時の監査ログ](../api/webhooks.md#webhook-retry-exhausted-log) を先に見て、署名失敗の固定分類と混ぜないでください。
+
+| `failure_reason` | 初動分類 | 次に見る場所 |
+| --- | --- | --- |
+| `missing_signature_header` | 送信元が `X-Webhook-Signature` を付けていない、またはプロキシで落ちている | [Webhookが発火しない](#webhook-not-triggered) で endpoint と受信ログを確認 |
+| `missing_timestamp_header` | 送信元が `X-Webhook-Timestamp` を付けていない | [署名検証に失敗する](#webhook-signature-verification-failure) で送信元ヘッダーを確認 |
+| `timestamp_skew` | 送信元と受信側の時刻差が許容範囲を超えている | [署名検証に失敗する](#webhook-signature-verification-failure) で時刻同期と再送遅延を確認 |
+| `invalid_signature_format` | `algorithm=digest` 形式でない署名値が届いている | [署名検証に失敗する](#webhook-signature-verification-failure) で署名ヘッダー形式を確認 |
+| `unsupported_signature_algorithm` | 未対応アルゴリズムが指定されている | [署名検証に失敗する](#webhook-signature-verification-failure) で送信元の署名方式を `sha256` 系へ戻す |
+| `hmac_mismatch` | payload と署名鍵が一致していない | [Webhook reload 後も反映されない](#webhook-reload-後も反映されない) で secret 反映と再送を確認 |
+| `replay_detected` | 同じ署名/timestamp の再利用が疑われる | [配信履歴から初動を決める](#webhook-delivery-history-triage) で `event_id` と `attempt_count` を確認 |
+
+アプリ内例外として `invalid_signature` だけが見える場合は、例外メッセージの `error_code=<failure_reason>` をこの表へ戻してから初動分類してください。
+
 <a id="webhook-not-triggered"></a>
 
 ### Webhookが発火しない
@@ -725,6 +743,7 @@ API 側の項目定義は [Webhook API: 配信履歴から障害対応へ進む�
 
 再送・重複処理の調査では、`event_id` と `endpoint_id` の組み合わせを先に確定し、delivery レコードの `id` や `attempt_count` は個別試行の確認だけに使います。
 キーごとの取得元は [Webhook API: 監査キーの読み方（再送・重複調査）](../api/webhooks.md#webhook-audit-key-map) を参照してください。
+`failure_reason` の固定値と初動分類は [`failure_reason` の読み替え表](#webhook-failure-reason-map) を参照してください。
 署名鍵ローテーション時の手順は [Webhook設定ガイド](../guides/webhooks.md#署名鍵ローテーション最小手順) と [Webhook API の `reload` 説明](../api/webhooks.md#署名鍵ローテーション時の利用) を参照。
 監査ログ項目の完全版は [Webhook設定ガイド: 署名検証失敗時の監査ログ項目](../guides/webhooks.md#署名検証失敗時の監査ログ項目) を参照。
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -13,6 +13,7 @@
 
 障害時の確認手順は[トラブルシューティング: 障害時の参照順](help/troubleshooting.md#障害時の参照順最短導線)を参照してください。
 Webhook 設定変更後の反映不良は、[Webhook reload 障害の最短導線](#webhook-reload-障害の最短導線) から着手してください。
+配信履歴や API ログで `failure_reason` を確認した場合は、[トラブルシューティング: `failure_reason` の読み替え表](help/troubleshooting.md#webhook-failure-reason-map) へ進み、API 文書と同じ分類で切り分けてください。
 
 <a id="webhook-reload-障害の最短導線"></a>
 
@@ -32,6 +33,7 @@ Webhook 設定変更後の反映不良は、[Webhook reload 障害の最短導�
 
 - [FAQ: Webhook reload が効かないときの確認順は？](./help/faq.md#webhook-reload-が効かないときの確認順は)
 - [トラブルシューティング: Webhook reload 後も反映されない](./help/troubleshooting.md#webhook-reload-後も反映されない)
+- [トラブルシューティング: `failure_reason` の読み替え表](./help/troubleshooting.md#webhook-failure-reason-map)
 - [Webhook設定ガイド: 署名鍵ローテーション最小手順](./guides/webhooks.md#署名鍵ローテーション最小手順)
 - [Webhook API: `reload` 失敗時の最短確認手順](./api/webhooks.md#reload-失敗時の最短確認手順)
 


### PR DESCRIPTION
## Summary

- Add a troubleshooting `failure_reason` map for Webhook signature failures.
- Add stable API anchors for retry-exhausted and signature failure classifications.
- Link FAQ and installation Webhook recovery paths to the same troubleshooting map.

## Verification

- `rg -n "failure_reason|missing_signature_header|timestamp_skew|hmac_mismatch|webhook_delivery_retry_exhausted|webhook-failure-reason-map" docs/help/troubleshooting.md docs/api/webhooks.md docs/help/faq.md docs/installation.md`
- `rg -n "Webhookが届かない|Webhook reload 障害|配信履歴から初動|署名検証に失敗する" docs/help/troubleshooting.md docs/api/webhooks.md docs/help/faq.md docs/installation.md`
- `git diff --check`
- `docker run --rm -v "$PWD":/docs squidfunk/mkdocs-material:latest build --strict --site-dir /tmp/yesod-auth-site`

Fixes #629
