### PR TITLE
docs(queue): codex queue backlog の運用導線を一括整理

### DIFF
--- a/docs/api/auth.md
+++ b/docs/api/auth.md
@@ -378,6 +378,18 @@ Content-Type: application/json
 
 使い分け: `401` は未認証・無効トークン、`400` 系（本 API では主に `422`）は JSON 入力不正を示します。
 
+refresh / logout の問い合わせでは、次の順で記録を残してください。
+
+1. 対象 endpoint（`/refresh` か `/logout`）
+2. HTTP ステータス（`401` と `422` を混同しない）
+3. `detail` の代表メッセージ
+4. クライアント側で最新 `refresh_token` に置き換え済みか
+5. 再ログインへ切り替えたか
+
+```bash
+rg -n "refresh失敗時エラー分類|POST `/api/v1/auth/logout`|401|422|再ログイン" docs/api/auth.md docs/help/troubleshooting.md docs/getting-started.md
+```
+
 ### OAuth callback 共通（参考）
 
 | HTTP | 条件 | 原因の目安 | 対処の目安 |

--- a/docs/api/users.md
+++ b/docs/api/users.md
@@ -275,3 +275,5 @@ Authorization: Bearer <access_token>
     FAQ は [sync-from-provider の 400/404 の意味](../help/faq.md#sync-from-provider-の-400404-は何を意味する)、
     障害対応は [sync-from-provider で 400/404 が返る](../help/troubleshooting.md#sync-from-provider-errors)、
     provider 未設定時の初動は [インストール: provider 未設定時の最短スキップ手順](../installation.md#provider-未設定時の最短スキップ手順) を参照してください。
+
+運用で記録する場合は、`provider`、HTTP ステータス、代表メッセージ、再ログイン有無を 1 セットにしてください。`400 Unsupported provider` は入力修正、`404 No <provider> account linked` は再ログイン、`400 No provider info stored` は同一 provider でプロフィール再取得、という順で処理します。

--- a/docs/api/webhooks.md
+++ b/docs/api/webhooks.md
@@ -224,6 +224,8 @@ Webhook 配信が再試行上限に到達した場合、ワーカーは固定キ
 - `http_status`: HTTP ステータス（取得できない場合は `None`）
 - `endpoint_id` / `event_id`: 影響範囲の追跡キー
 
+`delivery_id` は配信履歴を追うための識別子であり、受信側の冪等キーではありません。再送や署名検証の調査では、`event_id` を重複排除の正本にし、`delivery_id`、`attempts`、`failure_reason` は配送経路の診断情報として扱います。
+
 ---
 
 <a id="webhook-signature-failure-reasons"></a>

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -6,6 +6,20 @@
     Docker要件や `default` / `full` / `ci` の違いは[インストール](installation.md)に整理しています。初回導入時は先に確認してください。
     導入順で迷った場合は [docs index: 導入者向け最短導線（3ステップ）](index.md#導入者向け最短導線3ステップ) を起点に進めてください。
 
+## 最小確認順
+
+初回導入では、OAuth provider の詳細設定へ進む前に次の順で土台を固定します。
+
+1. secret を作成し、必要な provider だけを有効化する
+2. `docker compose --profile default up -d` で起動する
+3. `/health` と `/docs` の到達を確認する
+4. provider 管理画面の callback URL と `API_URL` を完全一致させる
+5. `GET /api/v1/auth/{provider}` から認可を開始する
+
+```bash
+rg -n "最小確認順|/health|/docs|redirect_uri_mismatch|state mismatch" docs/getting-started.md docs/help/first-start-troubleshooting.md docs/help/troubleshooting.md
+```
+
 ## 前提条件
 
 - Docker & Docker Compose

--- a/docs/guides/codex-automation-ops.md
+++ b/docs/guides/codex-automation-ops.md
@@ -31,14 +31,36 @@ README / AGENTS / CI 設定を同時に揃える前提で利用してくださ�
 - `blocked`: issue コメントと `codex:blocked` を付与
 - `pr-opened`: merge 確認後に reconcile で close（自動レーン主体）
 
-## 3. Woodpecker docs-only CI 分岐ルール
+## 3. Run 記録導線
+
+自動レーンの記録は、実行前の状態、処理した issue、PR/merge 結果、後続メモを 1 本の流れで残します。記録先が分散しても、同じ run を後から追えるように `run_id`、issue 番号、branch、PR URL を同じ値でそろえてください。
+
+| 段階 | 記録する内容 | yesod-auth での確認コマンド |
+| --- | --- | --- |
+| preflight | 認証、remote、working tree、必須ラベル、Project 連携状態 | `git status --short --branch` / `gh issue list -R <REPO_SLUG> --label codex:queue --state open` |
+| queue snapshot | 着手前の `codex:queue` 件数と候補 issue | `python3 scripts/queue_seed_snapshot.py --repo <REPO_SLUG> --format markdown` |
+| run log | 対象 issue、実行コマンド、検証結果、失敗時の blocker | issue コメントまたは run artifact |
+| PR reconcile | PR URL、merge commit、remote branch 削除、issue close | `gh pr view <pr> --json state,mergedAt,mergeCommit` |
+| memory | 1 run 1 file の運用メモ。直接追記ではなく append helper を使う | 展開先の `append_memory.sh` / Codex 運用 helper |
+
+`scripts/preflight_automation.sh` や `append_memory.sh` を配布している repo へ展開する場合は、上表の preflight と memory にそれぞれ接続します。yesod-auth では repo 内に同名 helper を置かないため、repo 内の再現確認は `scripts/queue_seed_snapshot.py` と `scripts/weekly_git_inventory.sh` を正本にします。
+
+受け入れ時の同期チェック:
+
+```bash
+rg -n "Run 記録導線|queue_seed_snapshot|weekly_git_inventory|append_memory|preflight" docs/guides/codex-automation-ops.md README.md AGENTS.md
+python3 scripts/queue_seed_snapshot.py --repo mashirou1234/yesod-auth --format markdown
+bash scripts/weekly_git_inventory.sh
+```
+
+## 4. Woodpecker docs-only CI 分岐ルール
 
 - 対象ファイル: `docs/**`, `README.md`, `AGENTS.md`
 - 変更が対象のみ: 重い検証ステップをスキップ
 - 対象外が 1 つでも含まれる: 通常 CI を実行
 - 判定が不確実なとき: スキップせず通常 CI を実行（fail-open）
 
-## 4. README / AGENTS 反映ポイント
+## 5. README / AGENTS 反映ポイント
 
 ### README に必ず書くこと
 
@@ -54,7 +76,7 @@ README / AGENTS / CI 設定を同時に揃える前提で利用してくださ�
 - `blocked` / `pr-opened` のラベル運用
 - Project 未連携時の `N/A` 記録ルール
 
-## 5. 適用チェックリスト
+## 6. 適用チェックリスト
 
 - [ ] `<ORCH_RUN_COMMAND>` を実在コマンドへ置換した
 - [ ] `<REPO_SLUG>`, `<BASE_BRANCH>`, `<REQUIRED_CHECKS>`, `<LABEL_SET>` を置換した
@@ -62,3 +84,4 @@ README / AGENTS / CI 設定を同時に揃える前提で利用してくださ�
 - [ ] CI 定義（Woodpecker）と README の docs-only 条件が一致している
 - [ ] `queue -> claimed -> (blocked | pr-opened) -> merge確認 -> close` が運用文書で一致している
 - [ ] `codex:priority` を含む issue 選定順が README / AGENTS / 実行プロンプトと矛盾していない
+- [ ] run 記録が preflight / snapshot / run log / PR reconcile / memory の順で追跡できる

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -167,6 +167,13 @@ docker compose logs --since=24h api | rg -n "/api/v1/auth/.*/callback|invalid_cl
    - 同じコマンドを `--since=30m` で再実行し、該当エラー件数が増加しないことを確認する
    - `curl -sS -o /dev/null -w "%{http_code}\n" https://api.your-domain.com/health` が `200` であることを確認する
 
+本番前の最小ゲートは、[インストール: 本番切替前チェック](../installation.md#production-cutover-check) と同じ順にそろえます。
+
+```bash
+rg -n "MOCK_OAUTH_ENABLED|callback|secret|production|本番" docs/guides/deployment.md docs/installation.md docs/help/faq.md
+docker compose config | rg -n "MOCK_OAUTH_ENABLED|client_(id|secret)|SESSION_COOKIE"
+```
+
 ## OAuthシークレットローテーション手順
 
 プロバイダー個別の管理画面差分（Google/Discord など）に依存しない、共通の切替手順です。Compose/ECS/Kubernetes いずれでも「シークレット更新」「API再起動（または再デプロイ）」「疎通確認」の順序は共通です。

--- a/docs/guides/oauth/discord.md
+++ b/docs/guides/oauth/discord.md
@@ -100,6 +100,8 @@ docker compose logs --tail=100 api | rg -n "discord|Failed to get user info|KeyE
 
 - アプリ側の認可URLで `scope=identify email` を維持する
 - 認証を最初からやり直して再同意を取得する
+- 既存の同意が古い scope のまま残っている場合は、Discord 側の連携を解除してから `GET /api/v1/auth/discord` で再同意する
+- 復旧後は `docker compose logs api --since=30m | rg -n "discord|scope|email"` で同じ scope 不足ログが再発していないことを確認する
 
 !!! info "PKCE対応について"
     DiscordはPKCEパラメータを受け入れますが、公式ドキュメントには記載されていません。

--- a/docs/guides/oauth/facebook.md
+++ b/docs/guides/oauth/facebook.md
@@ -51,6 +51,13 @@ echo "your-app-secret" > secrets/facebook_client_secret.txt
 - 監査ログの保持期間・ローテーション方針は [Deployment ガイド](../deployment.md#ログ保全設定例) で先に定義してください。
 - 障害時は [トラブルシューティング](../../help/troubleshooting.md) の「管理者トークン失効で管理APIが `401 Unauthorized` になる」節の再認証導線とあわせて確認してください。
 
+更新失敗時は、長期トークンの再交換を繰り返す前にユーザー再認可へ切り替えます。
+
+1. Facebook Developer Portal の有効な OAuth リダイレクト URI を確認する
+2. 対象ユーザーに `GET /api/v1/auth/facebook` から再ログインしてもらう
+3. 追加 Graph API 呼び出しがある場合のみ、新しい短期 token から長期 token を再発行する
+4. 監査ログに更新日時、失敗理由、再認可有無を記録する
+
 ## 技術仕様
 
 | 項目 | 値 |

--- a/docs/guides/oauth/github.md
+++ b/docs/guides/oauth/github.md
@@ -62,6 +62,19 @@ curl -sSI \
 
 5. `user:email` が不足している場合は、GitHub 側で再認可（連携解除後の再ログイン）を実施する
 
+### scope不足時の再同意手順
+
+`read:user user:email` のどちらかが不足している場合、YESOD Auth 側で secret を直しても既存の認可 grant は自動更新されません。次の順で再同意してください。
+
+1. GitHub の Authorized OAuth Apps で対象アプリの認可を取り消す
+2. `GET /api/v1/auth/github` から認可を開始する
+3. consent 画面で `read:user` と `user:email` が表示されることを確認する
+4. callback 後に `X-OAuth-Scopes` を再確認する
+
+```bash
+curl -sSI -H "Authorization: Bearer <github_access_token>" https://api.github.com/user | rg -i '^x-oauth-scopes:'
+```
+
 ## organization制限時の挙動
 
 現在の YESOD Auth は GitHub OAuth で organization 制限を実施しません。  

--- a/docs/guides/oauth/google.md
+++ b/docs/guides/oauth/google.md
@@ -78,6 +78,7 @@ Google 側で `Error 400: redirect_uri_mismatch` が表示された場合は、�
     - 実 Google OAuth を検証する環境では `MOCK_OAUTH_ENABLED=0` になっていること
     - `google_client_id` / `google_client_secret` が対象環境の値で、`secrets/google_client_*.txt` またはデプロイ先の secret に配置されていること
     - `docker compose config | rg -n "MOCK_OAUTH_ENABLED|google_client_(id|secret)"` で Compose 側の反映を確認すること
+    - scope は `openid email profile` を維持すること。メール取得に失敗する場合は Google Cloud Console の同意画面とテストユーザー設定を先に確認すること
 4. アプリ側 URL 設定を確認
     - `API_URL` が実際の公開 URL と一致していること
     - reverse proxy 配下では `X-Forwarded-Proto` が正しく引き継がれていること
@@ -88,6 +89,12 @@ Google 側で `Error 400: redirect_uri_mismatch` が表示された場合は、�
 ```bash
 docker compose config | rg -n "MOCK_OAUTH_ENABLED|google_client_(id|secret)"
 docker compose logs api --since=30m | rg -n "auth/google|callback|redirect_uri|mismatch"
+```
+
+secret / scope / redirect URI の三点同期チェック:
+
+```bash
+rg -n "openid email profile|google_client_(id|secret)|redirect_uri_mismatch" docs/guides/oauth/google.md docs/installation.md docs/help/troubleshooting.md
 ```
 
 `Invalid or expired state` が同時に発生する場合は、[トラブルシューティング](../../help/troubleshooting.md#state-mismatch-flow) の診断フローも併せて確認してください。

--- a/docs/guides/oauth/index.md
+++ b/docs/guides/oauth/index.md
@@ -11,12 +11,14 @@ Callback URL は provider 名だけを差し替え、ローカルと本番で同
 |-------------|------------|----------------------|-------------------|------|----------------|------|
 | Google | [google.md](google.md) | `http://localhost:8000/api/v1/auth/google/callback` | `https://<api-domain>/api/v1/auth/google/callback` | 公式 | ✅ | 推奨 |
 | GitHub | [github.md](github.md) | `http://localhost:8000/api/v1/auth/github/callback` | `https://<api-domain>/api/v1/auth/github/callback` | 公式 | ❌ | |
-| Discord | [discord.md](discord.md) | `http://localhost:8000/api/v1/auth/discord/callback` | `https://<api-domain>/api/v1/auth/discord/callback` | 独自 | ❌ | プロバイダーは対応しているが公式ドキュメントなし |
 | X (Twitter) | [x.md](x.md) | `http://localhost:8000/api/v1/auth/x/callback` | `https://<api-domain>/api/v1/auth/x/callback` | 公式 | ❌ | メールアドレス取得不可 |
 | LinkedIn | [linkedin.md](linkedin.md) | `http://localhost:8000/api/v1/auth/linkedin/callback` | `https://<api-domain>/api/v1/auth/linkedin/callback` | 公式 | ✅ | |
 | Facebook | [facebook.md](facebook.md) | `http://localhost:8000/api/v1/auth/facebook/callback` | `https://<api-domain>/api/v1/auth/facebook/callback` | 公式 | ❌ | [Graph API v18.0](https://developers.facebook.com/docs/graph-api/){:target="_blank"} |
+| Discord | [discord.md](discord.md) | `http://localhost:8000/api/v1/auth/discord/callback` | `https://<api-domain>/api/v1/auth/discord/callback` | 独自 | ❌ | プロバイダーは対応しているが公式ドキュメントなし |
 | Slack | [slack.md](slack.md) | `http://localhost:8000/api/v1/auth/slack/callback` | `https://<api-domain>/api/v1/auth/slack/callback` | 独自 | ✅ | |
 | Twitch | [twitch.md](twitch.md) | `http://localhost:8000/api/v1/auth/twitch/callback` | `https://<api-domain>/api/v1/auth/twitch/callback` | 独自 | ❌ | [Helix API](https://dev.twitch.tv/docs/api/){:target="_blank"} |
+
+表の並び順は README / docs index と同じ `Google -> GitHub -> X -> LinkedIn -> Facebook -> Discord -> Slack -> Twitch` を正本にします。provider を追加・並べ替える場合は、このページ、[ドキュメント入口](../../index.md)、[インストールガイド](../../installation.md#oauth-credentials) の 3 点で順序と provider 名を同期してください。
 
 <a id="初回導入の読み順"></a>
 
@@ -41,10 +43,10 @@ Callback URL は provider 名だけを差し替え、ローカルと本番で同
 |---|---|---|---|---|
 | Google | `google_client_id` / `google_client_secret` | `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` | `/api/v1/auth/google/callback` | [google.md](google.md) |
 | GitHub | `github_client_id` / `github_client_secret` | `GITHUB_CLIENT_ID` / `GITHUB_CLIENT_SECRET` | `/api/v1/auth/github/callback` | [github.md](github.md) |
-| Discord | `discord_client_id` / `discord_client_secret` | `DISCORD_CLIENT_ID` / `DISCORD_CLIENT_SECRET` | `/api/v1/auth/discord/callback` | [discord.md](discord.md) |
 | X (Twitter) | `x_client_id` / `x_client_secret` | `X_CLIENT_ID` / `X_CLIENT_SECRET` | `/api/v1/auth/x/callback` | [x.md](x.md) |
 | LinkedIn | `linkedin_client_id` / `linkedin_client_secret` | `LINKEDIN_CLIENT_ID` / `LINKEDIN_CLIENT_SECRET` | `/api/v1/auth/linkedin/callback` | [linkedin.md](linkedin.md) |
 | Facebook | `facebook_client_id` / `facebook_client_secret` | `FACEBOOK_CLIENT_ID` / `FACEBOOK_CLIENT_SECRET` | `/api/v1/auth/facebook/callback` | [facebook.md](facebook.md) |
+| Discord | `discord_client_id` / `discord_client_secret` | `DISCORD_CLIENT_ID` / `DISCORD_CLIENT_SECRET` | `/api/v1/auth/discord/callback` | [discord.md](discord.md) |
 | Slack | `slack_client_id` / `slack_client_secret` | `SLACK_CLIENT_ID` / `SLACK_CLIENT_SECRET` | `/api/v1/auth/slack/callback` | [slack.md](slack.md) |
 | Twitch | `twitch_client_id` / `twitch_client_secret` | `TWITCH_CLIENT_ID` / `TWITCH_CLIENT_SECRET` | `/api/v1/auth/twitch/callback` | [twitch.md](twitch.md) |
 

--- a/docs/guides/oauth/linkedin.md
+++ b/docs/guides/oauth/linkedin.md
@@ -56,6 +56,19 @@ YESOD Auth の LinkedIn ログインで要求する最小 scope は次の 3 つ�
     `openid profile email` の 3 つはセットで必要です。
     一部のみを要求すると、`/v2/userinfo` から必要情報を取得できずログイン失敗の原因になります。
 
+### scope不足時の re-authorization
+
+LinkedIn 側で `Sign In with LinkedIn using OpenID Connect` が未承認、または `openid profile email` の一部だけで認可した場合は、既存セッションを破棄して再認可します。
+
+1. LinkedIn Developer Portal で対象アプリの Product と Authorized redirect URLs を確認する
+2. クライアント側の token pair を破棄する
+3. `GET /api/v1/auth/linkedin` から認可をやり直す
+4. 失敗時は API ログで `linkedin|userinfo|scope|email` を確認する
+
+```bash
+docker compose logs api --since=30m | rg -n "linkedin|userinfo|scope|email"
+```
+
 ## 技術仕様
 
 | 項目 | 値 |

--- a/docs/guides/oauth/slack.md
+++ b/docs/guides/oauth/slack.md
@@ -42,6 +42,7 @@ echo "your-client-secret" > secrets/slack_client_secret.txt
     - callback: `http://localhost:8000/api/v1/auth/slack/callback`
 - 開発時は`MOCK_OAUTH_ENABLED=1`を無効化してから実OAuthを試してください。Mock OAuthが有効だと、Slack設定ミスが見えにくくなります。
 - `OpenID Connect`を有効化していない場合、Slackログイン画面まで進んでもユーザー情報取得で失敗します。
+- secret は `secrets/slack_client_id.txt` と `secrets/slack_client_secret.txt` に配置し、`api` と必要に応じて `api-ci` へ mount します。Redirect URLs、secret、OpenID Connect の 3 点を同じ Slack App でそろえてください。
 
 ### ローカル検証チェックリスト
 
@@ -59,6 +60,12 @@ echo "your-client-secret" > secrets/slack_client_secret.txt
     ```
 4. 認証後の callback で失敗した場合は、Slack 側 Redirect URLs と
    `http://localhost:8000/api/v1/auth/slack/callback` の完全一致を再確認する
+
+secret mount の同期確認:
+
+```bash
+docker compose config | rg -n "slack_client_(id|secret)|MOCK_OAUTH_ENABLED"
+```
 
 !!! info "OpenID Connect"
     SlackはOpenID Connectを使用します。

--- a/docs/guides/oauth/twitch.md
+++ b/docs/guides/oauth/twitch.md
@@ -35,6 +35,7 @@ echo "your-client-secret" > secrets/twitch_client_secret.txt
     - `secrets/twitch_client_secret.txt`
 3. **APIコンテナへ secrets をマウント**
     - `docker-compose.override.yml` で `twitch_client_id` / `twitch_client_secret` を `api` と `api-ci` に追加
+    - CI で実 OAuth を検証する場合は `api-ci` 側の mount も必須。`api` だけに追加するとローカルは成功して CI が `invalid_client` になります。
 4. **実OAuthモードへ切替**
     - `MOCK_OAUTH_ENABLED=0`（または未設定）を確認
 5. **スコープを固定**
@@ -74,6 +75,12 @@ curl -fsS http://localhost:8000/health
 # 2) Twitch OAuth導線確認（302想定）
 curl -fsS -o /dev/null -w '%{http_code}\n' \
   "http://localhost:8000/api/v1/auth/twitch"
+```
+
+CI/ローカルの mount 同期確認:
+
+```bash
+docker compose config | rg -n "api-ci:|twitch_client_(id|secret)|MOCK_OAUTH_ENABLED"
 ```
 
 !!! info "Helix API"

--- a/docs/guides/oauth/x.md
+++ b/docs/guides/oauth/x.md
@@ -70,6 +70,17 @@ X の `client_id` / `client_secret` が未設定または不正な場合に発�
 - ブラウザ戻る操作や callback URL の再実行を避ける
 - `API_URL` と実アクセス先ホスト/スキームの一致
 
+復旧時は古い callback URL を再読み込みせず、必ず次の固定順で再取得します。
+
+1. 古い認可タブを閉じる
+2. `GET /api/v1/auth/x` から新しい `state` と PKCE verifier を発行する
+3. X の認可画面で同意する
+4. callback 後に API ログで `auth/x|invalid_request|state` が再発していないことを確認する
+
+```bash
+docker compose logs api --since=30m | rg -n "auth/x|invalid_request|Invalid state|callback"
+```
+
 ### `400 Bad Request` / `Failed to exchange code`
 
 認可コード交換に失敗した場合に発生します。X 側の callback URL 設定不一致

--- a/docs/guides/webhooks.md
+++ b/docs/guides/webhooks.md
@@ -279,6 +279,17 @@ HTTP 4xx エラーはリトライしません（クライアントエラーの�
 配信履歴の `id` や `attempt_count` は再送ごとに変わるため、重複判定には使えません。  
 API 契約の詳細は [Webhook API: 冪等性の注意点（再送時）](../api/webhooks.md#冪等性の注意点再送時) を参照してください。
 
+### delivery_id / retry 用語の使い分け
+
+| 用語 | 意味 | 冪等キーに使うか |
+| --- | --- | --- |
+| `event_id` | Webhook イベントそのものの ID。同一イベントの再送でも変わらない | 使う |
+| `delivery_id` / 配信履歴の `id` | 1 回の配信試行または履歴行を追跡する ID | 使わない |
+| `attempt_count` | 同一イベントの何回目の配信かを示す回数 | 使わない |
+| `next_retry_at` | 次回再送予定時刻 | 使わない |
+
+運用上の重複排除は `event_id` に固定し、配送経路の調査だけ `delivery_id`、`attempt_count`、`request_id` を併用してください。
+
 <a id="webhook-delivery-log-checklist"></a>
 
 ### 配信失敗時のログ確認項目

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -125,6 +125,20 @@ docker compose logs admin --since=10m | rg -n "SESSION_EXPIRY_HOURS is invalid|u
 手順詳細は [トラブルシューティング: `SESSION_EXPIRY_HOURS` が不正値](./troubleshooting.md#session-expiry-hours-invalid)、
 導入手順側の位置づけは [インストール: 管理画面付き](../installation.md#管理画面付き) を参照してください。
 
+<a id="session-cookie-samesite-recommended"></a>
+
+### `SESSION_COOKIE_SAMESITE` の推奨値は？
+
+管理画面の通常運用では `Lax` を推奨します。別ドメイン iframe や外部 IdP からのクロスサイト遷移で cookie を明示的に送る必要がある場合のみ `None` を選び、その場合は `SESSION_COOKIE_SECURE=true` と HTTPS を必須にしてください。
+
+| 値 | 用途 | 追加条件 |
+| --- | --- | --- |
+| `Lax` | 通常の管理画面ログイン | なし |
+| `Strict` | 同一サイト内だけで完結する高制限運用 | 外部遷移後の復帰を事前検証 |
+| `None` | クロスサイト cookie が必要な運用 | `SESSION_COOKIE_SECURE=true` と HTTPS |
+
+警告が出た場合は [トラブルシューティング: `SESSION_COOKIE_SAMESITE` が空文字/未知値](./troubleshooting.md#session-cookie-samesite-invalid) を確認し、導入時の設定位置は [インストール: 管理画面付き](../installation.md#管理画面付き) と同期してください。
+
 <a id="oauth-secret-permission-recovery"></a>
 
 ### OAuth secret の権限不備を最短で復旧するには？

--- a/docs/help/first-start-troubleshooting.md
+++ b/docs/help/first-start-troubleshooting.md
@@ -13,6 +13,8 @@
    ls -1 secrets/{google_client_id,google_client_secret,discord_client_id,discord_client_secret,jwt_secret}.txt
    ```
 
+<a id="first-start-three-checks"></a>
+
 ## 1. 初回3点確認順（固定）
 
 初回起動失敗時は、必ず次の順番で確認してください。
@@ -29,6 +31,8 @@
    ```bash
    curl -fsS -o /dev/null -w '%{http_code}\n' http://localhost:8000/metrics
    ```
+
+OAuth provider の設定に進むのは、この 3 点が成功してからにしてください。`/health` が失敗している状態で callback や secret を調べると、依存サービス障害と provider 設定不備を混同しやすくなります。
 
 ## 2. 結果別の次アクション（次に読む文書）
 

--- a/docs/help/troubleshooting.md
+++ b/docs/help/troubleshooting.md
@@ -25,6 +25,8 @@ docker compose logs api --since=30m | rg -n "Invalid state|/api/v1/auth/.*/callb
 | `provider` | [`401 Unauthorized` / `invalid_client`](#401-unauthorized--invalid_client) | `docker compose logs --tail=100 api \| rg -n "invalid_client\|401\|client_secret\|client_id"` |
 | `webhook` | [Webhook設定ガイド](../guides/webhooks.md#ローカルテスト) | `curl -fsS http://localhost:8000/api/v1/admin/webhooks/endpoints` |
 
+callback / state mismatch の問い合わせでは、まず [初回起動トラブルシュート](./first-start-troubleshooting.md#first-start-three-checks) の `/health`、`/docs`、`/metrics` を確認し、その後に本ページの `state mismatch`、`invalid_client`、`redirect_uri_mismatch` へ分岐します。callback URL を直接開いた結果は再現証跡にせず、必ず `GET /api/v1/auth/{provider}` から開始したログを採取してください。
+
 ## 起動時のエラー
 
 `secret ... not found` の即時復旧は [`インストールガイド` の secret不足時手順](../installation.md#1-docker-compose-up-で-secret-未設定エラーになる) を先に実行してください。
@@ -130,6 +132,8 @@ SESSION_EXPIRY_HOURS is invalid ('<value>'); using default value 24
 
 ---
 
+<a id="session-cookie-samesite-invalid"></a>
+
 ### `SESSION_COOKIE_SAMESITE` が空文字/未知値
 
 **症状:** admin 起動時に `SESSION_COOKIE_SAMESITE` の警告が出る。
@@ -151,6 +155,11 @@ SESSION_COOKIE_SAMESITE='<value>' is unsupported; falling back to framework defa
    ```bash
    docker compose up -d --force-recreate admin
    ```
+
+導線同期:
+
+- FAQ: [`SESSION_COOKIE_SAMESITE` の推奨値は？](./faq.md#session-cookie-samesite-recommended)
+- Installation: [管理画面付き](../installation.md#管理画面付き)
 
 ---
 

--- a/docs/help/weekly-git-inventory.md
+++ b/docs/help/weekly-git-inventory.md
@@ -1,11 +1,11 @@
 # 週次Git棚卸し Runbook
 
-この手順は、`yesod-auth` の Git 状態を週次で確認し、重複コメントを避けながら記録するための運用手順です。
+この手順は、`yesod-auth` の Git 状態を週次で確認し、重複コメントを避けながら記録するための運用手順です。2026-05-04 以降の棚卸し issue は、その時点で open な棚卸し issue へ記録し、完了後に `completed` として close します。
 
 ## 目的
 
 - 未整理ブランチ、未コミット変更、不要な差分の早期発見
-- Issue `#560`（週次Git棚卸し）への定期記録の標準化
+- open な週次Git棚卸し issue への定期記録の標準化
 - OSS 運用時の再現性確保
 
 ## 実行コマンド
@@ -26,8 +26,9 @@ bash scripts/weekly_git_inventory.sh
 
 1. 同一 JST 日付のコメントが既にある場合は重複投稿しない
 2. 未確認項目は推測で埋めず `未確認` として残す
-3. コメント先は `mashirou1234/yesod-auth` の `#560` のみ
+3. コメント先は `mashirou1234/yesod-auth` の open な週次Git棚卸し issue を優先する
+4. 棚卸し結果を投稿し、不要ブランチや未コミット変更がなければ `completed` で close する
 
 ## 参考
 
-- [週次Git棚卸し Issue #560](https://github.com/mashirou1234/yesod-auth/issues/560)
+- [週次Git棚卸し Issue 検索](https://github.com/mashirou1234/yesod-auth/issues?q=is%3Aissue+%E9%80%B1%E6%AC%A1Git%E6%A3%9A%E5%8D%B8%E3%81%97)

--- a/docs/index.md
+++ b/docs/index.md
@@ -97,6 +97,18 @@ APIドキュメントは http://localhost:8000/docs で確認できます。
    - [トラブルシューティング](help/troubleshooting.md): callback / state mismatch などの切り分け手順を確認
    - [FAQ](help/faq.md): 導入後によくある確認事項を横断で参照
 
+API 導線の同期確認は次の 3 点を正本にします。
+
+| 領域 | 正本 | 確認する用語 |
+| --- | --- | --- |
+| 認証 | [認証API](api/auth.md) | `refresh` / `logout` / `state mismatch` |
+| ユーザー | [ユーザーAPI](api/users.md) | `sync-from-provider` / provider 連携 |
+| Webhook | [Webhook API](api/webhooks.md) | `delivery_id` / retry / 署名検証 |
+
+```bash
+rg -n "refresh|logout|sync-from-provider|delivery_id|retry" docs/index.md docs/api/*.md docs/help/troubleshooting.md
+```
+
 ## 運用導線の同期チェック
 
 トップページの導線を更新したときは、次の 3 文書へのリンクと記述の整合をあわせて確認してください。

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -197,6 +197,8 @@ FAQ で同じ確認観点を参照: [どのsecretを必須で用意すべき？]
 
 - `ADMIN_USER`: 管理者ログイン名。既定値は `admin`（`docker-compose.yml` で設定）
 - `SESSION_EXPIRY_HOURS`: 管理画面セッション期限（時間）。未指定時はアプリ既定値 `24`
+- `SESSION_COOKIE_SAMESITE`: 管理画面 cookie の SameSite 属性。通常は `Lax`、クロスサイト cookie が必要な場合のみ `None`
+- `SESSION_COOKIE_SECURE`: `SESSION_COOKIE_SAMESITE=None` を使う場合は `true` と HTTPS を必須にする
 
 #### 2. 起動
 
@@ -234,6 +236,16 @@ docker compose logs admin --since=10m | rg -n "SESSION_EXPIRY_HOURS is invalid|u
 - 3コマンドの詳細は [トラブルシューティング: `SESSION_EXPIRY_HOURS` が不正値](./help/troubleshooting.md#session-expiry-hours-invalid)
 - 運用上の再発防止メモは [FAQ: SESSION_EXPIRY_HOURS の異常値を最短で復旧するには？](./help/faq.md#session-expiry-hours-recovery)
 
+5. `SESSION_COOKIE_SAMESITE` の確認
+
+```bash
+docker compose --profile full config | rg -n "SESSION_COOKIE_SAMESITE|SESSION_COOKIE_SECURE"
+docker compose logs admin --since=10m | rg -n "SESSION_COOKIE_SAMESITE|SESSION_COOKIE_SECURE"
+```
+
+- 推奨値は [FAQ: `SESSION_COOKIE_SAMESITE` の推奨値は？](./help/faq.md#session-cookie-samesite-recommended) を参照
+- 警告時は [トラブルシューティング: `SESSION_COOKIE_SAMESITE` が空文字/未知値](./help/troubleshooting.md#session-cookie-samesite-invalid) を参照
+
 #### 代表的な失敗例
 
 - 症状: `admin` サービスが起動失敗する / ログインできない
@@ -248,6 +260,7 @@ docker compose logs admin --since=10m | rg -n "SESSION_EXPIRY_HOURS is invalid|u
    - FAQ: [SESSION_EXPIRY_HOURS の異常値を最短で復旧するには？](./help/faq.md#session-expiry-hours-recovery)  
    - Installation: [管理画面付き](#管理画面付き)  
    - Troubleshooting: [`SESSION_EXPIRY_HOURS` が不正値](./help/troubleshooting.md#session-expiry-hours-invalid)
+4. `SESSION_COOKIE_SAMESITE=None` を使う場合は、`SESSION_COOKIE_SECURE=true` と HTTPS 前提が同じ PR で確認されている
 
 ### CI相当
 


### PR DESCRIPTION
## 概要

`codex:queue` に残っていた docs-only issue 21 件を一括処理する PR です。

対象は導入、OAuth provider、認証 API、Webhook、デプロイ、Codex automation、週次 Git 棚卸しの運用導線です。実装コードには触れず、既存ドキュメント間で分散していた参照順、用語、確認コマンド、復旧判断を同期しました。

Closes #671
Closes #670
Closes #669
Closes #668
Closes #667
Closes #666
Closes #665
Closes #664
Closes #663
Closes #662
Closes #661
Closes #660
Closes #659
Closes #658
Closes #644
Closes #643
Closes #642
Closes #639
Closes #637
Closes #636
Closes #635

## 背景

- `codex:queue` issue が docs-only の小粒な運用同期タスクとして 21 件残っていた
- 運用上、issue close の reconcile が遅れていたため、1 PR で実装、検証、merge、issue close まで進める必要があった
- README / docs index / installation / troubleshooting / provider 個別ガイドで、同じ概念の順序や確認コマンドが散らばっていた

## 主な変更点

- API 導線の正本を docs index に追加
  - 認証 API: `refresh` / `logout` / `state mismatch`
  - ユーザー API: `sync-from-provider`
  - Webhook API: `delivery_id` / retry / 署名検証
- 初回導入と callback/state mismatch の参照順を固定
  - `secret` 作成
  - `default` profile 起動
  - `/health` と `/docs`
  - callback URL と `API_URL` の完全一致
  - `GET /api/v1/auth/{provider}` から認可開始
- OAuth provider 表の順序を README / docs index と統一
  - Google -> GitHub -> X -> LinkedIn -> Facebook -> Discord -> Slack -> Twitch
- provider 個別ガイドに scope 不足、再同意、secret mount、invalid_request、長期トークン更新の復旧導線を追加
- Codex automation run 記録導線を追加
  - preflight
  - queue snapshot
  - run log
  - PR reconcile
  - memory
- 週次 Git 棚卸し runbook を、固定 issue ではなく open な棚卸し issue へ記録して close する運用へ更新

## ファイル別詳細

- `docs/index.md`
  - API 導線の同期表を追加
  - `refresh` / `logout` / `sync-from-provider` / `delivery_id` / retry の横断確認コマンドを追加
- `docs/getting-started.md`
  - 初回導入の最小確認順を追加
- `docs/installation.md`
  - `SESSION_COOKIE_SAMESITE` / `SESSION_COOKIE_SECURE` の管理画面設定観点を追加
  - `SESSION_COOKIE_SAMESITE=None` 時の HTTPS / secure cookie 前提を明示
- `docs/help/first-start-troubleshooting.md`
  - 初回 3 点確認順に明示アンカーを追加
  - OAuth provider 調査前に `/health` / `/docs` / `/metrics` を通す注意を追加
- `docs/help/troubleshooting.md`
  - callback/state mismatch の初動を初回 3 点確認へ接続
  - `SESSION_COOKIE_SAMESITE` の導線同期を追加
- `docs/help/faq.md`
  - `SESSION_COOKIE_SAMESITE` の推奨値と選定条件を追加
- `docs/api/auth.md`
  - refresh/logout 問い合わせ時の記録項目を追加
- `docs/api/users.md`
  - `sync-from-provider` の 400/404 運用記録観点を追加
- `docs/api/webhooks.md`
  - `delivery_id` を冪等キーではなく配送診断情報として扱う方針を追加
- `docs/guides/webhooks.md`
  - `event_id` / `delivery_id` / `attempt_count` / `next_retry_at` の使い分けを追加
- `docs/guides/deployment.md`
  - 本番前チェックと installation 同期の確認コマンドを追加
- `docs/guides/codex-automation-ops.md`
  - Run 記録導線を新設
- `docs/help/weekly-git-inventory.md`
  - open な週次棚卸し issue へ記録して close する運用へ更新
- `docs/guides/oauth/index.md`
  - provider 表と secret 一覧の順序を統一
- `docs/guides/oauth/discord.md`
  - scope 不足時の再同意チェックを追加
- `docs/guides/oauth/github.md`
  - `read:user user:email` の再同意手順を追加
- `docs/guides/oauth/linkedin.md`
  - `openid profile email` 不足時の re-authorization 導線を追加
- `docs/guides/oauth/facebook.md`
  - 長期トークン更新失敗時の再認可導線を追加
- `docs/guides/oauth/x.md`
  - `invalid_request` 時の state 再取得手順を追加
- `docs/guides/oauth/twitch.md`
  - `api-ci` secret mount 確認を追加
- `docs/guides/oauth/google.md`
  - scope / secret / redirect URI の三点同期チェックを追加
- `docs/guides/oauth/slack.md`
  - secret 配置と `api` / `api-ci` mount 確認を追加

## 影響とリスク

- docs-only のため、API 実装、DB schema、runtime dependency、CI workflow への直接影響はありません。
- 既存ドキュメントには以前から未解決の anchor INFO が残っていますが、今回追加した導線は明示アンカーを使い、PR 内の新規参照範囲では破綻しないようにしています。
- `mkdocs build --strict` は Docker 経由で成功しています。

## テスト内容

- `git diff --check`
- `python3 scripts/queue_seed_snapshot.py --repo mashirou1234/yesod-auth --format markdown`
- `bash scripts/weekly_git_inventory.sh`
- `docker run --rm -v "$PWD":/docs squidfunk/mkdocs-material:latest build --strict --site-dir /tmp/yesod-auth-site`

## レビュアーへの依頼

- provider 順序を README / docs index と同じ正本として扱ってよいか確認してください。
- `codex-automation-ops.md` の run 記録導線で、repo 内 helper と外部 Codex helper の境界が運用実態に合っているか確認してください。
