### PR TITLE
fix(automation): support GitHub operations without gh CLI

### DIFF
--- a/scripts/ensure_github_labels.sh
+++ b/scripts/ensure_github_labels.sh
@@ -1,11 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if ! command -v gh >/dev/null 2>&1; then
-  echo "gh CLI is required." >&2
-  exit 1
-fi
-
 dry_run=0
 repo=""
 
@@ -32,14 +27,83 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-repo="${repo:-${GH_REPO:-}}"
+repo="${repo:-${GH_REPO:-${GITHUB_REPOSITORY:-}}}"
 if [[ -z "${repo}" ]]; then
-  repo="$(gh repo view --json nameWithOwner -q '.nameWithOwner' 2>/dev/null || true)"
+  repo="$(git remote get-url origin 2>/dev/null | sed -E 's#.*github.com[:/]([^/]+/[^/.]+)(\\.git)?$#\1#' || true)"
+fi
+if [[ -z "${repo}" || "${repo}" == http* || "${repo}" == git@* ]]; then
+  if command -v gh >/dev/null 2>&1; then
+    repo="$(gh repo view --json nameWithOwner -q '.nameWithOwner' 2>/dev/null || true)"
+  fi
 fi
 
 if [[ -z "${repo}" ]]; then
-  echo "Repository not found. Pass owner/repo as the first argument or set GH_REPO." >&2
+  echo "Repository not found. Pass owner/repo as the first argument or set GH_REPO/GITHUB_REPOSITORY." >&2
   exit 1
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+  token="${GH_TOKEN:-${GITHUB_TOKEN:-}}"
+  if [[ -z "${token}" ]]; then
+    echo "gh CLI is unavailable and GH_TOKEN/GITHUB_TOKEN is not set; cannot sync GitHub labels." >&2
+    exit 1
+  fi
+  export GITHUB_LABEL_SYNC_REPO="${repo}"
+  export GITHUB_LABEL_SYNC_DRY_RUN="${dry_run}"
+  python3 - <<'PY'
+import json
+import os
+import sys
+import urllib.parse
+import urllib.request
+
+repo = os.environ["GITHUB_LABEL_SYNC_REPO"]
+dry_run = os.environ["GITHUB_LABEL_SYNC_DRY_RUN"] == "1"
+token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+encoded_repo = urllib.parse.quote(repo, safe="/")
+headers = {
+    "Accept": "application/vnd.github+json",
+    "Authorization": f"Bearer {token}",
+    "Content-Type": "application/json",
+    "User-Agent": "yesod-auth-codex-automation",
+    "X-GitHub-Api-Version": "2022-11-28",
+}
+
+def request(method, path, payload=None):
+    data = json.dumps(payload).encode("utf-8") if payload is not None else None
+    req = urllib.request.Request(f"https://api.github.com{path}", data=data, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(req, timeout=30) as response:
+            body = response.read().decode("utf-8")
+    except urllib.error.HTTPError as exc:
+        print(f"GitHub API request failed: HTTP {exc.code} {exc.read().decode('utf-8', errors='replace')}", file=sys.stderr)
+        raise SystemExit(1)
+    return json.loads(body) if body else None
+
+specs = [
+    ("codex", "0E8A16", "managed by Codex"),
+    ("codex-automation", "1D76DB", "created or updated by Codex automation"),
+    ("codex:queue", "0E8A16", "managed by codex-orch"),
+    ("codex:claimed", "0E8A16", "managed by codex-orch"),
+    ("codex:blocked", "0E8A16", "managed by codex-orch"),
+    ("codex:pr-opened", "0E8A16", "managed by codex-orch"),
+]
+existing = {item["name"] for item in request("GET", f"/repos/{encoded_repo}/labels?per_page=100")}
+for name, color, description in specs:
+    exists = name in existing
+    action = "update" if exists else "create"
+    if dry_run:
+        print(f"would {action}: {name}")
+        continue
+    if exists:
+        encoded_name = urllib.parse.quote(name, safe="")
+        request("PATCH", f"/repos/{encoded_repo}/labels/{encoded_name}", {"new_name": name, "color": color, "description": description})
+        print(f"updated: {name}")
+    else:
+        request("POST", f"/repos/{encoded_repo}/labels", {"name": name, "color": color, "description": description})
+        print(f"created: {name}")
+PY
+  exit $?
 fi
 
 existing_labels="$(

--- a/scripts/github_fallback.py
+++ b/scripts/github_fallback.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""Small GitHub helpers with gh-first and REST fallback behavior."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import urllib.parse
+import urllib.request
+from typing import Any
+
+
+def _token() -> str:
+    return os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN") or ""
+
+
+def gh_available() -> bool:
+    return shutil.which("gh") is not None
+
+
+def run_gh(args: list[str]) -> str:
+    try:
+        completed = subprocess.run(
+            ["gh", *args],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError:
+        print("gh CLI is not installed; using GitHub REST fallback when possible.", file=sys.stderr)
+        raise
+    except subprocess.CalledProcessError as exc:
+        print(exc.stderr.strip() or str(exc), file=sys.stderr)
+        raise SystemExit(exc.returncode)
+    return completed.stdout
+
+
+def api_json(method: str, path: str, payload: dict[str, Any] | None = None) -> Any:
+    token = _token()
+    if not token:
+        print(
+            "gh CLI is unavailable and GH_TOKEN/GITHUB_TOKEN is not set; GitHub API fallback cannot authenticate.",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+
+    data = None
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "Authorization": f"Bearer {token}",
+        "User-Agent": "yesod-auth-codex-automation",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    if payload is not None:
+        data = json.dumps(payload).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+
+    request = urllib.request.Request(
+        f"https://api.github.com{path}",
+        data=data,
+        headers=headers,
+        method=method,
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            body = response.read().decode("utf-8")
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")
+        print(f"GitHub API request failed: HTTP {exc.code} {detail}", file=sys.stderr)
+        raise SystemExit(1)
+    except urllib.error.URLError as exc:
+        print(f"GitHub API request failed: {exc}", file=sys.stderr)
+        raise SystemExit(1)
+
+    if not body:
+        return None
+    return json.loads(body)
+
+
+def detect_repo(explicit: str = "") -> str:
+    candidates = [
+        explicit.strip(),
+        os.environ.get("GH_REPO", "").strip(),
+        os.environ.get("GITHUB_REPOSITORY", "").strip(),
+    ]
+    for candidate in candidates:
+        if candidate:
+            return candidate
+
+    remote = _git_remote_repo()
+    if remote:
+        return remote
+
+    if gh_available():
+        return run_gh(["repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"]).strip()
+
+    print(
+        "Repository not found. Pass --repo owner/repo, set GH_REPO/GITHUB_REPOSITORY, or configure git remote origin.",
+        file=sys.stderr,
+    )
+    raise SystemExit(1)
+
+
+def _git_remote_repo() -> str:
+    try:
+        completed = subprocess.run(
+            ["git", "remote", "get-url", "origin"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return ""
+
+    url = completed.stdout.strip()
+    patterns = [
+        r"github\.com[:/](?P<repo>[^/]+/[^/.]+)(?:\.git)?$",
+        r"https://github\.com/(?P<repo>[^/]+/[^/.]+)(?:\.git)?$",
+    ]
+    for pattern in patterns:
+        match = re.search(pattern, url)
+        if match:
+            return match.group("repo")
+    return ""
+
+
+def list_open_issues(repo: str) -> list[dict[str, Any]]:
+    if gh_available():
+        output = run_gh(
+            [
+                "issue",
+                "list",
+                "--repo",
+                repo,
+                "--state",
+                "open",
+                "--limit",
+                "200",
+                "--json",
+                "number,title,url,createdAt,labels",
+            ]
+        )
+        return json.loads(output)
+
+    issues: list[dict[str, Any]] = []
+    encoded_repo = urllib.parse.quote(repo, safe="/")
+    page = 1
+    while True:
+        response = api_json(
+            "GET",
+            f"/repos/{encoded_repo}/issues?state=open&per_page=100&page={page}",
+        )
+        page_items = [item for item in response if "pull_request" not in item]
+        issues.extend(
+            {
+                "number": item["number"],
+                "title": item["title"],
+                "url": item["html_url"],
+                "createdAt": item["created_at"],
+                "labels": [{"name": label["name"]} for label in item.get("labels", [])],
+            }
+            for item in page_items
+        )
+        if len(response) < 100:
+            break
+        page += 1
+    return issues
+
+
+def edit_issue_title(repo: str, number: int, title: str) -> None:
+    if gh_available():
+        run_gh(["issue", "edit", str(number), "--repo", repo, "--title", title])
+        return
+
+    encoded_repo = urllib.parse.quote(repo, safe="/")
+    api_json("PATCH", f"/repos/{encoded_repo}/issues/{number}", {"title": title})

--- a/scripts/normalize_bench80_queue_titles.py
+++ b/scripts/normalize_bench80_queue_titles.py
@@ -4,53 +4,16 @@
 from __future__ import annotations
 
 import argparse
-import json
 import re
-import subprocess
-import sys
+
+from github_fallback import detect_repo, edit_issue_title, list_open_issues
 
 BENCH_TITLE_RE = re.compile(r"^\s*\[Bench-80\]\[(\d+)\]\s*(.+?)\s*$")
 
 
-def run_gh(args: list[str]) -> str:
-    try:
-        completed = subprocess.run(
-            ["gh", *args],
-            check=True,
-            capture_output=True,
-            text=True,
-        )
-    except FileNotFoundError:
-        print("gh CLI is required", file=sys.stderr)
-        raise SystemExit(1)
-    except subprocess.CalledProcessError as exc:
-        print(exc.stderr.strip() or str(exc), file=sys.stderr)
-        raise SystemExit(exc.returncode)
-    return completed.stdout
-
-
-def detect_repo(explicit: str) -> str:
-    if explicit:
-        return explicit
-    return run_gh(["repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"]).strip()
-
 
 def fetch_open_queue_issues(repo: str) -> list[dict]:
-    output = run_gh(
-        [
-            "issue",
-            "list",
-            "--repo",
-            repo,
-            "--state",
-            "open",
-            "--limit",
-            "200",
-            "--json",
-            "number,title,labels,createdAt",
-        ]
-    )
-    issues = json.loads(output)
+    issues = list_open_issues(repo)
     queue = []
     for issue in issues:
         labels = {label["name"] for label in issue.get("labels", [])}
@@ -92,7 +55,7 @@ def main() -> int:
         print(f"#{number}: {old_title} -> {new_title}")
         if not args.apply:
             continue
-        run_gh(["issue", "edit", str(number), "--repo", repo, "--title", new_title])
+        edit_issue_title(repo, number, new_title)
         updated += 1
 
     if args.apply:

--- a/scripts/queue_seed_snapshot.py
+++ b/scripts/queue_seed_snapshot.py
@@ -6,11 +6,12 @@ from __future__ import annotations
 import argparse
 import json
 import re
-import subprocess
 import sys
 from collections import defaultdict
 from dataclasses import dataclass
 from typing import Any
+
+from github_fallback import detect_repo, list_open_issues
 
 BENCH_TITLE_RE = re.compile(r"^\s*\[Bench-80\]\[(\d+)\]\s*(.+?)\s*$")
 
@@ -23,39 +24,8 @@ class BenchIssue:
     url: str
 
 
-def run_gh(args: list[str]) -> str:
-    try:
-        completed = subprocess.run(
-            ["gh", *args],
-            check=True,
-            capture_output=True,
-            text=True,
-        )
-    except FileNotFoundError:
-        print("gh CLI is required", file=sys.stderr)
-        raise SystemExit(1)
-    except subprocess.CalledProcessError as exc:
-        print(exc.stderr.strip() or str(exc), file=sys.stderr)
-        raise SystemExit(exc.returncode)
-    return completed.stdout
-
-
 def fetch_open_queue_issues(repo: str) -> list[dict[str, Any]]:
-    output = run_gh(
-        [
-            "issue",
-            "list",
-            "--repo",
-            repo,
-            "--state",
-            "open",
-            "--limit",
-            "200",
-            "--json",
-            "number,title,url,createdAt,labels",
-        ]
-    )
-    issues = json.loads(output)
+    issues = list_open_issues(repo)
     queue_issues = []
     for issue in issues:
         labels = {label["name"] for label in issue.get("labels", [])}
@@ -140,9 +110,7 @@ def main() -> int:
     parser.add_argument("--format", choices=("json", "markdown"), default="json")
     args = parser.parse_args()
 
-    repo = args.repo.strip()
-    if not repo:
-        repo = run_gh(["repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"]).strip()
+    repo = detect_repo(args.repo.strip())
     if not repo:
         print("Repository not found. pass --repo owner/repo.", file=sys.stderr)
         return 1


### PR DESCRIPTION
## Summary

This PR fixes Codex Cloud automation failures caused by assuming the GitHub CLI is available in the execution environment.

The failing symptom was:

```text
gh repo view mashirou1234/yesod-auth --json nameWithOwner,defaultBranchRef
# gh: command not found
```

The helper scripts now keep `gh` as the preferred local path, but can fall back to GitHub REST API calls when `GH_TOKEN` or `GITHUB_TOKEN` is available.

## Background

Codex Cloud tasks can run in minimal environments where `gh` is not installed. Several automation helpers used `gh repo view` for repository discovery and `gh issue` / `gh label` for queue and label operations. That made the Cloud workflow fail before it could reach the actual yesod-auth issue processing logic.

## Key Changes

- Added a shared Python helper module for GitHub operations with `gh`-first and REST fallback behavior.
- Removed duplicated `subprocess.run(["gh", ...])` wrappers from the Bench-80 queue scripts.
- Added repository detection from explicit args, `GH_REPO`, `GITHUB_REPOSITORY`, git remote origin, and only then `gh repo view` when `gh` exists.
- Added REST fallback for open issue listing, issue title updates, and label synchronization.
- Preserved existing `gh` behavior for developer machines that already have GitHub CLI installed.

## File-by-File Detailed Changes

- `scripts/github_fallback.py`
  - Adds `gh_available()` for CLI detection.
  - Adds `run_gh()` for the existing preferred CLI execution path.
  - Adds token lookup from `GH_TOKEN` and `GITHUB_TOKEN`.
  - Adds authenticated GitHub REST requests through the Python standard library.
  - Adds `detect_repo()` with explicit/env/git-remote/gh fallback ordering.
  - Adds `list_open_issues()` with REST pagination and pull request filtering.
  - Adds `edit_issue_title()` using either `gh issue edit` or REST `PATCH /issues/{number}`.

- `scripts/queue_seed_snapshot.py`
  - Replaces the local `gh` wrapper with `detect_repo()` and `list_open_issues()`.
  - Keeps the existing Bench-80 analysis and output format unchanged.
  - Avoids `gh repo view` when repo metadata is already available through args, env, or git remote.

- `scripts/normalize_bench80_queue_titles.py`
  - Replaces duplicated `gh` plumbing with the shared helper module.
  - Keeps dry-run and `--apply` behavior unchanged.
  - Allows title updates without `gh` when a GitHub token is present.

- `scripts/ensure_github_labels.sh`
  - Accepts `GITHUB_REPOSITORY` in addition to `GH_REPO`.
  - Detects `owner/repo` from `git remote get-url origin` before falling back to `gh repo view`.
  - Adds a Python standard-library REST fallback for label list/create/update when `gh` is unavailable.
  - Emits an explicit token-missing error if neither `gh` nor `GH_TOKEN` / `GITHUB_TOKEN` is available.

## Impact & Risk

- Existing local workflows with `gh` installed continue to use `gh`.
- Cloud/minimal workflows can now proceed with token-backed REST API calls instead of failing at command discovery.
- No runtime application code or API behavior is changed.
- The REST fallback depends on `GH_TOKEN` or `GITHUB_TOKEN`; without either token, GitHub mutation remains blocked by design.
- The new helper uses only Python standard library modules, so no dependency installation is required.

## Testing

- `python3 -m py_compile scripts/github_fallback.py scripts/queue_seed_snapshot.py scripts/normalize_bench80_queue_titles.py`
- `bash -n scripts/ensure_github_labels.sh`
- `git diff --check`
- `PATH="/usr/bin:/bin" GH_REPO=mashirou1234/yesod-auth python3 scripts/queue_seed_snapshot.py --format json`
- `PATH="/usr/bin:/bin" GH_REPO=mashirou1234/yesod-auth python3 scripts/normalize_bench80_queue_titles.py`
- `PATH="/usr/bin:/bin" ./scripts/ensure_github_labels.sh --dry-run mashirou1234/yesod-auth`

## Reviewer Notes

Please focus on whether the REST fallback behavior is conservative enough for Cloud automation while preserving the existing `gh` path for local operations.
