### PR TITLE
chore(api): normalize Ruff gate formatting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,10 @@ env/
 *.swp
 *.swo
 
+# Local agent/browser work artifacts
+.agent/
+.playwright-mcp/
+
 # Docker
 .docker/
 

--- a/api/app/accounts/router.py
+++ b/api/app/accounts/router.py
@@ -20,9 +20,9 @@ from app.models import OAuthAccount, User
 from app.valkey import OAuthStateStore
 
 from .schemas import (
-    OAuthAccountResponse,
     SUPPORTED_ACCOUNT_PROVIDERS,
     UNLINK_LAST_AUTH_METHOD_ERROR_DETAIL,
+    OAuthAccountResponse,
     UnlinkResponse,
 )
 
@@ -78,9 +78,7 @@ def _normalize_callback_url(url: str) -> str:
 
 def _build_link_redirect_uri(provider: str) -> str:
     """Build canonical redirect URI for account-link callback."""
-    return (
-        f"{settings.API_URL.rstrip('/')}{API_V1_PREFIX}/accounts/link/{provider}/callback"
-    )
+    return f"{settings.API_URL.rstrip('/')}{API_V1_PREFIX}/accounts/link/{provider}/callback"
 
 
 def _validate_link_callback_url_or_raise(

--- a/api/app/audit/service.py
+++ b/api/app/audit/service.py
@@ -97,6 +97,7 @@ class AuditLogger:
             return  # Skip audit logging in test environment
 
         import json
+
         normalized_details = AuditLogger._normalize_event_details(details)
 
         await db.execute(

--- a/api/app/auth/oauth.py
+++ b/api/app/auth/oauth.py
@@ -93,7 +93,9 @@ def _sanitize_error_snippet(text: str | None) -> str:
     return compact[:240]
 
 
-def _log_exchange_failure(provider: str, status_code: int, response_text: str, redirect_uri: str) -> None:
+def _log_exchange_failure(
+    provider: str, status_code: int, response_text: str, redirect_uri: str
+) -> None:
     normalized_uri = _normalize_redirect_uri(redirect_uri)
     logger.debug(
         "OAuth code exchange failed provider=%s status_code=%s redirect_uri_raw=%s "

--- a/api/app/auth/rate_limit.py
+++ b/api/app/auth/rate_limit.py
@@ -4,8 +4,7 @@ import inspect
 
 from fastapi import Request
 from fastapi.responses import Response
-from slowapi import Limiter
-from slowapi import _rate_limit_exceeded_handler
+from slowapi import Limiter, _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
 from slowapi.util import get_remote_address
 

--- a/api/app/auth/router.py
+++ b/api/app/auth/router.py
@@ -1159,9 +1159,7 @@ async def refresh_tokens(
     """Refresh access token using refresh token (with rotation)."""
     device_info, ip_address = _get_client_info(request)
 
-    result = await _rotate_refresh_token_with_retry(
-        db, body.refresh_token, device_info, ip_address
-    )
+    result = await _rotate_refresh_token_with_retry(db, body.refresh_token, device_info, ip_address)
 
     if not result:
         token_status = await classify_refresh_token_failure(db, body.refresh_token)

--- a/api/app/auth/tokens.py
+++ b/api/app/auth/tokens.py
@@ -146,9 +146,7 @@ async def classify_refresh_token_failure(
     token_hash = hash_refresh_token(token)
     now = datetime.now(UTC)
 
-    result = await db.execute(
-        select(RefreshToken).where(RefreshToken.token_hash == token_hash)
-    )
+    result = await db.execute(select(RefreshToken).where(RefreshToken.token_hash == token_hash))
     record = result.scalar_one_or_none()
     if not record:
         return "not_found"

--- a/api/app/config.py
+++ b/api/app/config.py
@@ -163,7 +163,9 @@ class Settings:
             if len(providers) > 1
         )
         if duplicate_provider_groups:
-            duplicate_message = ", ".join("/".join(providers) for providers in duplicate_provider_groups)
+            duplicate_message = ", ".join(
+                "/".join(providers) for providers in duplicate_provider_groups
+            )
             raise ValueError(
                 "OAuth provider client_id is duplicated across enabled providers. "
                 f"Resolve duplicates for: {duplicate_message}."

--- a/api/app/metrics.py
+++ b/api/app/metrics.py
@@ -1,7 +1,7 @@
 """Prometheus metrics endpoint."""
 
-from collections import defaultdict
 import re
+from collections import defaultdict
 from threading import Lock
 
 from fastapi import APIRouter, Depends

--- a/api/app/webhooks/config.py
+++ b/api/app/webhooks/config.py
@@ -162,9 +162,7 @@ class WebhookConfigLoader:
         prev_value = -1
         for idx, value in enumerate(retry_backoff_ms):
             if not isinstance(value, int) or value <= 0:
-                raise ValueError(
-                    f"settings.retry_backoff_ms[{idx}] must be a positive integer"
-                )
+                raise ValueError(f"settings.retry_backoff_ms[{idx}] must be a positive integer")
             if idx > 0 and value < prev_value:
                 raise ValueError(
                     f"settings.retry_backoff_ms[{idx}] must be greater than or equal to "
@@ -224,9 +222,7 @@ class WebhookConfigLoader:
         seen_events: set[str] = set()
         for idx, event in enumerate(events):
             if not isinstance(event, str):
-                raise ValueError(
-                    f"Endpoint '{endpoint_id}' events[{idx}] must be a string"
-                )
+                raise ValueError(f"Endpoint '{endpoint_id}' events[{idx}] must be a string")
             normalized_event = event.strip()
             if not normalized_event:
                 raise ValueError(

--- a/api/app/webhooks/emitter.py
+++ b/api/app/webhooks/emitter.py
@@ -66,10 +66,7 @@ class WebhookEmitter:
             )
         except Exception as e:
             logger.error(
-                (
-                    "Failed to queue webhook event "
-                    "(delivery_id=%s event_type=%s queue_key=%s): %s"
-                ),
+                ("Failed to queue webhook event (delivery_id=%s event_type=%s queue_key=%s): %s"),
                 event.event_id,
                 event_type,
                 WEBHOOK_QUEUE_KEY,

--- a/api/tests/test_accounts.py
+++ b/api/tests/test_accounts.py
@@ -215,9 +215,7 @@ def test_link_validate_callback_url_allows_trailing_slash_difference(caplog):
     caplog.set_level(logging.INFO, logger=accounts_router_module.logger.name)
     request = SimpleNamespace(
         url=SimpleNamespace(
-            replace=lambda **kwargs: (
-                "https://api.example.com/api/v1/accounts/link/google/callback/"
-            )
+            replace=lambda **kwargs: "https://api.example.com/api/v1/accounts/link/google/callback/"
         )
     )
 

--- a/api/tests/test_audit_service.py
+++ b/api/tests/test_audit_service.py
@@ -47,4 +47,3 @@ async def test_log_event_preserves_existing_request_id(monkeypatch):
     assert payload["request_id"] == "req-fixed-123"
     assert payload["request_id_backfilled"] is False
     db.commit.assert_awaited_once()
-

--- a/api/tests/test_auth_callback_url_normalization.py
+++ b/api/tests/test_auth_callback_url_normalization.py
@@ -29,9 +29,12 @@ async def test_validate_callback_url_allows_trailing_slash_difference(caplog):
         )
     )
 
-    with patch.object(auth_router_module, "record_oauth_failure_metric") as mock_metric, patch.object(
-        auth_router_module.AuditLogger, "log_login", new_callable=AsyncMock
-    ) as mock_log_login:
+    with (
+        patch.object(auth_router_module, "record_oauth_failure_metric") as mock_metric,
+        patch.object(
+            auth_router_module.AuditLogger, "log_login", new_callable=AsyncMock
+        ) as mock_log_login,
+    ):
         await auth_router_module._validate_callback_url_or_raise(
             request=request,
             db=AsyncMock(),
@@ -61,9 +64,12 @@ async def test_validate_callback_url_rejects_real_mismatch():
         )
     )
 
-    with patch.object(auth_router_module, "record_oauth_failure_metric") as mock_metric, patch.object(
-        auth_router_module.AuditLogger, "log_login", new_callable=AsyncMock
-    ) as mock_log_login:
+    with (
+        patch.object(auth_router_module, "record_oauth_failure_metric") as mock_metric,
+        patch.object(
+            auth_router_module.AuditLogger, "log_login", new_callable=AsyncMock
+        ) as mock_log_login,
+    ):
         with pytest.raises(HTTPException) as exc_info:
             await auth_router_module._validate_callback_url_or_raise(
                 request=request,

--- a/api/tests/test_auth_oauth_provider_disabled.py
+++ b/api/tests/test_auth_oauth_provider_disabled.py
@@ -3,9 +3,11 @@
 import importlib
 
 import pytest
+
 from app.oauth_providers import OAUTH_PROVIDER_CREDENTIAL_FIELDS
 
 auth_router_module = importlib.import_module("app.auth.router")
+
 
 @pytest.mark.parametrize("provider", list(OAUTH_PROVIDER_CREDENTIAL_FIELDS.keys()))
 def test_oauth_provider_disabled_raises_503(monkeypatch, provider: str):
@@ -44,8 +46,7 @@ def test_oauth_provider_name_is_case_insensitive(monkeypatch, provider_variant: 
 
     assert exc_info.value.status_code == 503
     assert exc_info.value.detail == (
-        "OAuth provider 'github' is disabled. "
-        "Configure GITHUB_CLIENT_ID and GITHUB_CLIENT_SECRET."
+        "OAuth provider 'github' is disabled. Configure GITHUB_CLIENT_ID and GITHUB_CLIENT_SECRET."
     )
 
 

--- a/api/tests/test_auth_provider_registry.py
+++ b/api/tests/test_auth_provider_registry.py
@@ -34,4 +34,6 @@ def test_provider_registry_order_is_logged(caplog) -> None:
         auth_router_module._log_provider_registry_order()
 
     assert "OAuth provider registry initialized in deterministic order" in caplog.text
-    assert "discord -> facebook -> github -> google -> linkedin -> slack -> twitch -> x" in caplog.text
+    assert (
+        "discord -> facebook -> github -> google -> linkedin -> slack -> twitch -> x" in caplog.text
+    )

--- a/api/tests/test_auth_provider_response_codes.py
+++ b/api/tests/test_auth_provider_response_codes.py
@@ -11,10 +11,13 @@ auth_router_module = importlib.import_module("app.auth.router")
 @pytest.fixture(autouse=True)
 def bypass_rate_limit(monkeypatch):
     """Avoid external Redis dependency for endpoint contract tests."""
+
     def _fake_check_request_limit(request, *args, **kwargs):
         request.state.view_rate_limit = None
 
-    monkeypatch.setattr(auth_router_module.limiter, "_check_request_limit", _fake_check_request_limit)
+    monkeypatch.setattr(
+        auth_router_module.limiter, "_check_request_limit", _fake_check_request_limit
+    )
 
 
 @pytest.mark.asyncio

--- a/api/tests/test_auth_rate_limit_provider_path.py
+++ b/api/tests/test_auth_rate_limit_provider_path.py
@@ -2,9 +2,11 @@
 
 import pytest
 
-from app.auth.rate_limit import MISSING_OAUTH_PROVIDER_KEY
-from app.auth.rate_limit import extract_oauth_provider_from_path
-from app.auth.rate_limit import resolve_oauth_provider_metric_key
+from app.auth.rate_limit import (
+    MISSING_OAUTH_PROVIDER_KEY,
+    extract_oauth_provider_from_path,
+    resolve_oauth_provider_metric_key,
+)
 
 
 @pytest.mark.parametrize(

--- a/api/tests/test_auth_refresh.py
+++ b/api/tests/test_auth_refresh.py
@@ -1,9 +1,9 @@
 """Refresh token endpoint tests."""
 
-import time
 import importlib
-from types import SimpleNamespace
+import time
 from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, PropertyMock, patch
 
 import pytest
@@ -113,7 +113,9 @@ async def test_refresh_accepts_token_one_second_before_expiry(
 
     with (
         patch("app.auth.tokens.datetime", FrozenDateTime),
-        patch.object(User, "email", new_callable=PropertyMock, return_value="refresh-boundary@example.com"),
+        patch.object(
+            User, "email", new_callable=PropertyMock, return_value="refresh-boundary@example.com"
+        ),
     ):
         FrozenDateTime.current = datetime(2026, 1, 1, tzinfo=UTC)
         refresh_token = await create_refresh_token(db_session, user.id)
@@ -154,7 +156,12 @@ async def test_refresh_rejects_token_at_exact_expiry_boundary(
 
     with (
         patch("app.auth.tokens.datetime", FrozenDateTime),
-        patch.object(User, "email", new_callable=PropertyMock, return_value="refresh-expired-boundary@example.com"),
+        patch.object(
+            User,
+            "email",
+            new_callable=PropertyMock,
+            return_value="refresh-expired-boundary@example.com",
+        ),
     ):
         FrozenDateTime.current = datetime(2026, 1, 1, tzinfo=UTC)
         refresh_token = await create_refresh_token(db_session, user.id)
@@ -175,9 +182,7 @@ async def test_refresh_rejects_token_at_exact_expiry_boundary(
 
 
 @pytest.mark.asyncio
-async def test_refresh_rejects_revoked_session_token(
-    client: AsyncClient, db_session: AsyncSession
-):
+async def test_refresh_rejects_revoked_session_token(client: AsyncClient, db_session: AsyncSession):
     """Revoked session refresh token should not be reusable."""
     user = User()
     db_session.add(user)
@@ -189,9 +194,7 @@ async def test_refresh_rejects_revoked_session_token(
     auth_header = {"Authorization": f"Bearer {access_token}"}
 
     token_record = await db_session.scalar(
-        select(RefreshToken).where(
-            RefreshToken.token_hash == hash_refresh_token(refresh_token)
-        )
+        select(RefreshToken).where(RefreshToken.token_hash == hash_refresh_token(refresh_token))
     )
     assert token_record is not None
     session_id = token_record.id
@@ -229,7 +232,9 @@ async def test_refresh_reuse_logs_revoked_token_status(
     refresh_token = await create_refresh_token(db_session, user.id)
     with (
         patch("app.auth.router.AuditLogger.log_event", new=AsyncMock()) as mock_log_event,
-        patch.object(User, "email", new_callable=PropertyMock, return_value="refresh-reuse@example.com"),
+        patch.object(
+            User, "email", new_callable=PropertyMock, return_value="refresh-reuse@example.com"
+        ),
     ):
         first_refresh = await client.post(
             "/api/v1/auth/refresh",
@@ -291,6 +296,8 @@ async def test_refresh_rate_limited_response_includes_retry_after_header(client:
     assert retry_after is not None
     assert retry_after.isdigit()
     assert int(retry_after) >= 0
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("max_retries", "expected_attempts"),
@@ -300,7 +307,9 @@ async def test_refresh_rate_limited_response_includes_retry_after_header(client:
         (5, 6),
     ],
 )
-async def test_refresh_retry_limit_is_configurable(monkeypatch, max_retries: int, expected_attempts: int):
+async def test_refresh_retry_limit_is_configurable(
+    monkeypatch, max_retries: int, expected_attempts: int
+):
     rotate_mock = AsyncMock(side_effect=RuntimeError("temporary failure"))
     monkeypatch.setattr(auth_router, "rotate_refresh_token", rotate_mock)
     monkeypatch.setattr(auth_router.settings, "TOKEN_REFRESH_MAX_RETRIES", max_retries)

--- a/api/tests/test_auth_tokens.py
+++ b/api/tests/test_auth_tokens.py
@@ -51,9 +51,7 @@ async def test_validate_refresh_token_accepts_naive_expiry_just_before_boundary(
         FrozenDateTime.current = datetime(2026, 1, 1, tzinfo=UTC)
         refresh_token = await create_refresh_token(db_session, user.id)
         token_record = await db_session.scalar(
-            select(RefreshToken).where(
-                RefreshToken.token_hash == hash_refresh_token(refresh_token)
-            )
+            select(RefreshToken).where(RefreshToken.token_hash == hash_refresh_token(refresh_token))
         )
         assert token_record is not None
 
@@ -78,9 +76,7 @@ async def test_refresh_token_classification_marks_exact_expiry_as_expired(
         FrozenDateTime.current = datetime(2026, 1, 1, tzinfo=UTC)
         refresh_token = await create_refresh_token(db_session, user.id)
         token_record = await db_session.scalar(
-            select(RefreshToken).where(
-                RefreshToken.token_hash == hash_refresh_token(refresh_token)
-            )
+            select(RefreshToken).where(RefreshToken.token_hash == hash_refresh_token(refresh_token))
         )
         assert token_record is not None
 

--- a/api/tests/test_config.py
+++ b/api/tests/test_config.py
@@ -11,8 +11,8 @@ import yaml
 
 from app.config import (
     DEFAULT_CORS_ORIGINS,
-    parse_bool_env,
     Settings,
+    parse_bool_env,
     read_secret,
     resolve_cors_origins,
 )
@@ -22,8 +22,9 @@ def test_read_secret_prefers_secret_file_over_env(monkeypatch):
     """Docker secret file value must win over environment variable."""
     monkeypatch.setenv("JWT_SECRET", "env-value")
 
-    with patch("app.config.os.path.exists", return_value=True), patch(
-        "builtins.open", mock_open(read_data="file-value\n")
+    with (
+        patch("app.config.os.path.exists", return_value=True),
+        patch("builtins.open", mock_open(read_data="file-value\n")),
     ):
         assert read_secret("jwt_secret", "default-value") == "file-value"
 
@@ -32,7 +33,10 @@ def test_read_secret_falls_back_to_env_when_secret_file_missing(monkeypatch):
     """Environment variable is used when secret file does not exist."""
     monkeypatch.setenv("JWT_SECRET", "env-value")
 
-    with patch("app.config.os.path.exists", return_value=False), patch("builtins.open") as mock_file:
+    with (
+        patch("app.config.os.path.exists", return_value=False),
+        patch("builtins.open") as mock_file,
+    ):
         assert read_secret("jwt_secret", "default-value") == "env-value"
         mock_file.assert_not_called()
 
@@ -41,7 +45,10 @@ def test_read_secret_falls_back_to_default_when_secret_and_env_missing(monkeypat
     """Default value is used when both secret file and environment are absent."""
     monkeypatch.delenv("JWT_SECRET", raising=False)
 
-    with patch("app.config.os.path.exists", return_value=False), patch("builtins.open") as mock_file:
+    with (
+        patch("app.config.os.path.exists", return_value=False),
+        patch("builtins.open") as mock_file,
+    ):
         assert read_secret("jwt_secret", "default-value") == "default-value"
         mock_file.assert_not_called()
 
@@ -50,8 +57,9 @@ def test_read_secret_strips_trailing_whitespace_from_secret_file(monkeypatch):
     """Trailing whitespace in secret files must be removed."""
     monkeypatch.setenv("JWT_SECRET", "env-value")
 
-    with patch("app.config.os.path.exists", return_value=True), patch(
-        "builtins.open", mock_open(read_data="file-value  \n\n")
+    with (
+        patch("app.config.os.path.exists", return_value=True),
+        patch("builtins.open", mock_open(read_data="file-value  \n\n")),
     ):
         assert read_secret("jwt_secret", "default-value") == "file-value"
 
@@ -87,7 +95,9 @@ def test_resolve_cors_origins_normalizes_and_deduplicates_origins():
 
 
 def test_resolve_cors_origins_keeps_http_and_https_as_distinct_origins():
-    origins, using_default = resolve_cors_origins("http://example.com,https://example.com,http://example.com/")
+    origins, using_default = resolve_cors_origins(
+        "http://example.com,https://example.com,http://example.com/"
+    )
 
     assert origins == ["http://example.com", "https://example.com"]
     assert using_default is False
@@ -114,13 +124,12 @@ def test_parse_bool_env_returns_default_when_unset(monkeypatch):
 def test_parse_bool_env_raises_clear_error_on_invalid_value(monkeypatch):
     monkeypatch.setenv("TESTING", "maybe")
 
-    try:
+    with pytest.raises(ValueError) as exc_info:
         parse_bool_env("TESTING")
-        assert False, "ValueError was not raised for invalid boolean value"
-    except ValueError as exc:
-        message = str(exc)
-        assert "Invalid boolean value for TESTING: raw='maybe', normalized='maybe'" in message
-        assert "Allowed values: 1,true,yes,0,false,no" in message
+
+    message = str(exc_info.value)
+    assert "Invalid boolean value for TESTING: raw='maybe', normalized='maybe'" in message
+    assert "Allowed values: 1,true,yes,0,false,no" in message
 
 
 def test_parse_bool_env_raises_with_raw_and_normalized_value(monkeypatch):
@@ -177,9 +186,7 @@ def test_settings_raises_when_provider_client_id_exists_but_secret_is_empty(monk
     monkeypatch.setattr(Settings, "GITHUB_CLIENT_ID", "github-client-id")
     monkeypatch.setattr(Settings, "GITHUB_CLIENT_SECRET", "")
 
-    with pytest.raises(
-        ValueError, match="GITHUB_CLIENT_SECRET"
-    ):
+    with pytest.raises(ValueError, match="GITHUB_CLIENT_SECRET"):
         Settings()
 
 

--- a/api/tests/test_github_oauth.py
+++ b/api/tests/test_github_oauth.py
@@ -157,8 +157,14 @@ class TestGitHubOAuthExchangeCode:
 
         assert result is None
         logs = "\n".join(caplog.messages)
-        assert "redirect_uri_raw=https://EXAMPLE.COM:443/api/v1/auth/github/callback/?code=abcd%2A%2A%2A" in logs
-        assert "redirect_uri_normalized=https://example.com/api/v1/auth/github/callback?code=abcd%2A%2A%2A" in logs
+        assert (
+            "redirect_uri_raw=https://EXAMPLE.COM:443/api/v1/auth/github/callback/?code=abcd%2A%2A%2A"
+            in logs
+        )
+        assert (
+            "redirect_uri_normalized=https://example.com/api/v1/auth/github/callback?code=abcd%2A%2A%2A"
+            in logs
+        )
         assert "redirect_uri_changed=True" in logs
         assert '"code":"***"' in logs
 
@@ -366,7 +372,9 @@ class TestGitHubOAuthCallback:
             patch("app.auth.router.record_oauth_failure_metric") as mock_metric,
             patch("app.auth.router.AuditLogger.log_login", new=AsyncMock()) as mock_log_login,
         ):
-            response = await client.get("/api/v1/auth/github/callback?error=provider_outage&state=s1")
+            response = await client.get(
+                "/api/v1/auth/github/callback?error=provider_outage&state=s1"
+            )
 
         assert response.status_code == 400
         assert response.json() == {"detail": "OAuth callback failed: provider_outage"}

--- a/api/tests/test_mock_oauth.py
+++ b/api/tests/test_mock_oauth.py
@@ -95,7 +95,9 @@ async def test_authenticated_request(client: AsyncClient):
 
 
 @pytest.mark.asyncio
-async def test_mock_login_github_avoids_provider_user_id_collision(client: AsyncClient, monkeypatch):
+async def test_mock_login_github_avoids_provider_user_id_collision(
+    client: AsyncClient, monkeypatch
+):
     """GitHub mock provider_user_id must avoid collisions even with same numeric suffix IDs."""
     collision_users = {
         "alice": MockOAuthUser(

--- a/api/tests/test_pkce.py
+++ b/api/tests/test_pkce.py
@@ -33,8 +33,6 @@ def test_generate_code_challenge_accepts_max_length_verifier():
         ("a" * 129, "code_verifier must be between 43 and 128 characters"),
     ],
 )
-def test_generate_code_challenge_rejects_out_of_range_length(
-    verifier: str, expected_message: str
-):
+def test_generate_code_challenge_rejects_out_of_range_length(verifier: str, expected_message: str):
     with pytest.raises(ValueError, match=expected_message):
         generate_code_challenge(verifier)

--- a/api/tests/test_sessions.py
+++ b/api/tests/test_sessions.py
@@ -155,5 +155,7 @@ async def test_sessions_openapi_limit_has_maximum(client: AsyncClient):
     response = await client.get("/openapi.json")
     assert response.status_code == 200
 
-    parameter_schema = response.json()["paths"]["/api/v1/sessions"]["get"]["parameters"][0]["schema"]
+    parameter_schema = response.json()["paths"]["/api/v1/sessions"]["get"]["parameters"][0][
+        "schema"
+    ]
     assert parameter_schema["maximum"] == 1000

--- a/api/tests/test_users_delete_account.py
+++ b/api/tests/test_users_delete_account.py
@@ -52,7 +52,9 @@ async def test_delete_account_invalidates_related_session_tokens(
     assert delete_response.status_code == 200
     assert payload["deleted_user_id"] == str(user.id)
     assert payload["deleted_email"] == "delete-session-test@example.com"
-    scheduled_delete_at = datetime.fromisoformat(payload["scheduled_delete_at"].replace("Z", "+00:00"))
+    scheduled_delete_at = datetime.fromisoformat(
+        payload["scheduled_delete_at"].replace("Z", "+00:00")
+    )
     assert scheduled_delete_at.tzinfo == UTC
 
     deleted_user = await db_session.scalar(select(DeletedUser).where(DeletedUser.id == user.id))

--- a/api/tests/test_webhook_config.py
+++ b/api/tests/test_webhook_config.py
@@ -1,8 +1,8 @@
 """Property-based tests for WebhookConfigLoader."""
 
+import logging
 import os
 import tempfile
-import logging
 from pathlib import Path
 from unittest.mock import patch
 

--- a/api/tests/test_webhook_signer.py
+++ b/api/tests/test_webhook_signer.py
@@ -71,7 +71,10 @@ class TestWebhookSigner:
         assert signature.startswith("sha256=")
 
         # Verification with same inputs should succeed
-        assert WebhookSigner.verify(payload, secret, timestamp, signature, current_timestamp=timestamp) is True
+        assert (
+            WebhookSigner.verify(payload, secret, timestamp, signature, current_timestamp=timestamp)
+            is True
+        )
 
     @settings(max_examples=50)
     @given(payload=payloads, secret=secrets, timestamp=timestamps)
@@ -145,13 +148,16 @@ class TestWebhookSigner:
 
         # Verify with wrong secret
         wrong_secret = secret + "wrong"
-        assert WebhookSigner.verify(
-            payload,
-            wrong_secret,
-            timestamp,
-            signature,
-            current_timestamp=timestamp,
-        ) is False
+        assert (
+            WebhookSigner.verify(
+                payload,
+                wrong_secret,
+                timestamp,
+                signature,
+                current_timestamp=timestamp,
+            )
+            is False
+        )
 
     @pytest.mark.parametrize("timestamp_offset", (-300, 300))
     def test_verification_accepts_timestamp_at_skew_boundary(self, timestamp_offset: int):


### PR DESCRIPTION
## 概要

Codex Cloud / CI の Ruff gate を安定して通せるよう、`api/` 配下の import order と formatter 出力を現在の Ruff に合わせて正規化します。

## 背景

最新 Ruff で `ruff check api/` と `ruff format --check api/` を実行すると、既存の import order や multiline formatting が gate で検出されます。Cloud 実行で余計な formatting failure を踏まないよう、API 本体と API テストのスタイルをまとめて揃えます。

## 主な変更点

- `api/app/**` の import order、長い関数呼び出し、例外メッセージ、コンテキストマネージャ表現を Ruff formatter に合わせて整理
- `api/tests/**` の import order、assertion、parametrize、長い式の折り返しを Ruff に合わせて整理
- #600 で確定した `retry_backoff_ms` の「正の整数」契約を保持したまま、`api/app/webhooks/config.py` の formatting conflict を解消
- 最新 `origin/main` 由来の `api/app/webhooks/emitter.py` も `ruff format --check api/` に通る形へ整形
- `.gitignore` にローカル生成物の除外を追加

## 影響とリスク

- 基本的に formatting / lint gate 安定化の変更です。
- `api/tests/test_config.py` では、最適化実行時にも壊れにくいよう `assert False` sentinel を `pytest.raises` ベースに置き換えていますが、検証しているエラー契約は維持しています。
- API の外部契約、レスポンス仕様、設定の意味は変更していません。

## テスト内容

- `uv run --with ruff ruff check api/`
- `uv run --with ruff ruff format --check api/`
- `uv run --with-requirements requirements.txt pytest tests/test_webhook_config.py -q`

## レビュアーへの依頼

- formatter 由来の差分として妥当か、特に `api/app/webhooks/config.py` が #600 の positive integer 契約を維持しているか確認してください。
