### PR TITLE
docs: sync users API provider error guidance

### DIFF
--- a/docs/api/users.md
+++ b/docs/api/users.md
@@ -258,6 +258,20 @@ Authorization: Bearer <access_token>
 }
 ```
 
+### sync-from-provider 失敗マトリクス（運用向け）
+
+`POST /api/v1/users/me/sync-from-provider` の失敗時は、まず次の表で `400` と `404` を切り分けてください。
+
+| ステータス | 代表メッセージ | 何が起きているか | 最初の対処 | 次に見る場所 |
+| --- | --- | --- | --- | --- |
+| `400` | `Unsupported provider` | `provider` が対応外（`google` / `discord` 以外） | `provider` クエリを `google` か `discord` に修正 | [FAQ: sync-from-provider の 400/404 は何を意味する？](../help/faq.md#sync-from-provider-の-400404-は何を意味する) |
+| `404` | `No <provider> account linked` | 指定 provider の OAuth 連携が未作成 | 対象 provider で再ログインし、連携作成後に再実行 | [トラブルシューティング: sync-from-provider で 400/404 が返る](../help/troubleshooting.md#sync-from-provider-errors) |
+| `400` | `No provider info stored for <provider>...` | 連携はあるが保存済みプロフィール情報が空 | 同 provider で再ログインし、プロフィール情報を再取得 | [トラブルシューティング: sync-from-provider で 400/404 が返る](../help/troubleshooting.md#sync-from-provider-errors) |
+
+!!! note "対応 provider の範囲"
+    `sync-from-provider` の `provider` は現時点で `google` / `discord` のみ対応です。
+
 !!! tip "三点同期の確認導線"
     FAQ は [sync-from-provider の 400/404 の意味](../help/faq.md#sync-from-provider-の-400404-は何を意味する)、
-    障害対応は [sync-from-provider で 400/404 が返る](../help/troubleshooting.md#sync-from-provider-errors) を参照してください。
+    障害対応は [sync-from-provider で 400/404 が返る](../help/troubleshooting.md#sync-from-provider-errors)、
+    provider 未設定時の初動は [インストール: provider 未設定時の最短スキップ手順](../installation.md#provider-未設定時の最短スキップ手順) を参照してください。

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -188,6 +188,7 @@ organization 制限が必要な場合は、次を追加実装してください�
 
 API 契約とレスポンス例は [ユーザーAPI: プロバイダ情報からプロフィール復元](../api/users.md#プロバイダ情報からプロフィール復元) を参照してください。  
 切り分け手順は [トラブルシューティング: sync-from-provider で 400/404 が返る](./troubleshooting.md#sync-from-provider-errors) を参照してください。
+provider 未設定の初動は [インストール: provider 未設定時の最短スキップ手順](../installation.md#provider-未設定時の最短スキップ手順) を参照してください。
 
 ---
 

--- a/docs/help/troubleshooting.md
+++ b/docs/help/troubleshooting.md
@@ -368,6 +368,11 @@ environment:
 | 404 | `No <provider> account linked` | 指定 provider の連携がない | 当該 provider で再ログインして連携を作成 |
 | 400 | `No provider info stored for <provider>...` | 連携はあるが保存済みプロフィール情報が空 | 同 provider で再ログインし、プロフィール情報を再取得 |
 
+参照導線:
+
+- FAQ での要点整理: [sync-from-provider の 400/404 は何を意味する？](./faq.md#sync-from-provider-の-400404-は何を意味する)
+- provider 未設定時の初動: [インストール: provider 未設定時の最短スキップ手順](../installation.md#provider-未設定時の最短スキップ手順)
+
 確認コマンド例:
 
 ```bash


### PR DESCRIPTION
## 概要

Issue #604 の `sync-from-provider` 失敗時の運用導線を、API ドキュメント / FAQ / troubleshooting の 3 点で同期します。

## 背景

`POST /api/v1/users/me/sync-from-provider` は `400 Unsupported provider`、`404 No <provider> account linked`、`400 No provider info stored ...` のように複数の失敗形を持ちます。API 利用者と運用者が同じ分類で切り分けられるよう、レスポンス例と復旧先リンクを明確化します。

## 主な変更点

- `docs/api/users.md` に運用向け失敗マトリクスを追加し、HTTP status / detail / 原因 / 初動 / 参照先を整理
- `docs/help/faq.md` に 400/404 の意味を短く確認できる FAQ 導線を追加
- `docs/help/troubleshooting.md` に具体的な切り分け手順と `curl` 例を追加

## 影響とリスク

- docs-only 変更です。API 実装、レスポンス契約、テストコード、設定値には影響しません。
- 既存リンクに対して新しい参照先を追加するのみで、既存の導入手順は変更していません。

## テスト内容

- `git diff --check`
- `rg -n "sync-from-provider|Unsupported provider|No .* account linked|No provider info stored" docs/api/users.md docs/help/faq.md docs/help/troubleshooting.md`

## レビュアーへの依頼

- `sync-from-provider` の 3 種類の失敗分類が、API 文書と運用導線で矛盾していないか確認してください。
